### PR TITLE
release: Horizun PBI MCP v1.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "horizun-pbi-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Power BI Desktop y PBIP desde Claude: DAX, TOM, TMDL, PBIR, visuales, auditoría y flujos seguros.",
   "author": {"name": "HorizunGroup", "url": "https://github.com/HorizunGroup"},
   "homepage": "https://github.com/HorizunGroup/horizun-pbi-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "horizun-pbi-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Power BI Desktop y PBIP desde Codex: DAX, TOM, TMDL, PBIR, visuales, auditoría y flujos seguros.",
   "author": {"name": "HorizunGroup", "url": "https://github.com/HorizunGroup"},
   "homepage": "https://github.com/HorizunGroup/horizun-pbi-mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Versionado semántico. **El contrato de las 34 tools originales nunca se rompe.*
 
 ---
 
-## [Sin publicar]
+## [1.0.1] — 2026-08-02
 
 ### Corregido
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Servidor **MCP** (Model Context Protocol) para trabajar con **Power BI Desktop local** y con proyectos **`.pbip`** desde Claude Code.
 
-**v1.0.0** — 117 tools, 1542 pruebas aprobadas (3 omitidas, con su condición documentada). Cubre dos capas complementarias:
+**v1.0.1** — 117 tools, 1547 pruebas aprobadas (3 omitidas, con su condición documentada). Cubre dos capas complementarias:
 
 | Capa | Para qué | Cómo |
 |---|---|---|

--- a/RELEASE_NOTES_1.0.1.md
+++ b/RELEASE_NOTES_1.0.1.md
@@ -1,0 +1,24 @@
+# Horizun PBI MCP v1.0.1
+
+Primera actualización correctiva de la versión estable. Mantiene intacto el
+contrato de las 117 tools y cierra cuatro huecos de validación detectados tras
+publicar `v1.0.0`.
+
+## Corregido
+
+- El oráculo oficial revisa también visuales que solo contienen
+  `visualContainerObjects`.
+- Las expresiones de formato vacías (`expr: {}`) se rechazan antes de escribir.
+- La degradación a una versión anterior del esquema PBIR solo se permite para
+  URLs que el manifiesto identifica expresamente como no publicadas por
+  Microsoft.
+- Una sesión PBIP ya abierta se reutiliza antes de validar el estado guardado
+  en disco, evitando bloquear un modelo válido que Desktop ya sirve en memoria.
+
+## Evidencia
+
+- 117 tools; contrato MCP sin cambios.
+- 1547 pruebas aprobadas y 3 omitidas por precondiciones externas documentadas.
+- CI verde en Windows con Python 3.10 y 3.13.
+- Wheel y sdist construidos y verificados con `twine check`.
+- `scripts/doctor.py` operativo con DLL, esquemas PBIR y CLI oficial presentes.

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -19,7 +19,7 @@ Cada afirmación lleva su **nivel de verificación**. No se mezclan.
 
 | Servidor | Versión | Estado | Nivel máximo alcanzado |
 |---|---|---|---|
-| **Horizun PBI MCP** (este repo) | 1.0.0 | Presente, arranca | **Probada** — handshake stdio, 117 tools, 1542 pruebas, DAX en vivo, fixture PBIR y captura de Desktop por PID |
+| **Horizun PBI MCP** (este repo) | 1.0.1 | Presente, arranca | **Probada** — handshake stdio, 117 tools, 1547 pruebas, DAX en vivo, fixture PBIR y captura de Desktop por PID |
 | **powerbi-report-mcp** | 0.9.6 | Presente y compilado en `..\PowerBI MCP\powerbi-report-mcp\dist\index.js` | **Observada** — 57 nombres de tool extraídos del bundle y del README. **No ejecutado** |
 | **@microsoft/powerbi-modeling-mcp** | 0.5.0-beta.11 | Descargado a temporal, extraído y leído. **No ejecutado** | **Declarada** — README + CHANGELOG + `index.js`. Ejecución **detenida** por condición de parada (§2.1) |
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -106,7 +106,7 @@ Sobre una **copia** fuera de OneDrive, nunca sobre el original:
 
 ## Etiquetado
 
-La versión estable es **`v1.0.0`**. Las excepciones de abajo son límites
+La versión estable es **`v1.0.1`**. Las excepciones de abajo son límites
 documentados del producto, no errores ocultos ni criterios omitidos.
 
 La versión declarada en `branding.VERSION` / `pyproject.toml` debe coincidir con el tag **antes** de etiquetar. Instalar desde un tag y obtener un paquete que reporta otra versión es exactamente lo que estas comprobaciones existen para evitar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "horizun-pbi-mcp"
 # PEP 440. Debe coincidir con branding.VERSION y con el tag de Git.
-version = "1.0.0"
+version = "1.0.1"
 description = "Servidor MCP para Power BI: modelo semantico en vivo (DAX/TOM), proyectos .pbip (TMDL/PBIR), autoria de informes, auditoria integral y workflows."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/plugin_bootstrap.py
+++ b/scripts/plugin_bootstrap.py
@@ -17,7 +17,7 @@ import venv
 from pathlib import Path
 from typing import Any
 
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 
 

--- a/src/branding.py
+++ b/src/branding.py
@@ -3,7 +3,7 @@
 El nombre vive aqui y no repartido por el codigo: renombrar un producto no
 deberia obligar a buscar cadenas sueltas en veinte archivos.
 
-COMPATIBILIDAD: las 88 tools conservan el prefijo `pbi_`. Renombrarlas romperia
+COMPATIBILIDAD: las 117 tools conservan el prefijo `pbi_`. Renombrarlas romperia
 a cualquier cliente ya configurado, y el nombre comercial no es motivo
 suficiente para eso.
 """
@@ -19,12 +19,12 @@ MCP_SERVER_NAME = "horizun-pbi-mcp"
 #: Nombre del paquete distribuible.
 PACKAGE_NAME = "horizun-pbi-mcp"
 #: Version VISIBLE del producto: la que anuncia serverInfo y la que coincide
-#: con el tag de Git. Esta es la primera release estable del repositorio nuevo.
-VERSION = "1.0.0"
+#: con el tag de Git.
+VERSION = "1.0.1"
 
 #: La misma version en el formato que exige PEP 440 para `pyproject.toml`.
-#: `1.0.0-rc.2` no es valido ahi; una release estable usa `1.0.0`.
-VERSION_PEP440 = "1.0.0"
+#: `1.0.0-rc.2` no es valido ahi; una release estable usa `1.0.1`.
+VERSION_PEP440 = "1.0.1"
 #: Logger raiz.
 LOGGER_NAME = "horizun_pbi_mcp"
 #: Prefijo de las tools. NO cambia: es contrato publico.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -143,7 +143,12 @@ def entorno_instalado(wheel, tmp_path_factory):
     py = venv / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
     if not py.exists():
         pytest.skip("no se encontro el interprete del venv")
-    res = _correr([str(py), "-m", "pip", "install", "--no-deps", "-q", str(wheel)])
+    # El venv hereda dependencias del entorno padre. Si ese entorno tiene un
+    # checkout editable de la misma version, pip puede declarar el requisito
+    # satisfecho y NO instalar el wheel que esta prueba pretende verificar.
+    # --ignore-installed obliga a que los imports salgan del artefacto.
+    res = _correr([str(py), "-m", "pip", "install", "--ignore-installed",
+                   "--no-deps", "-q", str(wheel)])
     if res.returncode != 0:
         pytest.skip(f"no se pudo instalar el wheel: {res.stderr[-400:]}")
     return py


### PR DESCRIPTION
## Resumen

Publica la actualización correctiva estable v1.0.1 sobre los cuatro arreglos ya integrados en main y endurece la prueba del wheel para impedir falsos positivos por checkouts editables.

## Verificación local

- 1547 passed, 3 skipped
- python scripts/doctor.py: OK (117 tools)
- python -m tests.contract_utils: contrato sin cambios
- wheel + sdist: twine check OK
- instalación aislada del wheel: versión 1.0.1, 117 tools

No publica en PyPI; la distribución se hará como GitHub Release después de CI verde y merge.