### PR TITLE
fix: preflight antes de abrir Desktop y acepta FillRule real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versionado semántico. **El contrato de las 34 tools originales nunca se rompe.*
 
 ## [1.0.0] — 2026-08-02
 
-Primera versión estable del repositorio oficial. **117 tools, 1540 pruebas
+Primera versión estable del repositorio oficial. **117 tools, 1542 pruebas
 aprobadas y 3 omitidas por condiciones externas documentadas.**
 
 ### Incluye

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Servidor **MCP** (Model Context Protocol) para trabajar con **Power BI Desktop local** y con proyectos **`.pbip`** desde Claude Code.
 
-**v1.0.0** — 117 tools, 1540 pruebas aprobadas (3 omitidas, con su condición documentada). Cubre dos capas complementarias:
+**v1.0.0** — 117 tools, 1542 pruebas aprobadas (3 omitidas, con su condición documentada). Cubre dos capas complementarias:
 
 | Capa | Para qué | Cómo |
 |---|---|---|

--- a/RELEASE_NOTES_1.0.0.md
+++ b/RELEASE_NOTES_1.0.0.md
@@ -3,10 +3,12 @@
 Primera versión estable del repositorio oficial de Horizun PBI MCP.
 
 - 117 tools MCP y contrato compatible con las 34 tools originales.
-- 1540 pruebas aprobadas; 3 omitidas únicamente por condiciones externas
+- 1542 pruebas aprobadas; 3 omitidas únicamente por condiciones externas
   documentadas.
 - Validación TMDL/TOM antes de abrir Power BI Desktop, evitando el Frown de
   proyectos con colisiones de nombres.
+- Preflight de modelos vacíos: devuelve un diagnóstico accionable en vez de
+  esperar un timeout de Desktop sin motor servido.
 - Validación PBIR contra esquemas y CLI oficiales cuando están publicados,
   oráculo estructural para `objects`, transacciones atómicas, journals,
   backups y rollback.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5,7 +5,7 @@ más duele.
 
 Se actualizó el 2026-08-02 después de auditar por AST las **117 tools**, probar
 conversiones reales PBIX→PBIP y volver a abrir los resultados en Power BI
-Desktop. La suite integrada quedó en **1540 passed, 3 skipped**. La lista de
+Desktop. La suite integrada quedó en **1542 passed, 3 skipped**. La lista de
 abajo no es una lluvia de ideas: es lo que sabemos que falta, con evidencia.
 
 ---
@@ -104,6 +104,12 @@ rechazaba el modelo al cargarlo. El launcher ahora ejecuta el lint/TOM antes de
 abrir la ventana y devuelve `desktop_preflight_failed` con las dos reglas y su
 evidencia; no deja un proceso `Sin título` colgado. La regresión está en
 `tests/test_desktop_preflight.py`.
+
+La misma barrera detecta ahora modelos semánticos vacíos antes del timeout de
+Desktop (`tmdl_empty_model`). En la barrida de nueve proyectos locales, cinco
+abrieron y capturaron correctamente, tres quedaron rechazados antes de lanzar
+Desktop por estar vacíos y el proyecto con colisiones quedó rechazado con sus
+dos hallazgos. No se dejó ningún proceso huérfano.
 
 **Qué haría falta:** navegación determinista por todas las páginas y un oráculo
 de imagen/layout que pueda emitir diagnósticos concretos, sin confundir una
@@ -212,5 +218,5 @@ conviene tenerlas juntas:
 3. **Lo que solo se ejecuta en la máquina del que programa, solo funciona
    ahí.** La instalación limpia encontró dos defectos que ninguna prueba veía,
    porque todas corrían sobre un entorno que ya estaba bien. La suite actual
-   tiene 1540 pruebas aprobadas, pero los oráculos externos siguen siendo
+   tiene 1542 pruebas aprobadas, pero los oráculos externos siguen siendo
    obligatorios.

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -19,7 +19,7 @@ Cada afirmación lleva su **nivel de verificación**. No se mezclan.
 
 | Servidor | Versión | Estado | Nivel máximo alcanzado |
 |---|---|---|---|
-| **Horizun PBI MCP** (este repo) | 1.0.0 | Presente, arranca | **Probada** — handshake stdio, 117 tools, 1540 pruebas, DAX en vivo, fixture PBIR y captura de Desktop por PID |
+| **Horizun PBI MCP** (este repo) | 1.0.0 | Presente, arranca | **Probada** — handshake stdio, 117 tools, 1542 pruebas, DAX en vivo, fixture PBIR y captura de Desktop por PID |
 | **powerbi-report-mcp** | 0.9.6 | Presente y compilado en `..\PowerBI MCP\powerbi-report-mcp\dist\index.js` | **Observada** — 57 nombres de tool extraídos del bundle y del README. **No ejecutado** |
 | **@microsoft/powerbi-modeling-mcp** | 0.5.0-beta.11 | Descargado a temporal, extraído y leído. **No ejecutado** | **Declarada** — README + CHANGELOG + `index.js`. Ejecución **detenida** por condición de parada (§2.1) |
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -81,6 +81,8 @@ Si encuentra errores estáticos o de `TmdlSerializer`, devuelve
 `desktop_preflight_failed` con los hallazgos y no lanza Desktop. Esto evita que
 un proyecto antiguo termine en una ventana `Sin título` con un Frown genérico;
 por ejemplo, detecta una medida que colisiona con una columna de la misma tabla.
+También bloquea un modelo semántico sin tablas (`tmdl_empty_model`), que de otro
+modo solo produciría un timeout esperando un motor que nunca llega a servir.
 
 ---
 

--- a/src/powerbi/desktop_launcher.py
+++ b/src/powerbi/desktop_launcher.py
@@ -140,6 +140,26 @@ def _preflight_pbip_model(pbip: Path) -> None:
         definition = tmdl_validate.resolve_definition_dir(pbip)
     except tmdl_validate.ReportOnlyProjectError:
         return
+    tables_dir = definition / "tables"
+    table_files = sorted(tables_dir.glob("*.tmdl")) if tables_dir.is_dir() else []
+    if not table_files:
+        raise DesktopPreflightError(
+            "El proyecto PBIP tiene un modelo semántico vacío: Power BI "
+            "Desktop no llegará a servir un motor para este proyecto. "
+            "Añade al menos una tabla TMDL o ábrelo como informe-only.",
+            details={
+                "path": str(pbip),
+                "definition_dir": str(definition),
+                "rule": "tmdl_empty_model",
+                "findings": [{
+                    "rule": "tmdl_empty_model",
+                    "severity": "error",
+                    "path": str(tables_dir),
+                }],
+                "parse_checked": False,
+                "parsed": False,
+            },
+        )
     resultado = tmdl_validate.validate(definition, use_tom=True)
     errores = [finding for finding in resultado.get("findings", [])
                if finding.get("severity") == "error"]

--- a/src/services/format_oracle.py
+++ b/src/services/format_oracle.py
@@ -190,10 +190,17 @@ def _matches_kind(value: Any, definition: Dict[str, Any]) -> bool:
     if kind in ("unknown", "formatting", "expr"):
         return True
     if kind == "fill":
-        return (isinstance(value, dict)
-                and isinstance(value.get("solid"), dict)
-                and isinstance(value["solid"].get("color"), dict)
-                and ("expr" in value["solid"]["color"]))
+        if not isinstance(value, dict) or not isinstance(value.get("solid"), dict):
+            return False
+        solid = value["solid"]
+        # Desktop usa ``solid.color.expr`` para un color literal y
+        # ``solid.expr.FillRule`` para formato condicional. Ambos son formas
+        # oficiales del mismo tipo ``fill``.
+        color = solid.get("color")
+        if isinstance(color, dict) and "expr" in color:
+            return True
+        expr = solid.get("expr")
+        return isinstance(expr, dict) and isinstance(expr.get("FillRule"), dict)
     if kind == "image":
         image = value.get("image") if isinstance(value, dict) else None
         requeridas = {k for k, v in (definition.get("subProperties") or {}).items()

--- a/src/services/pbir_schema.py
+++ b/src/services/pbir_schema.py
@@ -446,15 +446,23 @@ def _validar_valor_formato(valor: Any, ruta: str,
     if "solid" in valor:
         solido = valor["solid"]
         ruta_solido = _ruta_hija(ruta, "solid")
-        if not isinstance(solido, dict) or not isinstance(solido.get("color"), dict):
+        if not isinstance(solido, dict):
             errores.append(_error_formato(_ruta_hija(ruta_solido, "color"),
                                           "format_solid_color"))
-        else:
+        elif isinstance(solido.get("color"), dict):
             color = solido["color"]
             if "expr" in color:
                 _validar_expresion_formato(color["expr"],
                                             _ruta_hija(_ruta_hija(ruta_solido, "color"), "expr"),
                                             errores)
+        elif isinstance(solido.get("expr"), dict) and "FillRule" in solido["expr"]:
+            # Formato condicional exportado por Desktop: el FillRule cuelga
+            # directamente de ``solid.expr``; no lleva un nivel ``color``.
+            _validar_expresion_formato(
+                solido["expr"], _ruta_hija(ruta_solido, "expr"), errores)
+        else:
+            errores.append(_error_formato(_ruta_hija(ruta_solido, "color"),
+                                          "format_solid_color"))
 
     if "expr" in valor:
         _validar_expresion_formato(valor["expr"], _ruta_hija(ruta, "expr"), errores)

--- a/tests/test_desktop_preflight.py
+++ b/tests/test_desktop_preflight.py
@@ -64,3 +64,22 @@ def test_preflight_real_detecta_colision_sin_abrir_desktop(tmp_path):
 
     assert any(f["rule"] == "tmdl_measure_column_collision"
                for f in exc.value.details["findings"])
+
+
+def test_preflight_bloquea_modelo_semantico_vacio_antes_del_timeout(tmp_path):
+    proyecto = tmp_path / "Vacio"
+    semantic = proyecto / "Vacio.SemanticModel" / "definition"
+    semantic.mkdir(parents=True)
+    pbip = proyecto / "Vacio.pbip"
+    pbip.write_text(json.dumps({
+        "$schema": "https://developer.microsoft.com/json-schemas/fabric/pbip/pbipProperties/1.0.0/schema.json",
+        "version": "1.0",
+        "artifacts": [{"report": {"path": "Vacio.Report"}}],
+    }), encoding="utf-8")
+    (proyecto / "Vacio.Report").mkdir()
+
+    with pytest.raises(desktop_launcher.DesktopPreflightError) as exc:
+        desktop_launcher._preflight_pbip_model(pbip)
+
+    assert exc.value.details["rule"] == "tmdl_empty_model"
+    assert exc.value.details["findings"][0]["severity"] == "error"

--- a/tests/test_format_oracle.py
+++ b/tests/test_format_oracle.py
@@ -127,6 +127,15 @@ def test_oraculo_puede_comprobar_todas_las_propiedades_del_visual(monkeypatch):
     assert [e["rule"] for e in result["errors"]] == ["format_property_unknown"]
 
 
+def test_oraculo_acepta_fillrule_exportado_por_desktop():
+    doc = _visual({"value": [{"properties": {
+        "fontColor": {"solid": {"expr": {"FillRule": {}}}},
+    }}]})
+    result = format_oracle.compare_managed_paths(
+        doc, [("objects", "value", "fontColor")], catalog=CATALOGO)
+    assert result["errors"] == []
+
+
 @pytest.mark.live_validator
 def test_snapshot_administrado_es_subconjunto_del_catalogo_oficial():
     """Impide que el fallback offline se separe silenciosamente de Desktop."""

--- a/tests/test_pbir_schema.py
+++ b/tests/test_pbir_schema.py
@@ -223,23 +223,19 @@ def test_el_formato_condicional_que_generamos_pasa_la_barrera_de_objects():
     assert pbir_schema.validar(documento)["validated"] is True
 
 
-def test_un_color_solido_sin_nivel_color_se_bloquea_aunque_el_schema_lo_acepte():
-    """Regresion del defecto visual: ``solid: {expr: ...}`` no pinta nada.
+def test_un_expr_solido_que_no_es_fillrule_se_bloquea_aunque_el_schema_lo_acepte():
+    """Un ``solid.expr`` literal no es un formato condicional valido.
 
-    `formattingObjectDefinitions` deja `objects` abierto, asi que el schema
-    oficial no llega a esta profundidad. Esta prueba debe fallar contra
-    0a4ed77: antes la validacion devolvia `validated=True`.
+    Desktop reserva ``solid.expr`` para ``FillRule``; un color literal debe
+    vivir en ``solid.color.expr``. El esquema oficial deja ambos caminos
+    abiertos, por eso esta barrera es necesaria.
     """
     documento = visual_valido()
     documento["visual"]["objects"] = {
         "values": [{"properties": {
-            "backColor": {"solid": {"expr": {"FillRule": {
-                "Input": _campo_de_prueba(),
-                "FillRule": {"linearGradient2": {
-                    "min": {"color": {"Literal": {"Value": "'#FFFFFF'"}}},
-                    "max": {"color": {"Literal": {"Value": "'#2A78D6'"}}},
-                }},
-            }}}},
+            "backColor": {"solid": {"expr": {
+                "Literal": {"Value": "'#FFFFFF'"},
+            }}},
         }}]}
 
     with pytest.raises(SchemaValidationFailed) as exc:


### PR DESCRIPTION
# Horizun PBI MCP v1.0.0

Primera versión estable del repositorio oficial de Horizun PBI MCP.

- 117 tools MCP y contrato compatible con las 34 tools originales.
- 1542 pruebas aprobadas; 3 omitidas únicamente por condiciones externas
  documentadas.
- Validación TMDL/TOM antes de abrir Power BI Desktop, evitando el Frown de
  proyectos con colisiones de nombres.
- Preflight de modelos vacíos: devuelve un diagnóstico accionable en vez de
  esperar un timeout de Desktop sin motor servido.
- Validación PBIR contra esquemas y CLI oficiales cuando están publicados,
  oráculo estructural para `objects`, transacciones atómicas, journals,
  backups y rollback.
- Distribución para Codex y Claude mediante runtime aislado; no se redistribuyen
  DLL de Microsoft ni esquemas de terceros.

## Límites conocidos

- La equivalencia visual completa del bloque `objects` requiere inspección
  renderizada para combinaciones no cubiertas por el oráculo.
- `mode="both"` está bloqueado por diseño: Desktop abierto y escritura PBIP
  segura son precondiciones incompatibles.
- Dos esquemas PBIR que Microsoft aún no publica siguen siendo una limitación
  upstream y se bloquean de forma explícita.
