### PR TITLE
fix: instalador del runtime moria en Windows por DETACHED_PROCESS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,6 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-
-[project.urls]
-Homepage = "https://horizunhub.com"
-Repository = "https://github.com/HorizunGroup/horizun-pbi-mcp"
-Documentation = "https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/INSTALL.md"
-Changelog = "https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/CHANGELOG.md"
 dependencies = [
     # Acotada por arriba a proposito: el servidor fija la version del producto
     # con `mcp._mcp_server.version` porque FastMCP.__init__ NO acepta `version`
@@ -43,6 +37,12 @@ dependencies = [
     "jsonschema>=4.20,<5",
     "referencing>=0.30,<1",
 ]
+
+[project.urls]
+Homepage = "https://horizunhub.com"
+Repository = "https://github.com/HorizunGroup/horizun-pbi-mcp"
+Documentation = "https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/INSTALL.md"
+Changelog = "https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 test = ["pytest>=8.0"]

--- a/scripts/plugin_bootstrap.py
+++ b/scripts/plugin_bootstrap.py
@@ -82,8 +82,25 @@ def runtime_env(p: dict[str, Path]) -> dict[str, str]:
     return env
 
 
-def _run(command: list[str], *, env: dict[str, str]) -> None:
-    subprocess.run(command, cwd=str(PLUGIN_ROOT), env=env, check=True)
+_STATUS_DLL_INIT_FAILED = 0xC0000142
+
+
+def _run(command: list[str], *, env: dict[str, str], retries: int = 1) -> None:
+    attempt = 0
+    while True:
+        try:
+            subprocess.run(command, cwd=str(PLUGIN_ROOT), env=env, check=True)
+            return
+        except subprocess.CalledProcessError as exc:
+            code = exc.returncode & 0xFFFFFFFF if exc.returncode is not None else None
+            # Bajo ciertos contextos de proceso en Windows (sin window station)
+            # un nieto puede morir en la carga de DLL antes de imprimir nada.
+            # Un segundo intento con el mismo comando normalmente basta.
+            if code == _STATUS_DLL_INIT_FAILED and attempt < retries:
+                attempt += 1
+                time.sleep(1)
+                continue
+            raise
 
 
 def install(base: Path | None = None, *, include_validator: bool = True) -> int:
@@ -138,8 +155,13 @@ def install(base: Path | None = None, *, include_validator: bool = True) -> int:
                       message="Runtime listo. Reinicia Codex o Claude.")
         return 0
     except Exception as exc:
-        _write_status(p, state="failed", ready=False,
-                      message=f"{type(exc).__name__}: {exc}")
+        message = f"{type(exc).__name__}: {exc}"
+        _write_status(p, state="failed", ready=False, message=message)
+        try:
+            with open(p["log"], "a", encoding="utf-8") as log:
+                log.write(f"\n[FAILED] {message}\n")
+        except OSError:
+            pass
         return 1
     finally:
         try:

--- a/scripts/plugin_launcher.py
+++ b/scripts/plugin_launcher.py
@@ -42,8 +42,11 @@ def _start_install() -> dict[str, Any]:
     kwargs: dict[str, Any] = {"stdin": subprocess.DEVNULL, "stdout": log,
                               "stderr": subprocess.STDOUT, "close_fds": True}
     if os.name == "nt":
-        kwargs["creationflags"] = (getattr(subprocess, "CREATE_NO_WINDOW", 0) |
-                                   getattr(subprocess, "DETACHED_PROCESS", 0))
+        # Solo CREATE_NO_WINDOW: oculta la consola sin cortar la asociacion a
+        # una window station. Con DETACHED_PROCESS los nietos (pip, node) la
+        # pierden y algunos mueren con STATUS_DLL_INIT_FAILED (0xC0000142)
+        # antes de imprimir nada, dejando install.log vacio.
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     else:
         kwargs["start_new_session"] = True
     try:
@@ -69,10 +72,16 @@ def bootstrap_server() -> int:
             _start_install()
         except Exception as exc:
             print(f"launcher: no se pudo iniciar el instalador: {exc}", file=sys.stderr)
+        status = bootstrap.read_status()
+
+    runtime_note = ""
+    if status.get("state") == "failed":
+        runtime_note = f" La ultima instalacion fallo: {status.get('message', '')}"
 
     tools = [
         {"name": "pbi_install_runtime",
-         "description": "Prepara en segundo plano el runtime local aislado y verificado del plugin.",
+         "description": "Prepara en segundo plano el runtime local aislado y verificado del plugin."
+                         + runtime_note,
          "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False}},
         {"name": "pbi_install_status",
          "description": "Informa el avance o el error de la instalación del runtime local.",


### PR DESCRIPTION
## Resumen

- `plugin_launcher.py` lanzaba `plugin_bootstrap.py` con `DETACHED_PROCESS | CREATE_NO_WINDOW`. Sin window station, los nietos que ese proceso spawnea (pip, node) podian morir en la carga de DLL con `STATUS_DLL_INIT_FAILED` (`0xC0000142`) antes de imprimir nada — `install.log` quedaba en 0 bytes y el runtime se quedaba indefinidamente en `failed`/`installing`, exponiendo solo `pbi_install_runtime`/`pbi_install_status`.
- Se quita `DETACHED_PROCESS`, dejando solo `CREATE_NO_WINDOW`. Ademas `_run()` reintenta una vez si un hijo muere con ese codigo especifico, y el mensaje de fallo ahora tambien se escribe en `install.log` (antes solo vivia en `install-status.json`).
- De paso: `pyproject.toml` tenia `dependencies` anidado dentro de `[project.urls]` (regresion de la prep de publicacion en PyPI), lo que rompia `pip install .` en cualquier SO. No afecta al release `v1.0.1` ya publicado (el commit que lo introdujo es posterior a ese tag), pero rompe cualquier instalacion desde `main`. Devuelto a `[project]`.

## Test plan

- [x] Reproducido el crash original spawneando `_start_install()` exactamente como lo hace el launcher real (detached, `CREATE_NO_WINDOW`, sin consola) contra un data dir descartable.
- [x] Con el fix de `creationflags` puesto, el crash de pip (`0xC0000142`) desaparece; la instalacion fallo por el bug de `pyproject.toml` (efecto secundario de mi propio checkout, no del fix).
- [x] Con ambos fixes puestos, una instalacion limpia de punta a punta (venv nuevo, pip, DLLs de Analysis Services, esquemas PBIR, validador PBIR) llego a `state: ready`.