### PR TITLE
fix: cierra huecos de validacion PBIR posteriores a v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Versionado semántico. **El contrato de las 34 tools originales nunca se rompe.*
 
 ---
 
+## [Sin publicar]
+
+### Corregido
+
+- El oráculo oficial comprueba también visuales que solo contienen
+  `visualContainerObjects`; ya no cae al snapshot parcial en ese caso.
+- Las expresiones de formato vacías (`expr: {}`) se rechazan antes de escribir.
+- La degradación a un esquema PBIR anterior se limita a versiones que el
+  manifiesto identifica expresamente como no publicadas por Microsoft.
+- Una sesión PBIP ya abierta puede reutilizarse sin validar primero una copia
+  distinta o incompleta del modelo guardado en disco.
+
+---
+
 ## [1.0.0] — 2026-08-02
 
 Primera versión estable del repositorio oficial. **117 tools, 1542 pruebas

--- a/README.md
+++ b/README.md
@@ -294,9 +294,15 @@ Ninguna de estas es un defecto que se pueda corregir desde aquí. Están documen
 
 ### Esquemas que Microsoft no publica
 
-Power BI Desktop escribe `visualContainer/2.10.0` en informes recientes, y esa URL devuelve **404** en el origen oficial. Lo mismo con `bookmarks/2.0.0`. **El CLI oficial de Microsoft tampoco puede validarlos** — emite `PBIR_SCHEMA_UNREACHABLE` y se salta la validación de esquema de esos archivos.
+Power BI Desktop escribe `visualContainer/2.10.0` y `2.11.0` en informes
+recientes, y esas URLs devuelven **404** en el origen oficial. Lo mismo ocurre
+con `bookmarks/2.0.0`. **El CLI oficial de Microsoft tampoco puede validarlos**:
+emite `PBIR_SCHEMA_UNREACHABLE` y se salta la validación de esos archivos.
 
-Consecuencia: las escrituras sobre archivos que declaren esos esquemas se **bloquean** con `schema_unavailable` (`rule=no_publicado_upstream`). Es deliberado y fail-closed: validar 2.10.0 contra 2.7.0 sería adivinar, y `additionalProperties: false` rechazaría propiedades nuevas legítimas.
+Para `visualContainer`, 2.10/2.11 se comparan con 2.7 porque esa degradación
+se midió sobre 275 archivos reales y solo difiere lo que una versión posterior
+puede añadir. `bookmarks/2.0.0` se **bloquea** con `schema_unavailable` porque no
+existe una versión anterior de la misma familia contra la cual comprobarlo.
 
 Medido sobre un informe real de 443 documentos: 176 se validan, 240 quedan bloqueados por esta causa.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -175,12 +175,12 @@ convertirlo en un **workflow guiado**, no en una operación.
 
 ---
 
-## 7. G10 — dos esquemas PBIR sin publicar
+## 7. G10 — tres versiones de esquema PBIR sin publicar
 
 **Estado:** abierto **upstream**, no nuestro.
 
-`visualContainer/2.10.0` y `bookmarks/2.0.0` devuelven 404 en el origen oficial
-de Microsoft. Su propio CLI tampoco los valida: emite
+`visualContainer/2.10.0`, `visualContainer/2.11.0` y `bookmarks/2.0.0` devuelven
+404 en el origen oficial de Microsoft. Su propio CLI tampoco los valida: emite
 `PBIR_SCHEMA_UNREACHABLE` y se los salta.
 
 No hay nada que hacer de este lado hasta que Microsoft los publique.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -95,7 +95,7 @@ Sobre una **copia** fuera de OneDrive, nunca sobre el original:
 
 | Excepción | Por qué |
 |---|---|
-| `visualContainer/2.10.0` y `bookmarks/2.0.0` sin publicar | 404 en el origen oficial; el CLI de Microsoft tampoco los valida |
+| `visualContainer/2.10.0`, `2.11.0` y `bookmarks/2.0.0` sin publicar | 404 en el origen oficial; el CLI de Microsoft tampoco los valida |
 | **G10** parcialmente cerrado | Consecuencia directa de lo anterior |
 | **R15** abierto, `both` bloqueado | Precondiciones mutuamente excluyentes ([`DUAL_MODE.md`](DUAL_MODE.md)) |
 | **Equivalencia visual completa de `objects` parcialmente cerrada** | Las rutas administradas se comprueban contra `effective-properties` oficial y un corpus anonimizado de formas exportadas por Desktop. Esto prueba estructura, propiedades, tipos y enums; no demuestra aún el resultado semántico de todos los píxeles ni todas las combinaciones posibles |

--- a/src/powerbi/desktop_launcher.py
+++ b/src/powerbi/desktop_launcher.py
@@ -260,11 +260,6 @@ def open_pbix(pbix_path: str | Path, timeout: int = 300,
             details={"path": str(pbix), "extension": pbix.suffix},
         )
 
-    # No se lanza Desktop para descubrir un error que el lint/TOM ya puede
-    # explicar. Esto evita el Frown "Sin título" de PBIP antiguos con medidas
-    # que chocan con columnas.
-    _preflight_pbip_model(pbix)
-
     # Se comprueba SIEMPRE, tambien cuando reuse_open=False. Antes ese modo
     # lanzaba otro PBIDesktop y la correlacion por archivo podia devolver la
     # ventana preexistente; el resultado quedaba marcado launched_by_us=True y
@@ -293,6 +288,13 @@ def open_pbix(pbix_path: str | Path, timeout: int = 300,
             return OpenedPbix(
                 str(pbix), instancia, pid_existente, False, 0.0,
                 desktop_started=_process_started(pid_existente))
+
+    # Solo se valida el TMDL cuando realmente vamos a crear una ventana. Una
+    # sesion ya abierta sirve el modelo que Desktop tiene en memoria y debe
+    # poder reutilizarse aunque el estado guardado en disco sea distinto.
+    # Para aperturas nuevas, el preflight evita el Frown "Sin título" de PBIP
+    # antiguos con medidas que chocan con columnas.
+    _preflight_pbip_model(pbix)
 
     ejecutable = find_executable()
     # La foto previa incluye TODOS los puertos, no solo los que ya sirven un

--- a/src/services/format_oracle.py
+++ b/src/services/format_oracle.py
@@ -198,7 +198,7 @@ def _matches_kind(value: Any, definition: Dict[str, Any]) -> bool:
         # oficiales del mismo tipo ``fill``.
         color = solid.get("color")
         if isinstance(color, dict) and "expr" in color:
-            return True
+            return isinstance(color["expr"], dict) and bool(color["expr"])
         expr = solid.get("expr")
         return isinstance(expr, dict) and isinstance(expr.get("FillRule"), dict)
     if kind == "image":
@@ -340,6 +340,17 @@ def compare_all_managed_objects(document: Dict[str, Any]) -> Dict[str, Any]:
     rutas = all_object_paths(document)
     if not rutas:
         return {"available": False, "source": "none", "errors": []}
+    visual = document.get("visual") if isinstance(document, dict) else None
+    visual_type = visual.get("visualType") if isinstance(visual, dict) else None
+    catalogo_oficial = (_load_catalog(visual_type)
+                        if isinstance(visual_type, str) and visual_type else None)
+    if catalogo_oficial is not None:
+        resultado = compare_managed_paths(
+            document, rutas, catalog=catalogo_oficial)
+        resultado["source"] = "official_cli"
+        resultado["equivalence_checked"] = True
+        return resultado
+
     resultado = compare_managed_paths(document, rutas)
     if resultado.get("source") != "official_cli":
         resultado = dict(resultado)

--- a/src/services/pbir_schema.py
+++ b/src/services/pbir_schema.py
@@ -299,7 +299,12 @@ def cargar(url: str, *, permitir_cercana: bool = False) -> Tuple[Dict[str, Any],
     version anterior de su familia en vez de bloquear.
     """
     conocido = any(d["url"] == url for d in manifiesto()["documents"])
-    if not conocido and permitir_cercana:
+    ausente = no_publicados().get(url)
+    # La aproximacion solo se permite para URLs que el manifiesto registra
+    # explicitamente como declaradas por Desktop pero ausentes en Microsoft.
+    # Una version arbitraria de la misma familia (por ejemplo 2.999.999) no es
+    # evidencia de compatibilidad y debe conservar la taxonomia unsupported.
+    if not conocido and permitir_cercana and ausente:
         alternativa = version_mas_cercana(url)
         if alternativa:
             _exigir_cache()
@@ -307,7 +312,6 @@ def cargar(url: str, *, permitir_cercana: bool = False) -> Tuple[Dict[str, Any],
             ruta = cache_dir() / entrada["file"]
             return json.loads(ruta.read_text(encoding="utf-8")), alternativa
 
-    ausente = no_publicados().get(url)
     if ausente:
         raise SchemaUnavailable(
             f"Power BI declara el esquema {url}, pero Microsoft no lo publica "
@@ -391,6 +395,9 @@ def _validar_expresion_formato(valor: Any, ruta: str,
     """
     if not isinstance(valor, dict):
         errores.append(_error_formato(ruta, "format_expression_object"))
+        return
+    if not valor:
+        errores.append(_error_formato(ruta, "format_expression_empty"))
         return
 
     literal = valor.get("Literal")

--- a/src/services/schemas/pbir_manifest.json
+++ b/src/services/schemas/pbir_manifest.json
@@ -28,6 +28,10 @@
     {
       "url": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.10.0/schema.json",
       "reason": "404 en el origen oficial"
+    },
+    {
+      "url": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.11.0/schema.json",
+      "reason": "404 en el origen oficial"
     }
   ],
   "documents": [

--- a/tests/test_desktop_preflight.py
+++ b/tests/test_desktop_preflight.py
@@ -47,6 +47,24 @@ def test_pbip_invalido_falla_antes_de_lanzar_desktop(tmp_path, monkeypatch):
         "tmdl_measure_column_collision"
 
 
+def test_pbip_ya_abierto_se_reutiliza_sin_validar_el_disco(tmp_path, monkeypatch):
+    pbip = _pbip_con_modelo(tmp_path)
+    instancia = {"port": 54321, "catalog": "Demo", "table_count": 1}
+    monkeypatch.setattr(
+        desktop_launcher, "proceso_con_archivo_abierto", lambda _path: 888)
+    monkeypatch.setattr(
+        desktop_launcher, "_instancia_de_proceso", lambda _pid: instancia)
+    monkeypatch.setattr(
+        desktop_launcher, "_preflight_pbip_model",
+        lambda _path: pytest.fail("no debe validar disco al reutilizar Desktop"))
+
+    opened = desktop_launcher.open_pbix(pbip, reuse_open=True)
+
+    assert opened.instance == instancia
+    assert opened.desktop_pid == 888
+    assert opened.launched_by_us is False
+
+
 def test_preflight_real_detecta_colision_sin_abrir_desktop(tmp_path):
     pbip = _pbip_con_modelo(tmp_path)
     definition = pbip.parent / "Demo.SemanticModel" / "definition"

--- a/tests/test_format_oracle.py
+++ b/tests/test_format_oracle.py
@@ -127,6 +127,30 @@ def test_oraculo_puede_comprobar_todas_las_propiedades_del_visual(monkeypatch):
     assert [e["rule"] for e in result["errors"]] == ["format_property_unknown"]
 
 
+def test_oraculo_completo_consulta_cli_si_el_visual_solo_tiene_vco(monkeypatch):
+    monkeypatch.setattr(format_oracle, "_load_catalog", lambda _vt: CATALOGO)
+    doc = _visual(vcos={"grupoInventado": [{"properties": {
+        "propiedadInventada": _lit("true"),
+    }}]})
+
+    result = format_oracle.compare_all_managed_objects(doc)
+
+    assert result["source"] == "official_cli"
+    assert result["equivalence_checked"] is True
+    assert [e["rule"] for e in result["errors"]] == ["format_group_unknown"]
+
+
+def test_oraculo_rechaza_expr_vacio_en_un_fill():
+    doc = _visual({"value": [{"properties": {
+        "fontColor": {"solid": {"color": {"expr": {}}}},
+    }}]})
+
+    result = format_oracle.compare_managed_paths(
+        doc, [("objects", "value", "fontColor")], catalog=CATALOGO)
+
+    assert [e["rule"] for e in result["errors"]] == ["format_property_shape"]
+
+
 def test_oraculo_acepta_fillrule_exportado_por_desktop():
     doc = _visual({"value": [{"properties": {
         "fontColor": {"solid": {"expr": {"FillRule": {}}}},

--- a/tests/test_pbir_schema.py
+++ b/tests/test_pbir_schema.py
@@ -249,6 +249,21 @@ def test_un_expr_solido_que_no_es_fillrule_se_bloquea_aunque_el_schema_lo_acepte
     }]
 
 
+def test_un_expr_vacio_se_bloquea_aunque_el_schema_lo_acepte():
+    documento = visual_valido()
+    documento["visual"]["visualType"] = "pivotTable"
+    documento["visual"]["objects"] = {
+        "values": [{"properties": {
+            "backColor": {"solid": {"color": {"expr": {}}}},
+        }}]}
+
+    with pytest.raises(SchemaValidationFailed) as exc:
+        pbir_schema.validar(documento)
+
+    assert exc.value.details["rule"] == "format_objects"
+    assert exc.value.details["errors"][0]["rule"] == "format_expression_empty"
+
+
 def test_el_oraculo_completo_bloquea_propiedad_desconocida(monkeypatch):
     """El esquema acepta ``objects`` abierto, Desktop no debe hacerlo."""
     from services import format_oracle
@@ -301,6 +316,16 @@ def test_version_futura_de_otra_mayor_se_bloquea():
     futuro["$schema"] = VISUAL.replace("2.7.0", "9.9.0")
     with pytest.raises(SchemaUnsupported) as exc:
         pbir_schema.validar(futuro)
+    assert exc.value.code == "schema_unsupported"
+
+
+def test_version_futura_inventada_de_la_misma_mayor_se_bloquea():
+    futuro = visual_valido()
+    futuro["$schema"] = VISUAL.replace("2.7.0", "2.999.999")
+
+    with pytest.raises(SchemaUnsupported) as exc:
+        pbir_schema.validar(futuro)
+
     assert exc.value.code == "schema_unsupported"
 
 


### PR DESCRIPTION
## Cambios

- obliga al oraculo oficial a revisar visuales que solo tienen visualContainerObjects
- rechaza expresiones de formato vacias
- limita el fallback de esquemas a URLs no publicadas incluidas en el manifiesto
- reutiliza sesiones PBIP abiertas antes de validar el estado guardado en disco
- actualiza la documentacion de los esquemas 2.10, 2.11 y bookmarks 2.0

## Verificacion

- 1547 passed, 3 skipped
- python scripts/doctor.py: operativo
- python -m tests.contract_utils: sin cambios de contrato
- 66 pruebas dirigidas en verde