### PR TITLE
Add 5 report-authoring improvements found while building a real dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,51 @@ Semantic versioning. **The contract of the original 34 tools is never broken.**
 
 ---
 
+## [Unreleased]
+
+Five gaps found while using the server on a real case (building a
+construction-budget dashboard from scratch, with data from an external ERP),
+not invented ones: each one cost real session time before being worked
+around by hand, and this delivery keeps the next case from paying the same
+price.
+
+### Added
+
+- **`options` in `pbi_create_visual`**: the tool never exposed the parameter
+  even though `visual_factory.build_visual` already supported it for
+  shape/card visuals; now `pbi_apply_page_spec` and `pbi_create_visual` share
+  the same capability.
+- **Color frame for any visual** (`background_color`, `border_color`,
+  `border_radius`, `background_transparency` inside `options`): it previously
+  only existed to turn the frame off (`show=False`) on composition elements;
+  there was no way to ask for a colored background/border on a card, a chart
+  or a table without hand-writing `visualContainerObjects`. Verified against
+  real shapes captured from Power BI Desktop
+  (`tests/fixtures/synthetic/format_objects_corpus.json`), not just against
+  the schema.
+- **`references` in `pbi_validate_pbip_project`**: cross-checks every
+  `Measure`/`Column` that a `visual.json` or its `filterConfig` cites against
+  the real TMDL. The official validator certifies the JSON's SHAPE; it had no
+  way to know whether a mistyped measure name actually exists. A report could
+  pass with 0 errors and open in Desktop with a silently blank card.
+- **`pbi_set_visual_filter`**: filters an ALREADY-WRITTEN visual without
+  hand-editing `filterConfig`. `pbip.filter_builder` (filter alias, typed
+  values, stable name) had existed for a while with no tool exposing it for
+  an existing visual, only for new specs.
+- **`pbi_add_table_from_file` reads HTML disguised as `.xls`**: a common ERP
+  export pattern (`Excel.Workbook` fails outright on these files). The
+  `.xls` extension is no longer taken at face value: the real file signature
+  is sniffed (OLE2 is rejected with a clear message; ZIP is read as
+  `.xlsx`; anything else is profiled as an HTML table). Repeats a `colspan`
+  cell's value across every column it spans, detects the declared encoding
+  (`<meta charset>`), only promotes headers if the table actually uses
+  `<th>`, and fixes column names by position in the M query
+  (`Table.FromRows` + `Table.ToRows`) instead of trusting how `Web.Page`
+  names them at refresh time — that naming isn't predictable from Python
+  when there is no `<th>`.
+
+---
+
 ## [1.0.0] — 2026-08-02
 
 First stable release of the official repository. **117 tools, 1542 tests

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,4 +1,4 @@
-# Tool catalog — 117
+# Tool catalog — 118
 
 Generated from the contract frozen in `tests/golden/tools_v1.json`.
 The **34 baseline** tools keep their name, parameters, types, defaults and response shape since version 0.1.0.
@@ -16,7 +16,7 @@ tools registered.
 | Original baseline | 34 |
 | A — platform | 7 |
 | B — semantic model | 16 |
-| C — PBIR authoring | 17 |
+| C — PBIR authoring | 18 |
 | D — declarative spec | 8 |
 | E — comprehensive audit | 6 |
 | F — workflows | 8 |
@@ -26,7 +26,7 @@ tools registered.
 | I — pre-delivery verification | 3 |
 | J — data loading | 2 |
 | L — design and entry point | 4 |
-| **Total** | **117** |
+| **Total** | **118** |
 
 ---
 
@@ -120,7 +120,7 @@ tools registered.
 | `pbi_report_capabilities` · `pbi_get_visual` · `pbi_list_report_pages` · `pbi_list_visuals` | No |
 | `pbi_create_visual` · `pbi_duplicate_visual` · `pbi_create_html_visual` · `pbi_add_custom_visual` | No |
 | `pbi_delete_visual` | **Yes** (`confirm`) |
-| `pbi_set_visual_title` · `pbi_set_visual_z_order` · `pbi_replace_visual_field` · `pbi_copy_visual_format` · `pbi_update_visual_position` | No |
+| `pbi_set_visual_title` · `pbi_set_visual_z_order` · `pbi_replace_visual_field` · `pbi_copy_visual_format` · `pbi_update_visual_position` · `pbi_set_visual_filter` | No |
 | `pbi_duplicate_page` · `pbi_rename_page` · `pbi_reorder_pages` | No |
 | `pbi_delete_page` | **Yes** (`confirm`) |
 | `pbi_detect_layout_issues` · `pbi_align_visuals` · `pbi_distribute_visuals` · `pbi_normalize_page_layout` · `pbi_arrange_visuals` | No |

--- a/src/pbip/pbir_writer.py
+++ b/src/pbip/pbir_writer.py
@@ -178,6 +178,57 @@ def update_visual_position(
             "transaction": result}
 
 
+def update_visual_filters(
+    active: ActivePbip,
+    page: str,
+    visual_id: str,
+    filters: List[Dict[str, Any]],
+    do_backup: bool = True,
+    tx: Optional[txn_service.Transaction] = None,
+) -> Dict[str, Any]:
+    """Reemplaza el `filterConfig` de un visual EXISTENTE.
+
+    `filters` llega en el formato de `filter_builder.build_filter` (una lista
+    vacia quita el filterConfig del visual por completo, no lo deja vacio:
+    Power BI no distingue "sin filtros" de "filterConfig: {filters: []}", y
+    dejar la clave vacia es basura que ningun lector espera).
+    """
+    from pbip import filter_builder
+
+    page_dir = resolve_page_dir(active, page)
+    target = _visual_path(page_dir, visual_id)
+    if not target.exists():
+        raise ValidationError(
+            f"No existe el visual '{visual_id}' en la pagina '{page}'.")
+
+    data = read_json(target)
+    antes = data.get("filterConfig")
+    nuevo = filter_builder.build_filter_config(filters)
+    if nuevo is None:
+        data.pop("filterConfig", None)
+    else:
+        data["filterConfig"] = nuevo
+
+    if tx is not None:
+        tx.write_json(target, data)
+        result = None
+    else:
+        _assert_escritura_pbir(active, operation="Filtrar un visual")
+        with txn_service.project_transaction(
+                active, [target], tool="pbi_set_visual_filter") as t:
+            t.write_json(target, data)
+            result = t.summary()
+
+    if do_backup and result:
+        record_change("pbi_set_visual_filter",
+                      f"Filtros del visual '{visual_id}' actualizados en "
+                      f"pagina '{page}'.",
+                      files=[str(target)], backup=result["journal"])
+    return {"visual_id": visual_id, "before": antes, "after": nuevo,
+            "backup": result["journal"] if result else None,
+            "transaction": result}
+
+
 def _existing_page_id(active: ActivePbip, display_name: str) -> Optional[str]:
     """Devuelve el id de una pagina con ese nombre visible, si ya existe."""
     for d in pages_dir(active).iterdir():

--- a/src/pbip/project_locator.py
+++ b/src/pbip/project_locator.py
@@ -253,15 +253,49 @@ def validate_project(session: Session) -> Dict[str, Any]:
             warnings.append(f"No se pudo validar el TMDL: {exc}")
             valid = False
 
+    # El esquema (arriba) y la sintaxis TMDL (arriba) pueden ser perfectos y
+    # el informe seguir citando una medida que ya no existe: ninguno de los
+    # dos sabe que hay DENTRO del otro archivo. Solo tiene sentido comparar
+    # si el TMDL se pudo leer bien; contra un modelo a medio parsear el
+    # resultado seria ruido, no una comprobacion.
+    references: Dict[str, Any] = {
+        "checked": False,
+        "reason": "el TMDL no es valido o el proyecto no tiene TMDL: no se "
+                 "compara un informe contra un modelo que no abre"}
+    if checks["has_tmdl"] and active.has_pbir and tmdl.get("valid"):
+        from pbip import tmdl_reader  # perezoso: evita un ciclo de import
+        from services import reference_audit
+
+        try:
+            model_data = tmdl_reader.read_semantic_model(active, strict=False)
+            references = reference_audit.check_report_references(active, model_data)
+            if not references["valid"]:
+                valid = False
+                for r in references["broken_references"]:
+                    warnings.append(
+                        f"Referencia: {r['kind']} '{r['property']}' de "
+                        f"'{r['table']}' no existe en el modelo (visual "
+                        f"'{r['visual_id']}' en pagina '{r['page']}').")
+                for u in references["unreadable_files"]:
+                    warnings.append(f"No se pudo leer {u['file']}: {u['error']}")
+        except Exception as exc:  # noqa: BLE001
+            references = {"checked": False, "reason": str(exc)}
+            warnings.append(f"No se pudieron comprobar las referencias del informe: {exc}")
+            valid = False
+
     checks["tmdl_valid"] = tmdl.get("valid") if tmdl.get("checked") else None
     checks["pbir_valid"] = (
         False if report_parse_errors else report_validation.get("valid"))
+    checks["references_valid"] = (
+        references.get("valid") if references.get("checked") else None)
 
     return {"valid": bool(valid), "checks": checks, "warnings": warnings,
             "tmdl": tmdl,
             "report": {**report_validation,
                        "parse_errors": report_parse_errors},
+            "references": references,
             "fully_validated": bool(
                 valid and tmdl.get("parse_checked")
-                and report_validation.get("checked")),
+                and report_validation.get("checked")
+                and references.get("checked")),
             "project": active.to_dict()}

--- a/src/pbip/table_from_file.py
+++ b/src/pbip/table_from_file.py
@@ -31,6 +31,7 @@ import re
 import unicodedata
 import uuid
 import zipfile
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -45,9 +46,32 @@ class TableFromFileError(PowerBIMCPError):
 
 
 #: Extensiones que sabemos cargar. Lo demas se rechaza por su nombre, para que
-#: el mensaje diga QUE formato es y no un generico "no soportado".
+#: el mensaje diga QUE formato es y no un generico "no soportado". '.xls' NO
+#: mapea directo a un formato fijo: hay que mirar los primeros bytes (ver
+#: `_formato_real_de_xls`), porque en la practica un '.xls' casi nunca es el
+#: binario OLE2 que la extension promete.
 _FORMATOS = {".csv": "csv", ".txt": "csv", ".tsv": "csv",
-             ".xlsx": "xlsx", ".xlsm": "xlsx", ".json": "json"}
+             ".xlsx": "xlsx", ".xlsm": "xlsx", ".json": "json",
+             ".html": "html", ".htm": "html"}
+
+#: Firma de un .xls binario de verdad (Excel 97-2003, formato OLE2/CFB).
+_MAGIC_OLE2 = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+#: Firma de un .xlsx/.xlsm real (son un .zip), aunque venga con extension .xls.
+_MAGIC_ZIP = b"PK\x03\x04"
+
+#: Juegos de caracteres declarados en <meta charset> -> codec de Python. Los
+#: reportes de ERPs casi nunca declaran UTF-8 de verdad: 'windows-1252' e
+#: 'iso-8859-1' son el caso normal, no la excepcion.
+_CHARSET_A_CODEC = {
+    "utf-8": "utf-8", "utf8": "utf-8",
+    "windows-1252": "cp1252", "cp1252": "cp1252",
+    "iso-8859-1": "cp1252", "latin1": "cp1252", "latin-1": "cp1252",
+    "iso-8859-15": "cp1252",
+}
+#: codec de Python -> textEncoding de Power Query (`Text.FromBinary`). Son los
+#: dos unicos que este cargador necesita distinguir; falta cualquier otro se
+#: trata como 1252 porque es el fallback mas comun en reportes latinoamericanos.
+_CODEC_A_TEXTENCODING = {"utf-8": 65001, "cp1252": 1252}
 
 _DELIMITADORES = (",", ";", "\t", "|")
 
@@ -326,24 +350,191 @@ def _perfilar_json(ruta: Path, muestra: int) -> Dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# '.xls' que en realidad es HTML (el caso normal en exportaciones de ERP)
+# ---------------------------------------------------------------------------
+
+def _formato_real_de_xls(ruta: Path) -> str:
+    """Mira los primeros bytes: la extension '.xls' no dice la verdad.
+
+    Un ERP casi nunca exporta el binario OLE2 que la extension promete;
+    exporta una tabla HTML y la nombra '.xls' porque Excel la abre igual.
+    Tratarlo como el .xls real (`Excel.Workbook`) falla en seco; tratarlo
+    siempre como HTML rompe el .xls autentico que si aparezca. Se decide
+    mirando la firma, no la extension.
+    """
+    cabecera = ruta.read_bytes()[:8]
+    if cabecera.startswith(_MAGIC_OLE2):
+        raise TableFromFileError(
+            f"'{ruta.name}' es un .xls binario real (formato Excel 97-2003, "
+            "OLE2). Este cargador no lo lee: convierte el archivo a .xlsx "
+            "desde Excel y vuelve a intentarlo.",
+            details={"path": str(ruta), "detected": "ole2"})
+    if cabecera.startswith(_MAGIC_ZIP):
+        return "xlsx"  # un .xlsx/.xlsm real, solo que renombrado a .xls
+    return "html"  # el caso normal: tabla HTML con extension .xls
+
+
+def _detectar_codec(crudo: bytes) -> str:
+    """Codec de Python a partir de un <meta charset> o Content-Type.
+
+    Se busca en los primeros 4KB decodificados como latin-1 (que nunca falla
+    y conserva cada byte 1 a 1): los <meta> siempre estan en ASCII puro, asi
+    que buscarlos ahi es seguro sin importar la codificacion real del resto.
+    """
+    cabecera = crudo[:4096].decode("latin-1")
+    m = re.search(r'charset\s*=\s*"?\'?([\w-]+)', cabecera, re.I)
+    declarado = (m.group(1).lower() if m else None)
+    return _CHARSET_A_CODEC.get(declarado or "", "cp1252")
+
+
+class _TablaHTML(HTMLParser):
+    """Extrae todas las <table> de un HTML, con celdas colspan repetidas.
+
+    Repetir el valor de una celda `colspan=N` en las N columnas que ocupa es
+    el MISMO criterio que usa `Web.Page` de Power Query al aplanar una fila:
+    reproducirlo aqui es lo que permite que el indice/id de tabla que se
+    calcula en Python siga significando lo mismo dentro de la consulta M.
+    """
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.tablas: List[Dict[str, Any]] = []
+        self._pila_tablas: List[int] = []
+        self._fila_actual: Optional[List[Tuple[str, int]]] = None
+        self._celda_actual: Optional[List[str]] = None
+
+    def handle_starttag(self, tag, attrs):
+        atributos = dict(attrs)
+        if tag == "table":
+            self.tablas.append({"id": atributos.get("id"), "rows": [],
+                                "has_th": False})
+            self._pila_tablas.append(len(self.tablas) - 1)
+        elif tag == "tr" and self._pila_tablas:
+            self._fila_actual = []
+        elif tag in ("td", "th") and self._fila_actual is not None:
+            if tag == "th" and self._pila_tablas:
+                self.tablas[self._pila_tablas[-1]]["has_th"] = True
+            try:
+                colspan = max(1, int(atributos.get("colspan", 1)))
+            except ValueError:
+                colspan = 1
+            self._celda_actual = []
+            self._colspan_actual = colspan
+
+    def handle_data(self, data):
+        if self._celda_actual is not None:
+            self._celda_actual.append(data)
+
+    def handle_endtag(self, tag):
+        if tag in ("td", "th") and self._celda_actual is not None:
+            texto = "".join(self._celda_actual).replace("\xa0", " ").strip()
+            self._fila_actual.extend([texto] * self._colspan_actual)
+            self._celda_actual = None
+        elif tag == "tr" and self._fila_actual is not None and self._pila_tablas:
+            self.tablas[self._pila_tablas[-1]]["rows"].append(self._fila_actual)
+            self._fila_actual = None
+        elif tag == "table" and self._pila_tablas:
+            self._pila_tablas.pop()
+
+
+def _elegir_tabla(tablas: List[Dict[str, Any]], table_id: Optional[str]
+                  ) -> Tuple[Dict[str, Any], int, List[str]]:
+    """Devuelve (tabla, indice, avisos). Sin `table_id`, la mas grande gana."""
+    avisos: List[str] = []
+    if table_id is not None:
+        for i, t in enumerate(tablas):
+            if t["id"] == table_id:
+                return t, i, avisos
+        disponibles = [t["id"] for t in tablas if t["id"]]
+        raise TableFromFileError(
+            f"No hay ninguna <table id=\"{table_id}\"> en el archivo.",
+            details={"requested_id": table_id, "available_ids": disponibles})
+
+    no_vacias = [(i, t) for i, t in enumerate(tablas) if t["rows"]]
+    if not no_vacias:
+        raise TableFromFileError("El archivo no contiene ninguna tabla HTML "
+                                 "con filas.")
+    indice, tabla = max(no_vacias, key=lambda par: len(par[1]["rows"]))
+    if tabla["id"] is None:
+        avisos.append(
+            f"Se eligio la tabla mas grande ({len(tabla['rows'])} filas, "
+            f"posicion {indice}) porque ninguna <table> tiene 'id'. Sin un "
+            "id, la consulta M selecciona por POSICION: si el archivo cambia "
+            "de estructura en el proximo reporte, puede dejar de apuntar a "
+            "la tabla correcta. Verificalo en el editor de Power Query.")
+    return tabla, indice, avisos
+
+
+def _perfilar_html(ruta: Path, muestra: int, table_id: Optional[str] = None
+                   ) -> Dict[str, Any]:
+    crudo = ruta.read_bytes()
+    codec = _detectar_codec(crudo)
+    texto = crudo.decode(codec, errors="replace")
+
+    parser = _TablaHTML()
+    parser.feed(texto)
+    tabla, indice, avisos = _elegir_tabla(parser.tablas, table_id)
+    filas = tabla["rows"]
+
+    ancho = max((len(f) for f in filas), default=0)
+    if ancho == 0:
+        raise TableFromFileError(f"La tabla elegida no tiene columnas: {ruta}")
+    filas = [f + [""] * (ancho - len(f)) for f in filas]  # rellena filas cortas
+
+    # Un reporte de ERP casi nunca tiene una fila 1 que sirva de encabezado
+    # (suele ser el titulo del reporte). Solo se promueve si ESTA tabla usa
+    # <th> en algun punto: adivinarlo a partir del texto de la fila 1 seria
+    # inventar una estructura que el archivo no afirma tener.
+    promover = bool(tabla["rows"]) and tabla.get("has_th", False)
+    if promover:
+        encabezados = [c or f"Column{i + 1}" for i, c in enumerate(filas[0])]
+        datos = filas[1:muestra + 1]
+    else:
+        encabezados = [f"Column{i + 1}" for i in range(ancho)]
+        datos = filas[:muestra]
+
+    columnas_valores = [[f[i] if i < len(f) else "" for f in datos]
+                        for i in range(ancho)]
+    sep = _separador_decimal([v for col in columnas_valores for v in col])
+
+    return {
+        "format": "html", "path": str(ruta), "sheet": None, "delimiter": None,
+        "encoding": _CODEC_A_TEXTENCODING.get(codec, 1252), "has_bom": False,
+        "decimal_separator": sep, "row_sample": len(datos),
+        "table_id": tabla["id"], "table_index": indice,
+        "promote_headers": promover, "warnings": avisos,
+        "columns": [{"name": n, "data_type": _inferir_tipo(v, sep)}
+                    for n, v in zip(encabezados, columnas_valores)],
+    }
+
+
 def perfilar(path: Path | str, sheet: Optional[str] = None,
-             muestra: int = 200) -> Dict[str, Any]:
+             muestra: int = 200, table_id: Optional[str] = None) -> Dict[str, Any]:
     """Mira dentro del archivo y deduce columnas, tipos y cultura."""
     ruta = Path(path).expanduser()
     if not ruta.exists():
         raise TableFromFileError(f"El archivo no existe: {ruta}",
                                  details={"path": str(ruta)})
-    formato = _FORMATOS.get(ruta.suffix.lower())
+    if ruta.suffix.lower() == ".xls":
+        # '.xls' no se toma por su palabra: se mira la firma real del
+        # archivo (ver `_formato_real_de_xls`).
+        formato = _formato_real_de_xls(ruta)
+    else:
+        formato = _FORMATOS.get(ruta.suffix.lower())
     if formato is None:
         raise TableFromFileError(
             f"No se sabe cargar un '{ruta.suffix}'. Formatos admitidos: "
-            f"{', '.join(sorted(_FORMATOS))}.",
+            f"{', '.join(sorted(_FORMATOS))}, .xls (si es HTML o un .xlsx "
+            "renombrado).",
             details={"path": str(ruta), "suffix": ruta.suffix})
 
     if formato == "csv":
         perfil = _perfilar_csv(ruta, muestra)
     elif formato == "xlsx":
         perfil = _perfilar_xlsx(ruta, sheet, muestra)
+    elif formato == "html":
+        perfil = _perfilar_html(ruta, muestra, table_id)
     else:
         perfil = _perfilar_json(ruta, muestra)
 
@@ -429,12 +620,46 @@ def construir_m(perfil: Dict[str, Any], culture: Optional[str] = None) -> str:
             f'    #"Navegación" = Origen{{[Item = {_literal_m(perfil["sheet"])}, '
             'Kind = "Sheet"]}[Data],')
         anterior = '#"Navegación"'
+    elif perfil["format"] == "html":
+        # Web.Page no toma codificacion: hay que decodificar ANTES con
+        # Text.FromBinary y darle texto, no bytes. Es la diferencia entre
+        # 'Cimentación' y 'CimentaciÃ³n' con signos de interrogación.
+        pasos.append(
+            f'    Origen = Web.Page(Text.FromBinary(File.Contents({ruta}), '
+            f'{perfil["encoding"]})),')
+        if perfil.get("table_id"):
+            pasos.append(
+                f'    #"Tabla" = Origen{{[Id = {_literal_m(perfil["table_id"])}]}}[Data],')
+        else:
+            # Sin id, se selecciona por POSICION: el mismo orden en que el
+            # extractor de Python encontro las <table> (ver `_elegir_tabla`
+            # y el aviso que ya viaja en `perfil["warnings"]`).
+            pasos.append(f'    #"Tabla" = Origen{{{perfil["table_index"]}}}[Data],')
+        anterior = '#"Tabla"'
+        if perfil.get("promote_headers"):
+            pasos.append(f'    #"Fila de titulo quitada" = Table.Skip({anterior}, 1),')
+            anterior = '#"Fila de titulo quitada"'
+        # Web.Page NO nombra las columnas "Column1", "Column2"... como Csv o
+        # Excel.Workbook sin encabezados: cuando la tabla no trae <th> les
+        # pone un nombre propio deducido de lo que ve en cada columna, y ese
+        # nombre no es predecible desde Python. Fijarlos aqui por POSICION
+        # (Table.FromRows + Table.ToRows) es lo que hace que
+        # Table.TransformColumnTypes, mas abajo, encuentre columnas que de
+        # verdad existen.
+        nombres_fijos = "{" + ", ".join(
+            _literal_m(c["name"]) for c in perfil["columns"]) + "}"
+        pasos.append(
+            f'    #"Encabezados fijados" = Table.FromRows(Table.ToRows('
+            f'{anterior}), {nombres_fijos}),')
+        anterior = '#"Encabezados fijados"'
     else:
         pasos.append(f'    Origen = Json.Document(File.Contents({ruta})),')
         pasos.append('    #"Convertida en tabla" = Table.FromRecords(Origen),')
         anterior = '#"Convertida en tabla"'
 
-    if perfil["format"] != "json":
+    if perfil["format"] == "html":
+        pass  # los nombres ya quedaron fijados arriba: promover aqui los duplicaria
+    elif perfil["format"] != "json":
         pasos.append(f'    #"Encabezados promovidos" = Table.PromoteHeaders('
                      f'{anterior}, [PromoteAllScalars = true]),')
         anterior = '#"Encabezados promovidos"'
@@ -502,13 +727,19 @@ def construir_tmdl(nombre: str, perfil: Dict[str, Any],
 def agregar_tabla(active: Any, path: Path | str, table_name: str = "",
                   sheet: Optional[str] = None, culture: Optional[str] = None,
                   description: Optional[str] = None, overwrite: bool = False,
-                  dry_run: bool = False, muestra: int = 200) -> Dict[str, Any]:
-    """Carga un archivo como tabla del modelo, y comprueba que el TMDL abre."""
+                  dry_run: bool = False, muestra: int = 200,
+                  table_id: Optional[str] = None) -> Dict[str, Any]:
+    """Carga un archivo como tabla del modelo, y comprueba que el TMDL abre.
+
+    `table_id`: solo para HTML/'.xls' que en realidad es HTML. El `id` de la
+    `<table>` a leer, cuando el archivo trae varias. Sin el, se elige la mas
+    grande y se avisa (`perfil["warnings"]`).
+    """
     from pbip.model_author import ModelAuthorError, resolver_destino_tabla
     from utils.validation import validate_object_name
 
     ruta = Path(path).expanduser()
-    perfil = perfilar(ruta, sheet=sheet, muestra=muestra)
+    perfil = perfilar(ruta, sheet=sheet, muestra=muestra, table_id=table_id)
 
     nombre = validate_object_name(table_name or ruta.stem, "tabla")
     try:
@@ -525,6 +756,12 @@ def agregar_tabla(active: Any, path: Path | str, table_name: str = "",
         "columns": perfil["columns"], "column_count": len(perfil["columns"]),
         "rows_sampled": perfil["row_sample"],
     }
+    if perfil["format"] == "html":
+        resumen["table_id"] = perfil.get("table_id")
+        resumen["table_index"] = perfil.get("table_index")
+        resumen["promoted_headers"] = perfil.get("promote_headers")
+        if perfil.get("warnings"):
+            resumen["warnings"] = perfil["warnings"]
     if dry_run:
         return {**resumen, "dry_run": True, "tmdl": texto, "m": construir_m(perfil, culture)}
 

--- a/src/pbip/visual_factory.py
+++ b/src/pbip/visual_factory.py
@@ -774,6 +774,43 @@ def _aplicar_opciones_de_tarjeta(vis: Dict[str, Any], actual_type: str,
         vis.pop("objects", None)
 
 
+def _aplicar_estilo_contenedor(vis: Dict[str, Any], opciones: Dict[str, Any]) -> None:
+    """Fondo y borde del MARCO: aplica a cualquier tipo de visual.
+
+    Es el panel General > Efectos de Power BI Desktop (Fondo / Borde), no el
+    relleno propio de una forma (`_build_shape`) ni el color de un valor de
+    tarjeta (`_aplicar_opciones_de_tarjeta`). Antes no habia forma de pedir
+    esto por 'options': `_sin_marco()` solo sabia APAGARLO (`show=False`) en
+    los elementos de composicion, y encenderlo con un color exigia escribir
+    `visualContainerObjects` a mano fuera de esta fabrica.
+
+    `background_color` / `border_color`: hex ('#RRGGBB'). Sin ellos, no se
+    toca nada (no se inventa un marco que nadie pidio).
+    """
+    color_fondo = opciones.get("background_color")
+    color_borde = opciones.get("border_color")
+    if not color_fondo and not color_borde:
+        return
+
+    contenedor = vis.setdefault("visualContainerObjects", {})
+
+    if color_fondo:
+        contenedor["background"] = [{"properties": {
+            "show": _lit(True),
+            "color": {"solid": {"color": _lit(color_fondo)}},
+            "transparency": _lit(float(opciones.get("background_transparency", 0))),
+        }}]
+
+    if color_borde:
+        props: Dict[str, Any] = {
+            "show": _lit(True),
+            "color": {"solid": {"color": _lit(color_borde)}},
+        }
+        if opciones.get("border_radius") is not None:
+            props["radius"] = _lit(float(opciones["border_radius"]))
+        contenedor["border"] = [{"properties": props}]
+
+
 def _build_shape(opciones: Dict[str, Any]) -> Dict[str, Any]:
     forma = opciones.get("shape", "rectangle")
     if forma not in FORMAS:
@@ -926,6 +963,15 @@ def _rutas_formato_generadas(vis: Dict[str, Any], *, completas: bool,
     if title is not None:
         rutas.extend([("visualContainerObjects", "title", "text"),
                       ("visualContainerObjects", "title", "show")])
+    if opciones.get("background_color"):
+        rutas.extend([("visualContainerObjects", "background", "show"),
+                      ("visualContainerObjects", "background", "color"),
+                      ("visualContainerObjects", "background", "transparency")])
+    if opciones.get("border_color"):
+        rutas.extend([("visualContainerObjects", "border", "show"),
+                      ("visualContainerObjects", "border", "color")])
+        if opciones.get("border_radius") is not None:
+            rutas.append(("visualContainerObjects", "border", "radius"))
     if actual_type in ("card", "cardVisual"):
         etiqueta = "label" if actual_type == "cardVisual" else "categoryLabels"
         valor = "value" if actual_type == "cardVisual" else "labels"
@@ -1002,6 +1048,7 @@ def build_visual(
         if title is not None and opciones.get("show_title"):
             vis.setdefault("visualContainerObjects", {})["title"] = [
                 {"properties": {"show": _lit(True), "text": _lit(title)}}]
+        _aplicar_estilo_contenedor(vis, opciones)
         if actual_type == "textbox":
             _ajustar_alto_de_texto(pos, opciones, warnings)
         documento = {"$schema": SCHEMA_VISUAL, "position": pos, "visual": vis}
@@ -1034,6 +1081,7 @@ def build_visual(
         _quitar_selectores_de_campos_obsoletos(vis, query, warnings)
         if actual_type in ("card", "cardVisual"):
             _aplicar_opciones_de_tarjeta(vis, actual_type, options or {})
+        _aplicar_estilo_contenedor(vis, options or {})
         origin = f"clonado de {template}"
     else:
         vis = {
@@ -1045,6 +1093,7 @@ def build_visual(
             _set_title(vis, title)
         if actual_type in ("card", "cardVisual"):
             _aplicar_opciones_de_tarjeta(vis, actual_type, options or {})
+        _aplicar_estilo_contenedor(vis, options or {})
         data = {"$schema": SCHEMA_VISUAL, "position": pos, "visual": vis}
         origin = "plantilla minima (validar en Power BI Desktop)"
         warnings.append(

--- a/src/services/format_oracle.py
+++ b/src/services/format_oracle.py
@@ -34,8 +34,10 @@ _MAX_CATALOG_BYTES = 8 * 1024 * 1024
 # Node solo para comprobar VCO compartidos como title.show/title.text.
 _SHARED_VCO = {
     "title": {"show": {"type": "bool"}, "text": {"type": "text"}},
-    "background": {"show": {"type": "bool"}},
-    "border": {"show": {"type": "bool"}},
+    "background": {"show": {"type": "bool"}, "color": {"type": "fill"},
+                   "transparency": {"type": "numeric"}},
+    "border": {"show": {"type": "bool"}, "color": {"type": "fill"},
+               "radius": {"type": "numeric"}},
     "visualLink": {
         "show": {"type": "bool"},
         "type": {"type": "enum", "values": [

--- a/src/services/reference_audit.py
+++ b/src/services/reference_audit.py
@@ -1,0 +1,103 @@
+"""Cruza lo que un informe PBIR REFERENCIA contra el modelo TMDL real.
+
+El validador oficial de Microsoft (`services.report_validator`) certifica que
+cada visual.json tiene la FORMA correcta; no sabe que hay dentro del .pbip ni
+si "Presupuesto Toal" (con la o y la a invertidas) existe de verdad. Un
+informe puede pasar esa validacion con 0 errores y abrir en Desktop con una
+tarjeta muda, porque Desktop resuelve el campo roto en silencio a nada: no
+hay excepcion, no hay marca visible, solo un numero que nunca aparece.
+
+Esto cierra ese hueco leyendo el TMDL de verdad (`tmdl_reader`) y comparando
+cada `Measure`/`Column` que un visual.json o su `filterConfig` referencian.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Set, Tuple
+
+from config import ActivePbip
+from pbip.pbir_reader import pages_dir
+from utils.json_utils import read_json
+
+
+def _measure_names(model_data: Dict[str, Any]) -> Set[str]:
+    return {m["name"] for m in model_data.get("measures", []) if m.get("name")}
+
+
+def _column_index(model_data: Dict[str, Any]) -> Dict[str, Set[str]]:
+    return {t["name"]: {c["name"] for c in t.get("columns", []) if c.get("name")}
+            for t in model_data.get("tables", []) if t.get("name")}
+
+
+def _walk_field_refs(node: Any) -> List[Tuple[str, str, str]]:
+    """(kind, entity, property) de cada nodo Measure/Column dentro de `node`.
+
+    Solo se cuenta un nodo cuando trae `Expression.SourceRef.Entity`, el
+    nombre REAL de la tabla. La mitad interna de un filtro referencia la
+    tabla por ALIAS (`SourceRef.Source`), no por nombre, y esa forma se
+    ignora aqui a proposito: comparar un alias de una letra contra nombres de
+    tabla produciria falsos positivos en cada filtro que el informe tenga.
+    """
+    hallados: List[Tuple[str, str, str]] = []
+    if isinstance(node, dict):
+        for kind in ("Measure", "Column"):
+            sub = node.get(kind)
+            if isinstance(sub, dict):
+                entidad = ((sub.get("Expression") or {}).get("SourceRef") or {}).get("Entity")
+                propiedad = sub.get("Property")
+                if entidad and propiedad:
+                    hallados.append((kind, entidad, propiedad))
+        for value in node.values():
+            hallados.extend(_walk_field_refs(value))
+    elif isinstance(node, list):
+        for item in node:
+            hallados.extend(_walk_field_refs(item))
+    return hallados
+
+
+def check_report_references(active: ActivePbip,
+                            model_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Referencias rotas: medida inexistente, tabla inexistente o columna
+    inexistente en una tabla que si existe. Recorre TODO el visual.json (la
+    consulta Y el `filterConfig`), asi que un filtro que apunta a una columna
+    borrada se detecta igual que una tarjeta que apunta a una medida borrada.
+    """
+    medidas_conocidas = _measure_names(model_data)
+    columnas_por_tabla = _column_index(model_data)
+    tablas_conocidas = set(columnas_por_tabla)
+
+    rotas: List[Dict[str, Any]] = []
+    ilegibles: List[Dict[str, str]] = []
+    revisados = 0
+
+    for archivo in sorted(pages_dir(active).glob("*/visuals/*/visual.json")):
+        try:
+            documento = read_json(archivo)
+        except Exception as exc:  # noqa: BLE001
+            ilegibles.append({"file": str(archivo),
+                              "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        revisados += 1
+        pagina = archivo.parent.parent.parent.name
+        visual_id = documento.get("name")
+
+        for kind, entidad, propiedad in _walk_field_refs(documento):
+            if kind == "Measure":
+                if propiedad not in medidas_conocidas:
+                    rotas.append({
+                        "file": str(archivo), "page": pagina, "visual_id": visual_id,
+                        "kind": "measure", "table": entidad, "property": propiedad,
+                        "reason": "medida_inexistente"})
+            elif entidad not in tablas_conocidas:
+                rotas.append({
+                    "file": str(archivo), "page": pagina, "visual_id": visual_id,
+                    "kind": "column", "table": entidad, "property": propiedad,
+                    "reason": "tabla_inexistente"})
+            elif propiedad not in columnas_por_tabla[entidad]:
+                rotas.append({
+                    "file": str(archivo), "page": pagina, "visual_id": visual_id,
+                    "kind": "column", "table": entidad, "property": propiedad,
+                    "reason": "columna_inexistente"})
+
+    return {"checked": True, "visuals_checked": revisados,
+            "broken_references": rotas, "unreadable_files": ilegibles,
+            "valid": not rotas and not ilegibles}

--- a/src/tools/model_edit_tools.py
+++ b/src/tools/model_edit_tools.py
@@ -268,7 +268,7 @@ def register(mcp) -> None:
     def pbi_add_table_from_file(path: str, table_name: str = "",
                                 sheet: str = "", culture: str = "",
                                 description: str = "", overwrite: bool = False,
-                                dry_run: bool = False,
+                                dry_run: bool = False, table_id: str = "",
                                 request_id: str = "") -> Dict[str, Any]:
         """Carga un archivo al modelo como lo haria una persona: abrir, transformar, cargar.
 
@@ -278,8 +278,23 @@ def register(mcp) -> None:
         'Encabezados promovidos', 'Tipo cambiado'), asi que se puede abrir y
         editar en el editor sin que desentone.
 
-        Admite .csv, .txt, .tsv, .xlsx, .xlsm y .json. Sin dependencias
-        nuevas: el .xlsx se lee como lo que es, un zip con XML.
+        Admite .csv, .txt, .tsv, .xlsx, .xlsm, .json, .html/.htm y '.xls'.
+        Sin dependencias nuevas: el .xlsx se lee como lo que es, un zip con
+        XML, y el HTML con `html.parser` de la biblioteca estandar.
+
+        Un '.xls' NO se toma por la extension: se mira la firma real del
+        archivo. En la practica, casi ningun '.xls' que exportan los ERPs es
+        el binario OLE2 que la extension promete -- es una tabla HTML con esa
+        extension porque Excel la abre igual. Si de verdad es OLE2 (Excel
+        97-2003), se rechaza con un mensaje claro en vez de leerlo mal; si es
+        un .xlsx renombrado, se lee como .xlsx.
+
+        Para HTML: si el archivo trae varias `<table>`, se elige la mas
+        grande y se avisa (usa `table_id` para elegir una en concreto, el
+        `id` HTML de la tabla). Los encabezados solo se promueven si la
+        tabla usa `<th>`; un reporte sin esa marca (el caso normal en un
+        reporte de ERP, donde la fila 1 es el titulo del reporte, no un
+        encabezado) carga con columnas 'Column1', 'Column2'...
 
         **La cultura se deduce del archivo**, mirando como escribe los
         decimales, y se emite SIEMPRE explicita en la consulta. Asumir la del
@@ -291,7 +306,7 @@ def register(mcp) -> None:
         no abre.
 
         `dry_run=true` devuelve el TMDL y la M sin escribir nada.
-        `sheet`: hoja del libro; si se omite, la primera.
+        `sheet`: hoja del libro; si se omite, la primera. Solo aplica a xlsx.
 
         Escribe en TMDL: requiere el proyecto CERRADO en Power BI Desktop.
         """
@@ -301,7 +316,7 @@ def register(mcp) -> None:
             _proyecto_activo(), path, table_name=table_name,
             sheet=sheet or None, culture=culture or None,
             description=description or None, overwrite=overwrite,
-            dry_run=dry_run))
+            dry_run=dry_run, table_id=table_id or None))
 
     @mcp.tool()
     def pbi_set_storage_mode(table: str, mode: str,

--- a/src/tools/pbip_tools.py
+++ b/src/tools/pbip_tools.py
@@ -23,7 +23,15 @@ def register(mcp) -> None:
 
     @mcp.tool()
     def pbi_validate_pbip_project() -> Dict[str, Any]:
-        """Valida a fondo el proyecto .pbip activo (estructura, PBIR, TMDL)."""
+        """Valida a fondo el proyecto .pbip activo (estructura, PBIR, TMDL).
+
+        Incluye `references`: cada Measure/Column que un visual.json o su
+        filterConfig citan, cruzada contra el TMDL real. El esquema PBIR y la
+        sintaxis TMDL pueden pasar limpios por separado con un visual que
+        apunta a una medida borrada -- Desktop lo resuelve en silencio a
+        nada, sin marca visible. Solo corre si el TMDL es valido (comparar
+        contra un modelo que no abre es ruido, no una comprobacion).
+        """
         return guard(lambda: project_locator.validate_project(get_session()))
 
     @mcp.tool()

--- a/src/tools/visual_tools.py
+++ b/src/tools/visual_tools.py
@@ -114,6 +114,7 @@ def register(mcp) -> None:
         fields: Dict[str, Any],
         position: Dict[str, float],
         title: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
     request_id: str = "") -> Dict[str, Any]:
         """Crea un visual PBIR en una pagina.
 
@@ -143,6 +144,18 @@ def register(mcp) -> None:
         Un rol que ese tipo de visual no tiene se RECHAZA con la lista de los
         validos. Antes se descartaba en silencio y el visual salia sin datos.
 
+        `options`: formato adicional. Llaves reconocidas (una clave no
+        reconocida se ignora, no se rechaza; ver `pbi_get_visual` para
+        comprobar que quedo escrito):
+        - `background_color`, `border_color` ('#RRGGBB'), `background_transparency`
+          (0-100), `border_radius` (px): el marco de CUALQUIER visual (panel
+          General > Efectos de Desktop). Sin `background_color`/`border_color`
+          no se toca el marco.
+        - `card`/`cardVisual`: `show_category_label`, `value_font_size`,
+          `bold_value`, `value_color`.
+        - `shape`: `fill`, `transparency`, `text`, `font_size`, `text_color`.
+        - `textbox`: `text`, `font_size`, `color`, `bold`, `font`, `align`.
+
         `position`: {x, y, width, height} (z opcional).
         Clona un visual del mismo tipo como plantilla si existe. Hace backup.
         """
@@ -150,7 +163,8 @@ def register(mcp) -> None:
             active = get_session().require_active_pbip()
             pos = validate_position(position)
             mi = _measure_index(_model_data())
-            built = visual_factory.build_visual(active, visual_type, fields or {}, pos, title, mi)
+            built = visual_factory.build_visual(
+                active, visual_type, fields or {}, pos, title, mi, options=options)
             res = pbir_writer.write_visual(active, page, built["visual"])
             return {
                 "visual_id": res["visual_id"],
@@ -223,6 +237,41 @@ def register(mcp) -> None:
             active = get_session().require_active_pbip()
             res = pbir_writer.update_visual_position(
                 active, page, visual_id, x, y, width, height, z)
+            res["reload_hint"] = RELOAD_HINT
+            return res
+        return guard_mutation(_impl)
+
+    @mcp.tool()
+    def pbi_set_visual_filter(
+        page: str,
+        visual_id: str,
+        filters: List[Dict[str, Any]],
+    request_id: str = "") -> Dict[str, Any]:
+        """Filtra un visual EXISTENTE sin escribir `filterConfig` a mano.
+
+        `filters`: lista de specs, cada uno
+        `{field: 'Tabla[Columna]', values?: [...], type?: 'Categorical' |
+        'Advanced' | 'TopN' | 'Range' | 'RelativeDate' | 'Passthrough',
+        exclude?: bool, raw?: {...}, hidden?: bool, locked?: bool,
+        display_name?: str}`. Con `values` se arma un filtro de lista
+        (Categorical); sin `values` ni `raw` el campo queda declarado pero
+        SIN acotar, como el panel de filtros vacio. `raw` pasa una consulta
+        semantica ya construida, para lo que este constructor no cubre.
+
+        `field` va con el NOMBRE real de la tabla. La mitad interna de la
+        consulta usa un ALIAS (`SourceRef.Source`) que esta tool resuelve
+        sola: escribirlo a mano ahi es el error mas comun al construir un
+        filtro de visual, y Power BI lo ignora sin decir por que.
+
+        Una lista vacia QUITA todos los filtros del visual (no los deja
+        declarados sin valor). No comprueba `field` contra el modelo: un
+        campo que no existe se escribe igual y Power BI lo resuelve en
+        silencio a nada, igual que si se escribiera a mano.
+        """
+        def _impl():
+            active = get_session().require_active_pbip()
+            res = pbir_writer.update_visual_filters(
+                active, page, visual_id, filters or [])
             res["reload_hint"] = RELOAD_HINT
             return res
         return guard_mutation(_impl)

--- a/tests/golden/tools_v1.json
+++ b/tests/golden/tools_v1.json
@@ -1,6 +1,6 @@
 {
   "contract_version": 1,
-  "tool_count": 117,
+  "tool_count": 118,
   "tools": [
     {
       "name": "pbi_add_custom_visual",
@@ -67,7 +67,7 @@
     },
     {
       "name": "pbi_add_table_from_file",
-      "description": "Carga un archivo al modelo como lo haria una persona: abrir, transformar, cargar.\n\nEl mismo recorrido de Power Query —Obtener datos, promover encabezados,\ncambiar tipos, Cargar— pero escrito directo en el proyecto. Los pasos\nde la consulta se llaman como los pone Power BI ('Origen',\n'Encabezados promovidos', 'Tipo cambiado'), asi que se puede abrir y\neditar en el editor sin que desentone.\n\nAdmite .csv, .txt, .tsv, .xlsx, .xlsm y .json. Sin dependencias\nnuevas: el .xlsx se lee como lo que es, un zip con XML.\n\n**La cultura se deduce del archivo**, mirando como escribe los\ndecimales, y se emite SIEMPRE explicita en la consulta. Asumir la del\nmodelo es lo que convierte 10527.52 en diez millones sin que nada\nfalle: un informe que abre, pinta y miente. `culture` permite forzarla.\n\nLo escrito se valida antes de darlo por bueno: si el TMDL generado no\npasara `pbi_validate_tmdl`, se aborta en vez de dejar un proyecto que\nno abre.\n\n`dry_run=true` devuelve el TMDL y la M sin escribir nada.\n`sheet`: hoja del libro; si se omite, la primera.\n\nEscribe en TMDL: requiere el proyecto CERRADO en Power BI Desktop.",
+      "description": "Carga un archivo al modelo como lo haria una persona: abrir, transformar, cargar.\n\nEl mismo recorrido de Power Query —Obtener datos, promover encabezados,\ncambiar tipos, Cargar— pero escrito directo en el proyecto. Los pasos\nde la consulta se llaman como los pone Power BI ('Origen',\n'Encabezados promovidos', 'Tipo cambiado'), asi que se puede abrir y\neditar en el editor sin que desentone.\n\nAdmite .csv, .txt, .tsv, .xlsx, .xlsm, .json, .html/.htm y '.xls'.\nSin dependencias nuevas: el .xlsx se lee como lo que es, un zip con\nXML, y el HTML con `html.parser` de la biblioteca estandar.\n\nUn '.xls' NO se toma por la extension: se mira la firma real del\narchivo. En la practica, casi ningun '.xls' que exportan los ERPs es\nel binario OLE2 que la extension promete -- es una tabla HTML con esa\nextension porque Excel la abre igual. Si de verdad es OLE2 (Excel\n97-2003), se rechaza con un mensaje claro en vez de leerlo mal; si es\nun .xlsx renombrado, se lee como .xlsx.\n\nPara HTML: si el archivo trae varias `<table>`, se elige la mas\ngrande y se avisa (usa `table_id` para elegir una en concreto, el\n`id` HTML de la tabla). Los encabezados solo se promueven si la\ntabla usa `<th>`; un reporte sin esa marca (el caso normal en un\nreporte de ERP, donde la fila 1 es el titulo del reporte, no un\nencabezado) carga con columnas 'Column1', 'Column2'...\n\n**La cultura se deduce del archivo**, mirando como escribe los\ndecimales, y se emite SIEMPRE explicita en la consulta. Asumir la del\nmodelo es lo que convierte 10527.52 en diez millones sin que nada\nfalle: un informe que abre, pinta y miente. `culture` permite forzarla.\n\nLo escrito se valida antes de darlo por bueno: si el TMDL generado no\npasara `pbi_validate_tmdl`, se aborta en vez de dejar un proyecto que\nno abre.\n\n`dry_run=true` devuelve el TMDL y la M sin escribir nada.\n`sheet`: hoja del libro; si se omite, la primera. Solo aplica a xlsx.\n\nEscribe en TMDL: requiere el proyecto CERRADO en Power BI Desktop.",
       "params": {
         "culture": {
           "required": false,
@@ -99,6 +99,11 @@
           "default": ""
         },
         "sheet": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "table_id": {
           "required": false,
           "type": "string",
           "default": ""
@@ -1408,11 +1413,16 @@
     },
     {
       "name": "pbi_create_visual",
-      "description": "Crea un visual PBIR en una pagina.\n\n`visual_type` acepta: actionButton, areaChart, barChart, button, card,\ncardVisual, clusteredBarChart, clusteredColumnChart, columnChart, donut,\ndonutChart, funnel, gauge, htmlContent,\nhtmlContent443BE3AD55E043BF878BED274D3A6855, image, kpi, lineChart,\nmatrix, multiRowCard, navigation, pageNavigator, pieChart, pivotTable,\nrectangle, ribbonChart, scatterChart, shape, slicer, table, tableEx,\ntext, textbox, treemap, waterfall y waterfallChart.\n\nPara visuales con datos, valida antes de escribir los roles obligatorios,\nla cardinalidad maxima de cada rol y el tipo de campo admitido: dimension\n(`Grouping`), medida (`Measure`) o cualquiera de ambos\n(`GroupingOrMeasure`). Los elementos decorativos (texto, forma, imagen,\nnavegador y boton) rechazan `fields` porque no llevan consulta.\n\n`fields`: rol -> campos, p.ej. {\"category\":\"Tabla[Col]\",\n          \"values\":[\"[Medida]\"], \"legend\":\"Tabla[Col]\"}.\n\nEl rol se reconoce escrito como sea: el logico (`values`), el nombre\nque usa PBIR y que devuelve `pbi_list_visuals` (`Values`, `Y`,\n`Category`, `Data`) o un sinonimo (`measure`, `axis`). Cada campo puede\nser `\"Tabla[Campo]\"` o el objeto que devuelve `pbi_list_visuals`, para\npoder leer una pagina y rehacerla sin traducir nada.\n\nUn rol que ese tipo de visual no tiene se RECHAZA con la lista de los\nvalidos. Antes se descartaba en silencio y el visual salia sin datos.\n\n`position`: {x, y, width, height} (z opcional).\nClona un visual del mismo tipo como plantilla si existe. Hace backup.",
+      "description": "Crea un visual PBIR en una pagina.\n\n`visual_type` acepta: actionButton, areaChart, barChart, button, card,\ncardVisual, clusteredBarChart, clusteredColumnChart, columnChart, donut,\ndonutChart, funnel, gauge, htmlContent,\nhtmlContent443BE3AD55E043BF878BED274D3A6855, image, kpi, lineChart,\nmatrix, multiRowCard, navigation, pageNavigator, pieChart, pivotTable,\nrectangle, ribbonChart, scatterChart, shape, slicer, table, tableEx,\ntext, textbox, treemap, waterfall y waterfallChart.\n\nPara visuales con datos, valida antes de escribir los roles obligatorios,\nla cardinalidad maxima de cada rol y el tipo de campo admitido: dimension\n(`Grouping`), medida (`Measure`) o cualquiera de ambos\n(`GroupingOrMeasure`). Los elementos decorativos (texto, forma, imagen,\nnavegador y boton) rechazan `fields` porque no llevan consulta.\n\n`fields`: rol -> campos, p.ej. {\"category\":\"Tabla[Col]\",\n          \"values\":[\"[Medida]\"], \"legend\":\"Tabla[Col]\"}.\n\nEl rol se reconoce escrito como sea: el logico (`values`), el nombre\nque usa PBIR y que devuelve `pbi_list_visuals` (`Values`, `Y`,\n`Category`, `Data`) o un sinonimo (`measure`, `axis`). Cada campo puede\nser `\"Tabla[Campo]\"` o el objeto que devuelve `pbi_list_visuals`, para\npoder leer una pagina y rehacerla sin traducir nada.\n\nUn rol que ese tipo de visual no tiene se RECHAZA con la lista de los\nvalidos. Antes se descartaba en silencio y el visual salia sin datos.\n\n`options`: formato adicional. Llaves reconocidas (una clave no\nreconocida se ignora, no se rechaza; ver `pbi_get_visual` para\ncomprobar que quedo escrito):\n- `background_color`, `border_color` ('#RRGGBB'), `background_transparency`\n  (0-100), `border_radius` (px): el marco de CUALQUIER visual (panel\n  General > Efectos de Desktop). Sin `background_color`/`border_color`\n  no se toca el marco.\n- `card`/`cardVisual`: `show_category_label`, `value_font_size`,\n  `bold_value`, `value_color`.\n- `shape`: `fill`, `transparency`, `text`, `font_size`, `text_color`.\n- `textbox`: `text`, `font_size`, `color`, `bold`, `font`, `align`.\n\n`position`: {x, y, width, height} (z opcional).\nClona un visual del mismo tipo como plantilla si existe. Hace backup.",
       "params": {
         "fields": {
           "required": true,
           "type": "object"
+        },
+        "options": {
+          "required": false,
+          "type": "null|object",
+          "default": null
         },
         "page": {
           "required": true,
@@ -3381,6 +3391,43 @@
       }
     },
     {
+      "name": "pbi_set_visual_filter",
+      "description": "Filtra un visual EXISTENTE sin escribir `filterConfig` a mano.\n\n`filters`: lista de specs, cada uno\n`{field: 'Tabla[Columna]', values?: [...], type?: 'Categorical' |\n'Advanced' | 'TopN' | 'Range' | 'RelativeDate' | 'Passthrough',\nexclude?: bool, raw?: {...}, hidden?: bool, locked?: bool,\ndisplay_name?: str}`. Con `values` se arma un filtro de lista\n(Categorical); sin `values` ni `raw` el campo queda declarado pero\nSIN acotar, como el panel de filtros vacio. `raw` pasa una consulta\nsemantica ya construida, para lo que este constructor no cubre.\n\n`field` va con el NOMBRE real de la tabla. La mitad interna de la\nconsulta usa un ALIAS (`SourceRef.Source`) que esta tool resuelve\nsola: escribirlo a mano ahi es el error mas comun al construir un\nfiltro de visual, y Power BI lo ignora sin decir por que.\n\nUna lista vacia QUITA todos los filtros del visual (no los deja\ndeclarados sin valor). No comprueba `field` contra el modelo: un\ncampo que no existe se escribe igual y Power BI lo resuelve en\nsilencio a nada, igual que si se escribiera a mano.",
+      "params": {
+        "filters": {
+          "required": true,
+          "type": "array[object]"
+        },
+        "page": {
+          "required": true,
+          "type": "string"
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "visual_id": {
+          "required": true,
+          "type": "string"
+        }
+      },
+      "required": [
+        "filters",
+        "page",
+        "visual_id"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      }
+    },
+    {
       "name": "pbi_set_visual_title",
       "description": "Cambia el titulo de un visual PRESERVANDO su formato (fuente, color).",
       "params": {
@@ -3704,7 +3751,7 @@
     },
     {
       "name": "pbi_validate_pbip_project",
-      "description": "Valida a fondo el proyecto .pbip activo (estructura, PBIR, TMDL).",
+      "description": "Valida a fondo el proyecto .pbip activo (estructura, PBIR, TMDL).\n\nIncluye `references`: cada Measure/Column que un visual.json o su\nfilterConfig citan, cruzada contra el TMDL real. El esquema PBIR y la\nsintaxis TMDL pueden pasar limpios por separado con un visual que\napunta a una medida borrada -- Desktop lo resuelve en silencio a\nnada, sin marca visible. Solo corre si el TMDL es valido (comparar\ncontra un modelo que no abre es ruido, no una comprobacion).",
       "params": {},
       "required": [],
       "output_shape": {

--- a/tests/test_container_style.py
+++ b/tests/test_container_style.py
@@ -1,0 +1,65 @@
+"""Fondo y borde del CONTENEDOR (`_aplicar_estilo_contenedor`).
+
+Antes de esto, `options` solo sabia pintar el relleno de una FORMA
+(`_build_shape`) o el numero de una TARJETA (`_aplicar_opciones_de_tarjeta`).
+No habia forma de pedir un marco de color en un grafico, una tabla o una
+matriz sin escribir `visualContainerObjects` a mano: `_sin_marco()` solo sabe
+APAGARLO. Estas pruebas fijan el contrato de la funcion que lo prende.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pbip import visual_factory
+
+
+def test_sin_colores_no_toca_nada():
+    """Sin 'background_color' ni 'border_color' no se inventa un marco."""
+    vis: Dict[str, Any] = {"visualType": "card"}
+    visual_factory._aplicar_estilo_contenedor(vis, {})
+    assert "visualContainerObjects" not in vis
+
+
+def test_solo_fondo_no_escribe_borde():
+    vis: Dict[str, Any] = {}
+    visual_factory._aplicar_estilo_contenedor(vis, {"background_color": "#F47920"})
+    vco = vis["visualContainerObjects"]
+    assert "background" in vco
+    assert "border" not in vco
+
+
+def test_solo_borde_sin_radio_no_escribe_radius():
+    vis: Dict[str, Any] = {}
+    visual_factory._aplicar_estilo_contenedor(vis, {"border_color": "#F47920"})
+    props = vis["visualContainerObjects"]["border"][0]["properties"]
+    assert "radius" not in props
+    assert props["show"]["expr"]["Literal"]["Value"] == "true"
+
+
+def test_transparencia_por_defecto_es_cero():
+    vis: Dict[str, Any] = {}
+    visual_factory._aplicar_estilo_contenedor(vis, {"background_color": "#123456"})
+    props = vis["visualContainerObjects"]["background"][0]["properties"]
+    assert props["transparency"]["expr"]["Literal"]["Value"] == "0.0D"
+
+
+def test_no_pisa_el_titulo_ya_escrito():
+    """El titulo lo pone otro paso de build_visual; este solo agrega fondo/borde."""
+    vis: Dict[str, Any] = {"visualContainerObjects": {
+        "title": [{"properties": {"show": {"expr": {"Literal": {"Value": "true"}}}}}]}}
+    visual_factory._aplicar_estilo_contenedor(
+        vis, {"background_color": "#123456", "border_color": "#654321",
+              "border_radius": 12})
+    vco = vis["visualContainerObjects"]
+    assert "title" in vco and "background" in vco and "border" in vco
+    assert vco["border"][0]["properties"]["radius"]["expr"]["Literal"]["Value"] == "12.0D"
+
+
+def test_color_va_como_fill_solido_no_como_texto():
+    """Un color mal escrito como _lit(str) en vez de fill produce JSON valido
+    de esquema que Power BI simplemente ignora: por eso se comprueba la forma
+    exacta, no solo que la clave exista."""
+    vis: Dict[str, Any] = {}
+    visual_factory._aplicar_estilo_contenedor(vis, {"background_color": "#F47920"})
+    color = vis["visualContainerObjects"]["background"][0]["properties"]["color"]
+    assert color == {"solid": {"color": {"expr": {"Literal": {"Value": "'#F47920'"}}}}}

--- a/tests/test_format_objects_corpus.py
+++ b/tests/test_format_objects_corpus.py
@@ -158,6 +158,20 @@ def test_visual_factory_equivale_a_exports_reales_en_todo_lo_que_formatea():
              "bold_value": True, "value_color": "#123456"})
         _assert_properties_seen(visual_type, visual)
 
+    # El marco (fondo/borde) se puede pedir en CUALQUIER tipo de visual, no
+    # solo tarjeta/forma. Se comprueba contra tres familias distintas (texto,
+    # grafico, segmentador) que el corpus confirma con la forma exacta que
+    # generamos (color liso, no ThemeDataColor/Conditional): 'card'/'tableEx'
+    # tambien aceptan el marco en Desktop, pero la muestra del corpus para
+    # esos dos solo capturo variantes de tema, asi que probarlos ahi habria
+    # sido una afirmacion sin evidencia, no una comprobacion real.
+    for visual_type in ("textbox", "lineChart", "slicer"):
+        visual = {}
+        visual_factory._aplicar_estilo_contenedor(
+            visual, {"background_color": "#123456", "border_color": "#654321",
+                     "border_radius": 8, "background_transparency": 10})
+        _assert_properties_seen(visual_type, visual)
+
 
 def test_fillrule_y_selectores_coinciden_con_formas_escritas_por_desktop():
     # Desktop conserva la agregacion exacta de la proyeccion. Es el caso que

--- a/tests/test_mcp_compat.py
+++ b/tests/test_mcp_compat.py
@@ -57,9 +57,14 @@ def test_las_88_tools_se_registran_con_esta_version_de_mcp():
 
 
 def test_la_cota_de_mcp_esta_declarada():
-    """La cota superior no es decorativa: sin ella el aviso no serviria."""
+    """La cota superior no es decorativa: sin ella el aviso no serviria.
+
+    La busqueda exige un especificador de version pegado a 'mcp' para no
+    engancharse con la entrada 'mcp' de `keywords`, que es solo una etiqueta
+    de PyPI y no declara ninguna cota.
+    """
     texto = (REPO / "pyproject.toml").read_text(encoding="utf-8")
-    linea = re.search(r'"mcp[^"]*"', texto)
+    linea = re.search(r'"mcp(?:>=|==|~=|<)[^"]*"', texto)
     assert linea, "no encuentro la dependencia 'mcp' en pyproject.toml"
     assert "<2" in linea.group(0), (
         f"la dependencia mcp debe estar acotada por arriba: {linea.group(0)}")

--- a/tests/test_reference_audit.py
+++ b/tests/test_reference_audit.py
@@ -1,0 +1,223 @@
+"""Un informe que cita un campo que ya no existe en el modelo.
+
+El esquema PBIR y la sintaxis TMDL pueden ser perfectos por separado; ninguno
+de los dos sabe que hay DENTRO del otro archivo. `pbi_validate_pbip_project`
+podia devolver 0 errores sobre un informe con una tarjeta que apuntaba a una
+medida borrada: Desktop la resuelve en silencio a nada, sin excepcion ni
+marca visible. Estas pruebas fijan el contrato de `reference_audit`, el
+cruce que cierra ese hueco, y de su conexion en `project_locator.validate_project`.
+"""
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from pbip import project_locator, tmdl_reader
+from services import reference_audit
+from tests.fixtures import synthetic
+
+
+@pytest.fixture
+def proyecto(tmp_path, session):
+    pbip = synthetic.materialize(tmp_path)
+    project_locator.open_project(session, str(pbip))
+    return session.require_active_pbip()
+
+
+def _visual_medida(entidad: str, propiedad: str) -> dict:
+    """Un visual.json minimo de tarjeta que cita una medida, como los
+    templates del fixture sintetico."""
+    return {
+        "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+        "name": "sonda0000000000000x",
+        "position": {"x": 0, "y": 0, "z": 0, "width": 100, "height": 100, "tabOrder": 0},
+        "visual": {
+            "visualType": "card",
+            "query": {"queryState": {"Values": {"projections": [{
+                "field": {"Measure": {
+                    "Expression": {"SourceRef": {"Entity": entidad}},
+                    "Property": propiedad}},
+                "queryRef": f"{entidad}.{propiedad}",
+                "nativeQueryRef": propiedad,
+            }]}}},
+            "drillFilterOtherVisuals": True,
+        },
+    }
+
+
+def _escribir_visual(active, visual: dict, nombre_carpeta: str = "sonda0000000000000x") -> None:
+    destino = (synthetic.find_report_dir(active.pbip_path) / "definition" /
+              "pages" / synthetic.PAGE_ID / "visuals" / nombre_carpeta)
+    destino.mkdir(parents=True, exist_ok=True)
+    (destino / "visual.json").write_text(
+        json.dumps(visual, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+# =============================================================== unitarias ===
+def test_proyecto_limpio_no_tiene_referencias_rotas(proyecto):
+    """Los dos templates del fixture (medida y columna validas) no disparan
+    ningun falso positivo: es la base de que el resto de pruebas signifique algo."""
+    model_data = tmdl_reader.read_semantic_model(proyecto)
+    resultado = reference_audit.check_report_references(proyecto, model_data)
+
+    assert resultado["checked"] is True
+    assert resultado["valid"] is True
+    assert resultado["broken_references"] == []
+    assert resultado["visuals_checked"] == 2  # los dos templates del fixture
+
+
+def test_detecta_medida_inexistente(proyecto):
+    _escribir_visual(proyecto, _visual_medida(
+        synthetic.VALID_TABLE, synthetic.MISSING_MEASURE))
+    model_data = tmdl_reader.read_semantic_model(proyecto)
+    resultado = reference_audit.check_report_references(proyecto, model_data)
+
+    assert resultado["valid"] is False
+    rota = next(r for r in resultado["broken_references"]
+               if r["property"] == synthetic.MISSING_MEASURE)
+    assert rota["kind"] == "measure"
+    assert rota["reason"] == "medida_inexistente"
+
+
+def test_no_le_importa_de_que_tabla_diga_venir_una_medida():
+    """Una medida se busca por NOMBRE en todo el modelo, no por la tabla que
+    el visual declare: Desktop puede anclar el mismo query a cualquier tabla
+    presente, y exigir que coincida con `measure['table']` del TMDL produciria
+    falsos positivos constantes."""
+    model_data = {"measures": [{"name": "TotalAmount", "table": "Fact"}],
+                  "tables": [{"name": "Fact", "columns": []},
+                             {"name": "Calendar", "columns": []}]}
+    referencias = reference_audit._walk_field_refs({
+        "field": {"Measure": {
+            "Expression": {"SourceRef": {"Entity": "Calendar"}},
+            "Property": "TotalAmount"}}})
+    assert referencias == [("Measure", "Calendar", "TotalAmount")]
+    # Y aun asi, la tabla equivocada no cuenta como referencia rota:
+    assert "TotalAmount" in reference_audit._measure_names(model_data)
+
+
+def test_detecta_tabla_inexistente_para_columna(proyecto):
+    tabla, columna = synthetic.MISSING_COLUMN[:-1].split("[")
+    visual = _visual_medida(tabla, columna)
+    visual["visual"]["query"]["queryState"]["Values"]["projections"][0]["field"] = {
+        "Column": {"Expression": {"SourceRef": {"Entity": tabla}}, "Property": columna}}
+    _escribir_visual(proyecto, visual)
+
+    model_data = tmdl_reader.read_semantic_model(proyecto)
+    resultado = reference_audit.check_report_references(proyecto, model_data)
+
+    rota = next(r for r in resultado["broken_references"] if r["table"] == tabla)
+    assert rota["kind"] == "column"
+    assert rota["reason"] == "tabla_inexistente"
+
+
+def test_detecta_columna_inexistente_en_tabla_real(proyecto):
+    """La tabla SI existe (`Fact`); la columna, no. Es el caso mas facil de
+    confundir con un falso negativo si solo se comprobara la tabla."""
+    visual = _visual_medida(synthetic.VALID_TABLE, "ColumnaQueNoExiste")
+    visual["visual"]["query"]["queryState"]["Values"]["projections"][0]["field"] = {
+        "Column": {"Expression": {"SourceRef": {"Entity": synthetic.VALID_TABLE}},
+                   "Property": "ColumnaQueNoExiste"}}
+    _escribir_visual(proyecto, visual)
+
+    model_data = tmdl_reader.read_semantic_model(proyecto)
+    resultado = reference_audit.check_report_references(proyecto, model_data)
+
+    rota = next(r for r in resultado["broken_references"]
+               if r["property"] == "ColumnaQueNoExiste")
+    assert rota["reason"] == "columna_inexistente"
+
+
+def test_el_alias_interno_de_un_filtro_no_produce_falsos_positivos(proyecto):
+    """La mitad interna de un filtro referencia la tabla por ALIAS
+    (`SourceRef.Source`, una letra), no por nombre. Si el cruce comparara esa
+    letra contra nombres de tabla, CUALQUIER filtro dispararia una referencia
+    rota inventada."""
+    visual = _visual_medida(synthetic.VALID_TABLE, synthetic.VALID_MEASURE)
+    visual["filterConfig"] = {"filters": [{
+        "name": "filtro-sonda",
+        "field": {"Column": {
+            "Expression": {"SourceRef": {"Entity": "Calendar"}},
+            "Property": "Year"}},
+        "type": "Categorical",
+        "filter": {
+            "Version": 2,
+            "From": [{"Name": "c", "Entity": "Calendar", "Type": 0}],
+            "Where": [{"Condition": {"In": {
+                "Expressions": [{"Column": {
+                    "Expression": {"SourceRef": {"Source": "c"}},
+                    "Property": "Year"}}],
+                "Values": [[{"Literal": {"Value": "2024L"}}]]}}}],
+        },
+    }]}
+    _escribir_visual(proyecto, visual)
+
+    model_data = tmdl_reader.read_semantic_model(proyecto)
+    resultado = reference_audit.check_report_references(proyecto, model_data)
+    assert resultado["valid"] is True
+
+
+def test_un_filtro_que_apunta_a_una_columna_borrada_si_se_detecta(proyecto):
+    """A diferencia del alias interno, el `field` de arriba del filtro SI usa
+    el nombre real de la tabla: por eso un filtro roto se puede detectar
+    igual que una tarjeta rota."""
+    visual = _visual_medida(synthetic.VALID_TABLE, synthetic.VALID_MEASURE)
+    visual["filterConfig"] = {"filters": [{
+        "name": "filtro-roto",
+        "field": {"Column": {
+            "Expression": {"SourceRef": {"Entity": "Calendar"}},
+            "Property": "ColumnaBorrada"}},
+        "type": "Categorical",
+    }]}
+    _escribir_visual(proyecto, visual)
+
+    model_data = tmdl_reader.read_semantic_model(proyecto)
+    resultado = reference_audit.check_report_references(proyecto, model_data)
+
+    assert resultado["valid"] is False
+    rota = next(r for r in resultado["broken_references"]
+               if r["property"] == "ColumnaBorrada")
+    assert rota["reason"] == "columna_inexistente"
+
+
+def test_archivo_illegible_se_reporta_sin_tumbar_la_comprobacion(proyecto):
+    destino = (synthetic.find_report_dir(proyecto.pbip_path) / "definition" /
+              "pages" / synthetic.PAGE_ID / "visuals" / "roto0000000000000000")
+    destino.mkdir(parents=True, exist_ok=True)
+    (destino / "visual.json").write_text("{ esto no es json", encoding="utf-8")
+
+    model_data = tmdl_reader.read_semantic_model(proyecto)
+    resultado = reference_audit.check_report_references(proyecto, model_data)
+
+    assert resultado["checked"] is True  # no se cae por un archivo suelto
+    assert len(resultado["unreadable_files"]) == 1
+    assert resultado["valid"] is False  # illegible tampoco cuenta como "todo bien"
+
+
+# ========================================================== extremo a extremo ===
+def test_validate_project_detecta_medida_inexistente(session, proyecto):
+    _escribir_visual(proyecto, _visual_medida(
+        synthetic.VALID_TABLE, synthetic.MISSING_MEASURE))
+
+    resultado = project_locator.validate_project(session)
+
+    assert resultado["valid"] is False
+    assert resultado["references"]["checked"] is True
+    assert resultado["references"]["valid"] is False
+    assert any("medida_inexistente" in w or synthetic.MISSING_MEASURE in w
+              for w in resultado["warnings"])
+    assert resultado["checks"]["references_valid"] is False
+
+
+def test_validate_project_limpio_no_reporta_referencias_rotas(session, proyecto):
+    """Un proyecto limpio de referencias puede seguir siendo `valid: False`
+    por motivos AJENOS (el fixture minimo no trae .platform/version.json);
+    lo que aqui se fija es que ESTE cruce, en concreto, no aporte ruido."""
+    resultado = project_locator.validate_project(session)
+
+    assert resultado["references"]["checked"] is True
+    assert resultado["references"]["valid"] is True
+    assert resultado["references"]["broken_references"] == []
+    assert resultado["checks"]["references_valid"] is True

--- a/tests/test_table_from_file_html.py
+++ b/tests/test_table_from_file_html.py
@@ -1,0 +1,286 @@
+"""Un '.xls' que en realidad es HTML: el caso normal en exportaciones de ERP.
+
+Nacio de un cargador de datos real (SINCO) cuyos '.xls' resultaron ser tablas
+HTML -- `Excel.Workbook` fallaba en seco sobre ellos. La forma correcta era
+`Web.Page(Text.FromBinary(...))`, con dos trampas que estas pruebas fijan:
+
+1. Las celdas con `colspan` repiten su valor en cada columna que abarcan (es
+   el mismo criterio que usa `Web.Page` al aplanar una fila); sin repetirlo,
+   una fila de titulo de 1 celda con colspan=9 desalinea las 8 columnas
+   siguientes de TODA la tabla.
+2. `Web.Page` NO nombra "Column1", "Column2"... cuando no hay <th>: le pone
+   un nombre propio deducido del contenido, y ese nombre no se puede predecir
+   desde Python. Fijar los nombres por POSICION (`Table.FromRows` +
+   `Table.ToRows`) es lo que hace que `Table.TransformColumnTypes` encuentre
+   columnas que de verdad existen en tiempo de refresco.
+
+Todo sintetico: los archivos se fabrican en tmp_path.
+"""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from pbip import project_locator, table_from_file
+from pbip.table_from_file import TableFromFileError, _TablaHTML
+from services import tmdl_validate
+
+
+@pytest.fixture
+def proyecto(session, sample_pbip):
+    project_locator.open_project(session, str(sample_pbip))
+    return session.require_active_pbip()
+
+
+def _html(tmp_path: Path, nombre: str, cuerpo: str, *,
+         charset: str = "iso-8859-1", encoding: str = "cp1252") -> Path:
+    ruta = tmp_path / nombre
+    doc = (f'<html><head><meta http-equiv="Content-Type" content="text/html; '
+          f'charset={charset}"></head><body>{cuerpo}</body></html>')
+    ruta.write_bytes(doc.encode(encoding))
+    return ruta
+
+
+#: Una tabla como la de un reporte SINCO real: titulo con colspan, filas
+#: "No." de detalle, SIN <th> en ningun lado.
+TABLA_REPORTE = (
+    '<table id="registrosAprobacion">'
+    '<tr><td colspan="3">PRODESA Y CIA S.A.</td></tr>'
+    '<tr><td colspan="3">Proyecto TRI D - ATRIO DE PANCE</td></tr>'
+    '<tr><td>Capítulo</td><td>Valor</td><td>Porcentaje</td></tr>'
+    '<tr><td>No. D003 CIMENTACIÓN</td><td>458.942,72</td><td>4,01%</td></tr>'
+    '<tr><td>No. D004 ESTRUCTURA</td><td>2.079.300,06</td><td>18,17%</td></tr>'
+    '</table>'
+)
+
+
+# --------------------------------------------------------------------------
+# La firma real decide, no la extension
+# --------------------------------------------------------------------------
+
+def test_xls_con_contenido_html_se_perfila_como_html(tmp_path):
+    ruta = _html(tmp_path, "reporte.xls", TABLA_REPORTE)
+    perfil = table_from_file.perfilar(ruta)
+    assert perfil["format"] == "html"
+
+
+def test_xls_binario_ole2_se_rechaza_con_mensaje_claro(tmp_path):
+    ruta = tmp_path / "real.xls"
+    ruta.write_bytes(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 32)
+    with pytest.raises(TableFromFileError) as exc:
+        table_from_file.perfilar(ruta)
+    assert "OLE2" in str(exc.value) or "97-2003" in str(exc.value)
+    assert exc.value.details.get("detected") == "ole2"
+
+
+def test_xls_que_en_realidad_es_zip_se_lee_como_xlsx(tmp_path):
+    """Un .xlsx real, solo que alguien lo guardo con extension .xls."""
+    ruta = tmp_path / "renombrado.xls"
+    with zipfile.ZipFile(ruta, "w") as z:
+        z.writestr(
+            "[Content_Types].xml",
+            '<?xml version="1.0"?><Types '
+            'xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>')
+        z.writestr(
+            "xl/workbook.xml",
+            '<?xml version="1.0"?>'
+            '<workbook xmlns="http://schemas.openxmlformats.org/'
+            'spreadsheetml/2006/main"><sheets>'
+            '<sheet name="Hoja1" sheetId="1" r:id="rId1" '
+            'xmlns:r="http://schemas.openxmlformats.org/officeDocument/'
+            '2006/relationships"/></sheets></workbook>')
+        z.writestr(
+            "xl/worksheets/sheet1.xml",
+            '<?xml version="1.0"?>'
+            '<worksheet xmlns="http://schemas.openxmlformats.org/'
+            'spreadsheetml/2006/main"><sheetData>'
+            '<row><c t="inlineStr"><is><t>Documento</t></is></c>'
+            '<c t="inlineStr"><is><t>Valor</t></is></c></row>'
+            '<row><c t="inlineStr"><is><t>FE-001</t></is></c>'
+            '<c><v>1500</v></c></row>'
+            '</sheetData></worksheet>')
+    perfil = table_from_file.perfilar(ruta)
+    assert perfil["format"] == "xlsx"
+    assert {c["name"] for c in perfil["columns"]} == {"Documento", "Valor"}
+
+
+# --------------------------------------------------------------------------
+# El colspan y el nombrado de columnas
+# --------------------------------------------------------------------------
+
+def test_colspan_repite_el_valor_en_cada_columna_que_abarca():
+    """Sin repetir, una fila de titulo con colspan=3 desalinearia las 2
+    columnas siguientes de toda la tabla."""
+    parser = _TablaHTML()
+    parser.feed('<table id="t"><tr><td colspan="3">Titulo</td></tr>'
+               '<tr><td>a</td><td>b</td><td>c</td></tr></table>')
+    filas = parser.tablas[0]["rows"]
+    assert filas[0] == ["Titulo", "Titulo", "Titulo"]
+    assert filas[1] == ["a", "b", "c"]
+
+
+def test_columnas_resultantes_del_reporte_sin_th(tmp_path):
+    ruta = _html(tmp_path, "reporte.xls", TABLA_REPORTE)
+    perfil = table_from_file.perfilar(ruta)
+    # 3 columnas (Capitulo/Valor/Porcentaje), sin promover: Column1..3.
+    assert len(perfil["columns"]) == 3
+    assert [c["name"] for c in perfil["columns"]] == ["Column1", "Column2", "Column3"]
+
+
+def test_sin_th_no_se_promueve_la_fila_de_titulo(tmp_path):
+    """La fila 1 real de la tabla ('PRODESA Y CIA S.A.' con colspan=3) NO
+    puede terminar siendo el nombre de una columna: es el titulo del reporte,
+    no un encabezado."""
+    ruta = _html(tmp_path, "reporte.xls", TABLA_REPORTE)
+    perfil = table_from_file.perfilar(ruta)
+    nombres = [c["name"] for c in perfil["columns"]]
+    assert "PRODESA Y CIA S.A." not in nombres
+    assert perfil["promote_headers"] is False
+
+
+def test_con_th_si_se_promueve(tmp_path):
+    tabla = ('<table id="t1"><tr><th>Documento</th><th>Valor</th></tr>'
+            '<tr><td>FE-001</td><td>1500.50</td></tr></table>')
+    ruta = _html(tmp_path, "con_headers.xls", tabla, charset="utf-8", encoding="utf-8")
+    perfil = table_from_file.perfilar(ruta)
+    assert perfil["promote_headers"] is True
+    assert [c["name"] for c in perfil["columns"]] == ["Documento", "Valor"]
+    assert perfil["row_sample"] == 1  # la fila de <th> no cuenta como dato
+
+
+def test_espacio_duro_se_limpia_de_las_celdas():
+    """\\xa0 (espacio duro) es el caracter que en la sesion de origen
+    producia 'CimentaciÃ³n' con signos de interrogacion cuando no se
+    limpiaba antes de comparar/mostrar el texto."""
+    parser = _TablaHTML()
+    parser.feed('<table id="t"><tr><td>Texto&nbsp;con&nbsp;espacio</td></tr></table>')
+    celda = parser.tablas[0]["rows"][0][0]
+    assert celda == "Texto con espacio"
+    assert "\xa0" not in celda
+
+
+# --------------------------------------------------------------------------
+# Seleccion de tabla cuando hay varias
+# --------------------------------------------------------------------------
+
+def test_con_id_explicito_elige_esa_tabla_aunque_no_sea_la_mas_grande(tmp_path):
+    doc = ('<table id="pequena"><tr><td>A</td></tr></table>'
+          '<table id="grande"><tr><td>X</td></tr><tr><td>Y</td></tr>'
+          '<tr><td>Z</td></tr></table>')
+    ruta = _html(tmp_path, "varias.xls", doc, charset="utf-8", encoding="utf-8")
+
+    perfil = table_from_file.perfilar(ruta, table_id="pequena")
+    assert perfil["table_id"] == "pequena"
+    assert perfil["row_sample"] == 1
+
+
+def test_sin_id_elige_la_mas_grande_y_avisa(tmp_path):
+    doc = ('<table><tr><td>A</td></tr></table>'
+          '<table><tr><td>X</td></tr><tr><td>Y</td></tr><tr><td>Z</td></tr></table>')
+    ruta = _html(tmp_path, "sin_id.xls", doc, charset="utf-8", encoding="utf-8")
+
+    perfil = table_from_file.perfilar(ruta)
+    assert perfil["row_sample"] == 3
+    assert perfil["warnings"], "debe avisar que la eleccion fue por tamano, sin id"
+
+
+def test_id_inexistente_lista_los_disponibles(tmp_path):
+    doc = '<table id="real1"><tr><td>A</td></tr></table>'
+    ruta = _html(tmp_path, "un_id.xls", doc, charset="utf-8", encoding="utf-8")
+
+    with pytest.raises(TableFromFileError) as exc:
+        table_from_file.perfilar(ruta, table_id="fantasma")
+    assert exc.value.details["available_ids"] == ["real1"]
+
+
+# --------------------------------------------------------------------------
+# Codificacion
+# --------------------------------------------------------------------------
+
+def test_detecta_windows_1252_por_el_meta_charset(tmp_path):
+    tabla = '<table id="t1"><tr><td>Cimentación</td><td>1</td></tr></table>'
+    ruta = _html(tmp_path, "cp1252.xls", tabla, charset="iso-8859-1", encoding="cp1252")
+    perfil = table_from_file.perfilar(ruta)
+    assert perfil["encoding"] == 1252  # TextEncoding.Windows, no Utf8
+
+
+def test_detecta_utf8_por_el_meta_charset(tmp_path):
+    tabla = '<table id="t1"><tr><td>Cimentación</td><td>1</td></tr></table>'
+    ruta = _html(tmp_path, "utf8.xls", tabla, charset="utf-8", encoding="utf-8")
+    perfil = table_from_file.perfilar(ruta)
+    assert perfil["encoding"] == 65001
+
+
+# --------------------------------------------------------------------------
+# La consulta M
+# --------------------------------------------------------------------------
+
+def test_la_m_decodifica_antes_de_llamar_a_web_page(tmp_path):
+    ruta = _html(tmp_path, "reporte.xls", TABLA_REPORTE)
+    perfil = table_from_file.perfilar(ruta)
+    m = table_from_file.construir_m(perfil)
+
+    assert "Web.Page(Text.FromBinary(File.Contents(" in m
+    assert "[Id = \"registrosAprobacion\"]" in m
+    # Los nombres de columna se fijan por POSICION, no se confia en como
+    # Web.Page nombre las columnas cuando no hay <th>.
+    assert 'Table.FromRows(Table.ToRows(' in m
+    assert '"Column1"' in m and '"Column2"' in m and '"Column3"' in m
+    # Sin <th>, promover encabezados aqui inventaria uno: no debe aparecer.
+    assert "PromoteHeaders" not in m
+
+
+def test_la_m_quita_la_fila_de_titulo_cuando_si_hay_th(tmp_path):
+    tabla = ('<table id="t1"><tr><th>Documento</th><th>Valor</th></tr>'
+            '<tr><td>FE-001</td><td>1500</td></tr></table>')
+    ruta = _html(tmp_path, "con_headers.xls", tabla, charset="utf-8", encoding="utf-8")
+    perfil = table_from_file.perfilar(ruta)
+    m = table_from_file.construir_m(perfil)
+
+    assert "Table.Skip(" in m  # se descarta la fila de <th> antes de tipar
+    assert '"Documento"' in m and '"Valor"' in m
+
+
+def test_sin_id_la_m_selecciona_por_posicion(tmp_path):
+    doc = '<table><tr><td>A</td></tr></table>'
+    ruta = _html(tmp_path, "sin_id.xls", doc, charset="utf-8", encoding="utf-8")
+    perfil = table_from_file.perfilar(ruta)
+    m = table_from_file.construir_m(perfil)
+    assert "Origen{0}[Data]" in m
+
+
+# --------------------------------------------------------------------------
+# Extremo a extremo: la tabla escrita abre de verdad
+# --------------------------------------------------------------------------
+
+def test_la_tabla_html_escrita_pasa_el_validador(proyecto, tmp_path):
+    ruta = _html(tmp_path, "reporte.xls", TABLA_REPORTE)
+    r = table_from_file.agregar_tabla(proyecto, ruta, table_name="ReporteSinco")
+
+    assert r["format"] == "html"
+    assert r["table_id"] == "registrosAprobacion"
+    assert r["column_count"] == 3
+
+    definition = Path(proyecto.semantic_model_dir) / "definition"
+    resultado = tmdl_validate.validate(definition, use_tom=False)
+    assert resultado["valid"] is True, resultado["findings"]
+    assert resultado["findings"] == []
+
+
+def test_dry_run_no_escribe_nada(proyecto, tmp_path):
+    ruta = _html(tmp_path, "reporte.xls", TABLA_REPORTE)
+    r = table_from_file.agregar_tabla(
+        proyecto, ruta, table_name="Sonda", dry_run=True)
+
+    assert r["dry_run"] is True
+    assert "Web.Page" in r["m"]
+    tabla_tmdl = Path(proyecto.semantic_model_dir) / "definition" / "tables" / "Sonda.tmdl"
+    assert not tabla_tmdl.exists()
+
+
+def test_html_puro_htm_tambien_se_reconoce(tmp_path):
+    ruta = _html(tmp_path, "reporte.htm", TABLA_REPORTE)
+    perfil = table_from_file.perfilar(ruta)
+    assert perfil["format"] == "html"

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -435,7 +435,8 @@ def test_el_catalogo_declara_el_numero_real_de_tools():
     doc = (Path(__file__).resolve().parents[1] / "docs" / "TOOL_CATALOG.md"
            ).read_text(encoding="utf-8")
 
-    cabecera = re.search(r"# Cat[aá]logo de tools\s*[—-]\s*(\d+)", doc)
+    cabecera = re.search(
+        r"# (?:Cat[aá]logo de tools|Tool catalog)\s*[—-]\s*(\d+)", doc)
     assert cabecera, "el catalogo no declara un numero en su titulo"
     assert int(cabecera.group(1)) == EXPECTED_COUNT, (
         f"el catalogo dice {cabecera.group(1)} y hay {EXPECTED_COUNT}")

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -163,10 +163,18 @@ DISENO_TOOLS = [
     "pbi_compose_page",
 ]
 
+#: Filtrar un visual EXISTENTE sin escribir `filterConfig` a mano.
+#: `filter_builder` (alias del filtro, valores tipados) llevaba tiempo
+#: existiendo sin ninguna tool que lo expusiera para un visual ya escrito.
+FILTRO_VISUAL_TOOLS = [
+    "pbi_set_visual_filter",
+]
+
 TOOLS_NUEVAS = (MACROFASE_A_TOOLS + MACROFASE_B_TOOLS + MACROFASE_C_TOOLS
                 + MACROFASE_D_TOOLS + MACROFASE_E_TOOLS + MACROFASE_F_TOOLS
                 + FASE_F_R5_TOOLS + CONVERSION_TOOLS + THEME_TOOLS
-                + VERIFICACION_TOOLS + CARGA_TOOLS + DISENO_TOOLS)
+                + VERIFICACION_TOOLS + CARGA_TOOLS + DISENO_TOOLS
+                + FILTRO_VISUAL_TOOLS)
 BASELINE_COUNT = 34
 EXPECTED_COUNT = BASELINE_COUNT + len(TOOLS_NUEVAS)
 

--- a/tests/test_visual_factory_fidelity.py
+++ b/tests/test_visual_factory_fidelity.py
@@ -61,6 +61,27 @@ def test_title_none_no_hereda_el_titulo_de_la_plantilla(proyecto_con_plantillas)
     assert "title" not in vco
 
 
+def test_build_visual_de_extremo_a_extremo_aplica_marco_de_color(
+        proyecto_con_plantillas):
+    """No solo la funcion interna: el camino completo (clonar plantilla +
+    _rutas_formato_generadas + el guardian de formato) tiene que aceptar el
+    marco sin lanzar FormatOracleMismatch."""
+    salida = visual_factory.build_visual(
+        proyecto_con_plantillas, "card", {"values": ["[Ratio Pct]"]}, POS,
+        title="KPI", measure_index={"Ratio Pct": "Fact"},
+        options={"background_color": "#FDECDD", "border_color": "#F47920",
+                 "border_radius": 10, "bold_value": True})
+
+    vco = salida["visual"]["visual"]["visualContainerObjects"]
+    assert vco["background"][0]["properties"]["show"]["expr"]["Literal"]["Value"] == "true"
+    assert vco["border"][0]["properties"]["radius"]["expr"]["Literal"]["Value"] == "10.0D"
+    # El titulo y el valor en negrita, pedidos en la MISMA llamada, sobreviven
+    # junto al marco nuevo: uno no debe pisar al otro.
+    assert vco["title"][0]["properties"]["text"]["expr"]["Literal"]["Value"] == "'KPI'"
+    assert salida["visual"]["visual"]["objects"]["labels"][0]["properties"]["bold"][
+        "expr"]["Literal"]["Value"] == "true"
+
+
 def test_clon_descarta_selectores_que_apuntan_al_campo_anterior(
         proyecto_con_plantillas):
     plantilla = visual_factory.find_template(proyecto_con_plantillas, "card")

--- a/tests/test_visual_filter_tool.py
+++ b/tests/test_visual_filter_tool.py
@@ -1,0 +1,100 @@
+"""Filtrar un visual EXISTENTE (`pbi_set_visual_filter` / `update_visual_filters`).
+
+`filter_builder.build_filter` ya resolvia el par field/alias correctamente
+desde hacia tiempo, pero nada lo conectaba con un visual YA ESCRITO: la unica
+forma de filtrar un visual existente era escribir `filterConfig` a mano
+directo en el JSON, exactamente la trampa que ese modulo existe para evitar.
+"""
+from __future__ import annotations
+
+import pytest
+
+from pbip import pbir_reader, pbir_writer, project_locator
+from powerbi.errors import PathSecurityError, ValidationError
+from tests.fixtures import synthetic
+
+
+@pytest.fixture
+def proyecto(session, tmp_path):
+    pbip = synthetic.materialize(tmp_path)
+    project_locator.open_project(session, str(pbip))
+    return session.require_active_pbip()
+
+
+def _leer(active, page, visual_id):
+    from utils.json_utils import read_json
+    page_dir = pbir_reader.resolve_page_dir(active, page)
+    return read_json(page_dir / "visuals" / visual_id / "visual.json")
+
+
+def test_agrega_un_filtro_categorico(proyecto):
+    res = pbir_writer.update_visual_filters(
+        proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID,
+        [{"field": "Calendar[Year]", "values": [2024, 2025]}])
+
+    assert res["before"] is None
+    documento = _leer(proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID)
+    filtros = documento["filterConfig"]["filters"]
+    assert len(filtros) == 1
+    assert filtros[0]["field"]["Column"]["Expression"]["SourceRef"] == {
+        "Entity": "Calendar"}
+    valores = filtros[0]["filter"]["Where"][0]["Condition"]["In"]["Values"]
+    assert [v[0]["Literal"]["Value"] for v in valores] == ["2024L", "2025L"]
+
+
+def test_lista_vacia_quita_el_filterconfig(proyecto):
+    pbir_writer.update_visual_filters(
+        proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID,
+        [{"field": "Calendar[Year]", "values": [2024]}])
+    assert "filterConfig" in _leer(proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID)
+
+    res = pbir_writer.update_visual_filters(
+        proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID, [])
+
+    assert res["after"] is None
+    documento = _leer(proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID)
+    assert "filterConfig" not in documento, (
+        "una lista vacia debe QUITAR la clave, no dejarla como {'filters': []}")
+
+
+def test_reemplaza_en_vez_de_acumular(proyecto):
+    """Dos llamadas seguidas: la segunda REEMPLAZA, no se suma a la primera."""
+    pbir_writer.update_visual_filters(
+        proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID,
+        [{"field": "Calendar[Year]", "values": [2024]}])
+    pbir_writer.update_visual_filters(
+        proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID,
+        [{"field": "Fact[Category]", "values": ["A"]}])
+
+    filtros = _leer(proyecto, synthetic.PAGE_ID,
+                    synthetic.CARD_TEMPLATE_ID)["filterConfig"]["filters"]
+    assert len(filtros) == 1
+    assert filtros[0]["field"]["Column"]["Property"] == "Category"
+
+
+def test_visual_inexistente_se_rechaza(proyecto):
+    with pytest.raises(ValidationError):
+        pbir_writer.update_visual_filters(
+            proyecto, synthetic.PAGE_ID, "no0000000000000000x",
+            [{"field": "Calendar[Year]", "values": [2024]}])
+
+
+def test_visual_id_con_traversal_es_rechazado(proyecto):
+    """La misma puerta de seguridad que ya protege mover un visual: esta
+    escritura reusa `_visual_path`, asi que hereda la comprobacion sola."""
+    with pytest.raises((PathSecurityError, ValidationError)):
+        pbir_writer.update_visual_filters(
+            proyecto, synthetic.PAGE_ID,
+            "../../../../FUERA_DEL_PROYECTO/x",
+            [{"field": "Calendar[Year]", "values": [2024]}])
+
+
+def test_tipo_de_filtro_invalido_no_escribe_nada(proyecto):
+    """Un spec mal formado se rechaza ANTES de tocar el archivo."""
+    antes = _leer(proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID)
+    with pytest.raises(Exception):
+        pbir_writer.update_visual_filters(
+            proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID,
+            [{"field": "Calendar[Year]", "type": "AlgoRaro", "values": [1]}])
+    despues = _leer(proyecto, synthetic.PAGE_ID, synthetic.CARD_TEMPLATE_ID)
+    assert antes == despues


### PR DESCRIPTION
## Summary

Five gaps found while using this server to build a real construction-budget dashboard, then closed here so the next case doesn't pay the same price:

- Exposes `options` in `pbi_create_visual` (it silently existed in `visual_factory.build_visual` but was never wired to the tool signature).
- Adds a colored background/border (with radius) for **any** visual type via `options`, verified against real shapes captured from Power BI Desktop, not just the schema.
- Adds a `references` check to `pbi_validate_pbip_project` that cross-checks every `Measure`/`Column` a `visual.json` (including its `filterConfig`) cites against the real TMDL model.
- Adds `pbi_set_visual_filter`, a new tool to filter an already-written visual without hand-editing `filterConfig`.
- Teaches `pbi_add_table_from_file` to read `.xls` files that are actually HTML (a common ERP export pattern), plus native `.html`/`.htm`, sniffing the real file signature and fixing column names by position instead of trusting `Web.Page`'s unpredictable naming.

Tool catalog: 117 -> 118.

Also fixes two tests that were already broken on `main` before this branch (unrelated to the above, found while running the full suite here): the tool-catalog-count test still searched for the Spanish title after the docs were translated to English, and the mcp-version-cap test matched the `keywords` PyPI tag instead of the actual dependency line.

## Test plan

- [x] `python -m pytest tests/ -q` on top of current `main`: 1589 passed, 3 skipped, 0 failed.
- [x] `tests/golden/tools_v1.json` regenerated and classified as a compatible change.
- [x] Dedicated tests for each of the 5 improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)