### PR TITLE
Release v1.1.1: close the field-report queue — theme_json, rename_measure, close_desktop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "horizun-pbi-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Power BI Desktop y PBIP desde Claude: DAX, TOM, TMDL, PBIR, visuales, auditoría y flujos seguros.",
   "author": {"name": "HorizunGroup", "url": "https://github.com/HorizunGroup"},
   "homepage": "https://github.com/HorizunGroup/horizun-pbi-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "horizun-pbi-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Power BI Desktop y PBIP desde Codex: DAX, TOM, TMDL, PBIR, visuales, auditoría y flujos seguros.",
   "author": {"name": "HorizunGroup", "url": "https://github.com/HorizunGroup"},
   "homepage": "https://github.com/HorizunGroup/horizun-pbi-mcp",

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.HorizunGroup/horizun-pbi-mcp",
   "title": "Horizun PBI MCP",
   "description": "Open-source MCP server for Power BI Desktop, DAX, PBIP, TMDL and PBIR automation.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": {
     "url": "https://github.com/HorizunGroup/horizun-pbi-mcp",
     "source": "github"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ Semantic versioning. **The contract of the original 34 tools is never broken.**
 
 ---
 
+## [1.1.1] — 2026-08-04
+
+Closes the field-report queue completely (items 6, 8 and 9 were the last
+three) and removes a real client's name from the repository — current state
+AND full history, which was rewritten for the purpose. Two new tools
+(121 total); zero breaking changes.
+
+### Added
+
+- **`theme_json` and `fonts` on `pbi_apply_theme`**: a complete caller-supplied
+  theme written as-is (corporate typography no longer requires overwriting the
+  generated file by hand), and `fonts: {title|body|callout}` mapped to the
+  real `textClasses` (`body` → `label`). Replacing a theme whose on-disk
+  content differs (hand-edited) now warns and points at the transaction
+  backup — it used to be silently destroyed on re-apply.
+- **`pbi_rename_measure`**: renames the TMDL header, the unqualified `[old]`
+  DAX references in other measures, and the report's `visual.json`s, all in
+  ONE transaction, then verifies by re-reading. Replacement runs only inside
+  measure blocks (in a calculated column, unqualified brackets mean a COLUMN
+  of its own table) and only on unqualified refs (`Tabla[old]` can be a
+  homonymous column of another table); anything left — bookmarks, filters,
+  qualified refs — comes back in `warnings` with its location, never
+  silently. Renaming onto an existing measure or a column of the same table
+  is refused up front: that exact collision passes the write and kills
+  Desktop at open.
+- **`pbi_close_desktop`**: the missing exit of the edit-open-look-edit cycle.
+  Closes ONLY the instance serving that file, verifies process identity
+  (name + start time, never bare PID), re-checks the file is no longer open
+  (`verified_closed`) and requires `confirm=true` — unsaved changes die with
+  the window, and in a `.pbip` that includes the session's refreshed data.
+
+### Changed
+
+- **Client names are gone from the repository**, current state and rewritten
+  history, with a tracked-files guard (`tests/test_sin_datos_de_empresa.py`)
+  that also watches for any trace of the team's internal knowledge base. The
+  guard builds the forbidden literal split so it never publishes what it
+  polices — which is how the name leaked the first time.
+- `docs/BACKLOG.md` brought current: the `pbi_apply_plan` question is
+  **decided** (the `plan_token` IS the explicit approval — a client cannot
+  hold a valid one by accident, and it dies on state drift; `confirm` stays
+  as documented redundancy), and R15 records `mode='auto'` as its mitigation.
+
+---
+
 ## [1.1.0] — 2026-08-03
 
 Everything here came out of real use, not a roadmap: five gaps hit while

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **MCP** (Model Context Protocol) server for working with **local Power BI Desktop** and **`.pbip`** projects from Claude Code.
 
-**v1.1.0** — 119 tools, 1699 tests passed (3 skipped, with their condition documented). Covers two complementary layers:
+**v1.1.1** — 121 tools, 1744 tests passed (3 skipped, with their condition documented). Covers two complementary layers:
 
 | Layer | For what | How |
 |---|---|---|
@@ -22,7 +22,7 @@
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Current architecture, structural debt and invariants |
 | [`docs/CAPABILITY_MATRIX.md`](docs/CAPABILITY_MATRIX.md) | Coexistence with other Power BI MCPs, with verification levels |
 | [`AGENTS.md`](AGENTS.md) | Rules for modifying this repository without breaking the contract |
-| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 119 tools by block, with their risk class |
+| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 121 tools by block, with their risk class |
 | [`docs/DUAL_MODE.md`](docs/DUAL_MODE.md) | Why `mode="both"` is blocked (R15) |
 | [`docs/VALIDATION.md`](docs/VALIDATION.md) | The two PBIR validation layers and their limits |
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | What is checked before publishing |
@@ -92,7 +92,7 @@ claude plugin install horizun-pbi-mcp@horizun
 
 When the first session opens, the plugin runs the full setup automatically in
 the background. Check `pbi_install_status`; once it finishes, restart the
-client and the 119 `pbi_*` tools will be available. There are no downloads or
+client and the 121 `pbi_*` tools will be available. There are no downloads or
 additional scripts the user needs to run manually.
 
 > **Honest technical limit:** there's no dedicated executable, but you do need
@@ -190,7 +190,7 @@ Exits with code **0** if everything mandatory is fine. It distinguishes missing 
 
 ---
 
-## Available tools (119)
+## Available tools (121)
 
 > Full catalog by block: [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md).
 > Baseline inventory with risk class and preconditions: [`docs/TOOL_INVENTORY.md`](docs/TOOL_INVENTORY.md).
@@ -369,7 +369,7 @@ python -m pytest -m live                # against an open Power BI Desktop
 python -m pytest -m live_validator      # against Microsoft's official CLI
 ```
 
-Verify the MCP contract (the 119 tools are frozen):
+Verify the MCP contract (the 121 tools are frozen):
 
 ```bash
 python -m tests.contract_utils

--- a/RELEASE_NOTES_1.1.1.md
+++ b/RELEASE_NOTES_1.1.1.md
@@ -1,0 +1,32 @@
+# Horizun PBI MCP v1.1.1
+
+Closes the fourteen-item field report completely and cleans the repository of
+client names — current state and full history. Two new tools (121 total),
+zero breaking changes: the frozen contract holds.
+
+## Added
+
+- **`theme_json` + `fonts`** on `pbi_apply_theme`: full caller themes written
+  as-is and corporate typography via `textClasses`, with a warning (and a
+  recovery pointer) when a hand-edited theme is being replaced.
+- **`pbi_rename_measure`**: TMDL header, DAX references and report visuals in
+  one transaction, verified by re-reading. Only unambiguous references are
+  rewritten; everything else is reported with its location, never silently.
+- **`pbi_close_desktop`**: closes only the instance serving that project,
+  identity-verified (name + start time), `confirm`-gated, and re-checks the
+  file is actually no longer open.
+
+## Changed
+
+- Client names removed from the repo and its rewritten history, guarded by a
+  test that scans every tracked file — and builds its own forbidden literal
+  split, so the guard never publishes what it polices.
+- `docs/BACKLOG.md` brought current; the `pbi_apply_plan` contract question is
+  decided and closed (the `plan_token` is the explicit approval).
+
+## Evidence
+
+- 121 tools; MCP contract: additive changes only, golden updated.
+- 1744 tests passed, 3 skipped with their condition documented.
+- Every behavioral change mutation-verified: reverting it fails a named test.
+- `scripts/doctor.py` exit 0; CI green on Windows, Python 3.10 and 3.13.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,10 +3,12 @@
 What remains open, why it matters and how to check it. Ordered by what
 hurts the most.
 
-Updated on 2026-08-02 after auditing the **117 tools** via AST, testing
-real PBIX→PBIP conversions and reopening the results in Power BI
-Desktop. The integrated suite came in at **1542 passed, 3 skipped**. The list
-below isn't a brainstorm: it's what we know is missing, with evidence.
+Updated on 2026-08-04 for **v1.1.1** (121 tools). The fourteen-item field
+report from the first real end-to-end session is now **fully closed**: the
+last three items landed as `theme_json`/`fonts` on `pbi_apply_theme`,
+`pbi_rename_measure` (model + DAX refs + report visuals in one transaction)
+and `pbi_close_desktop` (identity-verified, confirm-gated). The list below
+isn't a brainstorm: it's what we know is missing, with evidence.
 
 ---
 
@@ -176,6 +178,11 @@ deterministic partial state. It was blocked instead of faking atomicity.
 It's not debt: it's a decision with its reasoning written down. Reopening it
 requires turning it into a **guided workflow**, not an operation.
 
+**Mitigation since v1.1.0:** `mode='auto'` resolves live/pbip from the REAL
+state (verified session, not a stored field) before any effect, so the
+build-from-scratch flow no longer trips over the `live` default. `both`
+itself stays blocked; `auto` chooses one destination, never two.
+
 ---
 
 ## 7. G10 — three unpublished PBIR schema versions
@@ -192,16 +199,18 @@ There's nothing to do on our side until Microsoft publishes them.
 
 ## 8. `pbi_apply_plan` and contractual confirmation
 
-**Status:** pending contract decision.
+**Status:** decided on 2026-08-04. The `plan_token` IS the explicit approval.
 
-The tool applies a plan signed via `plan_token`, but keeps `confirm=true`
-as the historical default. If the token is interpreted as the explicit
-approval, the current contract is coherent. If a client-written
-`confirm=true` is also required, the default should switch to `false`.
+Reasoning: a client cannot hold a valid token by accident. It must call
+`pbi_plan_change`, receive a token bound to a fingerprint of the state the
+plan was computed on, and pass it back deliberately — and the token dies the
+moment the state drifts (`plan_token_stale`). That is a stronger consent
+mechanism than a boolean a client can hardcode. Requiring `confirm=true` on
+top would be a second signature for the same act; flipping its default to
+`false` would break the frozen contract to add no safety.
 
-That change would break the frozen MCP contract and so it wasn't made
-during the audit. It requires a deliberate approval and a golden update; it
-must not slip in disguised as a refactor.
+`confirm=true` stays as the historical default, documented as redundant with
+the token. Nothing to do; the item is closed.
 
 ---
 
@@ -220,5 +229,5 @@ but it's worth having them together:
 
 3. **What only runs on the developer's own machine only works there.**
    The clean install found two defects no test caught, because they all
-   ran on an environment that was already fine. The current suite has 1542
-   tests passed, but the external oracles remain mandatory.
+   ran on an environment that was already fine. The suite keeps growing (1,700+
+   tests), but the external oracles remain mandatory.

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -19,7 +19,7 @@ Every statement carries its **verification level**. They are not mixed.
 
 | Server | Version | Status | Highest level reached |
 |---|---|---|---|
-| **Horizun PBI MCP** (this repo) | 1.1.0 | Present, starts | **Tested** — stdio handshake, 119 tools, 1699 tests, live DAX, PBIR fixture and Desktop capture by PID |
+| **Horizun PBI MCP** (this repo) | 1.1.1 | Present, starts | **Tested** — stdio handshake, 121 tools, 1744 tests, live DAX, PBIR fixture and Desktop capture by PID |
 | **powerbi-report-mcp** | 0.9.6 | Present and built at `..\PowerBI MCP\powerbi-report-mcp\dist\index.js` | **Observed** — 57 tool names extracted from the bundle and the README. **Not run** |
 | **@microsoft/powerbi-modeling-mcp** | 0.5.0-beta.11 | Downloaded to a temp folder, extracted and read. **Not run** | **Declared** — README + CHANGELOG + `index.js`. Execution **halted** due to a stop condition (§2.1) |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,14 +17,14 @@ claude plugin install horizun-pbi-mcp@horizun
 
 Setup starts automatically on the first session. While it progresses
 you'll see `pbi_install_runtime` and `pbi_install_status`; after restarting
-the client the 119 tools will appear. Nothing needs to be downloaded or run
+the client the 121 tools will appear. Nothing needs to be downloaded or run
 separately. The runtime and verified downloads stay in the plugin's local
 data, outside the repository and your projects.
 
 Python 3.10+ is still a requirement: it's the local process that talks to
 Power BI Desktop. Node 20 is only needed for the optional PBIR validator.
 
-Reproducible guide from scratch. At the end, an MCP client should see 119 `pbi_*` tools.
+Reproducible guide from scratch. At the end, an MCP client should see 121 `pbi_*` tools.
 
 ---
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -106,7 +106,7 @@ On a **copy** outside OneDrive, never on the original:
 
 ## Tagging
 
-The stable version is **`v1.1.0`**. The exceptions below are documented
+The stable version is **`v1.1.1`**. The exceptions below are documented
 product limits, not hidden bugs or skipped criteria.
 
 The version declared in `branding.VERSION` / `pyproject.toml` must match the tag **before** tagging. Installing from a tag and getting a package that reports a different version is exactly what these checks exist to prevent.

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,4 +1,4 @@
-# Tool catalog — 119
+# Tool catalog — 121
 
 Generated from the contract frozen in `tests/golden/tools_v1.json`.
 The **34 baseline** tools keep their name, parameters, types, defaults and response shape since version 0.1.0.
@@ -27,7 +27,9 @@ tools registered.
 | J — data loading | 2 |
 | L — design and entry point | 4 |
 | M — work cycle | 1 |
-| **Total** | **119** |
+| N — refactoring | 1 |
+| O — session exit | 1 |
+| **Total** | **121** |
 
 ---
 
@@ -42,6 +44,7 @@ tools registered.
 | `pbi_select_model` | Sets the active model (requires a port if there are several) |
 | `pbi_test_connection` | Validates the connection |
 | `pbi_validate_desktop_render` | Captures the report's exact window by PID, without focus; only closes Desktop if the tool opened it |
+| `pbi_close_desktop` | **Destructive** (`confirm`): closes ONLY the Desktop instance serving that file, verifies identity by name+start time, re-checks the file is no longer open |
 | `pbi_list_pending_journals` | Journals of operations left half-done |
 | `pbi_inspect_journal` | Compares a journal with the current state (read-only) |
 
@@ -68,6 +71,7 @@ tools registered.
 |---|---|
 | `pbi_create_measure` · `pbi_update_measure` | No |
 | `pbi_delete_measure` | **Yes** (`confirm`) |
+| `pbi_rename_measure` | No — updates TMDL header, DAX refs and report visuals in ONE transaction; qualified refs and bookmarks come back as warnings, never silently |
 | `pbi_set_column_visibility` · `pbi_hide_columns` | No |
 | `pbi_set_relationship_direction` · `pbi_disable_auto_date_time` | No |
 | `pbi_refresh_model` | Irreversible. Devuelve `rows_by_table`: un refresh puede terminar en 'ok' y cargar CERO filas |

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 - Repository: https://github.com/HorizunGroup/horizun-pbi-mcp
 - Latest stable release: https://github.com/HorizunGroup/horizun-pbi-mcp/releases/latest
 - Installation and client setup: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/INSTALL.md
-- Full tool catalogue (119 tools): https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TOOL_CATALOG.md
+- Full tool catalogue (121 tools): https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TOOL_CATALOG.md
 - Architecture and invariants: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/ARCHITECTURE.md
 - Security model: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/SECURITY.md
 - Tutorial, install to first dashboard: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TUTORIAL.md
@@ -29,7 +29,7 @@ model; visuals, pages and layout are never touched through it or through any
 live API — those are edited exclusively through PBIR files. The server
 enforces that separation instead of trying to move visuals live.
 
-v1.1.0 ships 119 tools, backed by 1699 passing tests (3 skipped, each with
+v1.1.1 ships 121 tools, backed by 1744 passing tests (3 skipped, each with
 its documented condition). Two validation layers check every PBIR edit
 before it is written, and non-read-only DAX is blocked by a fail-closed
 classifier.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "horizun-pbi-mcp"
 # PEP 440. Debe coincidir con branding.VERSION y con el tag de Git.
-version = "1.1.0"
+version = "1.1.1"
 description = "MCP server for Power BI: live semantic model (DAX/TOM), .pbip projects (TMDL/PBIR), report authoring, full auditing and workflows."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/plugin_bootstrap.py
+++ b/scripts/plugin_bootstrap.py
@@ -17,7 +17,7 @@ import venv
 from pathlib import Path
 from typing import Any
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 
 

--- a/skills/horizun-pbi-setup/SKILL.md
+++ b/skills/horizun-pbi-setup/SKILL.md
@@ -17,7 +17,7 @@ y descarga las DLL y esquemas fijados, verificando sus hashes.
 3. Consulta `pbi_install_status` hasta que indique `ready` o `failed`. No inicies
    procesos adicionales mientras esté `installing`.
 4. Si termina en `ready`, pide reiniciar Codex o Claude. Al volver, comprueba que
-   `tools/list` expone las 119 tools `pbi_*`, no solo las dos de instalación.
+   `tools/list` expone las 121 tools `pbi_*`, no solo las dos de instalación.
 5. Si falla, informa el paso y el mensaje devueltos por el status. No borres el
    runtime ni ocultes el error; una nueva llamada permite reintentar.
 

--- a/src/horizun_pbi_mcp/branding.py
+++ b/src/horizun_pbi_mcp/branding.py
@@ -3,7 +3,7 @@
 El nombre vive aqui y no repartido por el codigo: renombrar un producto no
 deberia obligar a buscar cadenas sueltas en veinte archivos.
 
-COMPATIBILIDAD: las 119 tools conservan el prefijo `pbi_`. Renombrarlas romperia
+COMPATIBILIDAD: las 121 tools conservan el prefijo `pbi_`. Renombrarlas romperia
 a cualquier cliente ya configurado, y el nombre comercial no es motivo
 suficiente para eso.
 """
@@ -20,11 +20,11 @@ MCP_SERVER_NAME = "horizun-pbi-mcp"
 PACKAGE_NAME = "horizun-pbi-mcp"
 #: Version VISIBLE del producto: la que anuncia serverInfo y la que coincide
 #: con el tag de Git.
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 #: La misma version en el formato que exige PEP 440 para `pyproject.toml`.
 #: `1.0.0-rc.2` no es valido ahi; una release estable usa `1.0.1`.
-VERSION_PEP440 = "1.1.0"
+VERSION_PEP440 = "1.1.1"
 #: Logger raiz.
 LOGGER_NAME = "horizun_pbi_mcp"
 #: Prefijo de las tools. NO cambia: es contrato publico.

--- a/src/horizun_pbi_mcp/pbip/theme.py
+++ b/src/horizun_pbi_mcp/pbip/theme.py
@@ -164,10 +164,36 @@ def list_presets() -> List[Dict[str, Any]]:
             for clave, v in PRESETS.items()]
 
 
+#: Clases de texto del tema de Power BI a las que se puede fijar la fuente.
+#: La clave amable -> la clase real del esquema de temas.
+_CLASES_DE_FUENTE = {"title": "title", "body": "label", "callout": "callout"}
+
+
 def build_theme(preset: str = "control_room",
                 name: Optional[str] = None,
-                data_colors: Optional[List[str]] = None) -> Dict[str, Any]:
-    """Devuelve el JSON del tema. `data_colors` sustituye la paleta categorica."""
+                data_colors: Optional[List[str]] = None,
+                theme_json: Optional[Dict[str, Any]] = None,
+                fonts: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Devuelve el JSON del tema.
+
+    `theme_json`: un tema COMPLETO del llamante, que se escribe tal cual (se le
+    ajusta solo el nombre, que debe coincidir con el archivo). Existe porque
+    para tipografia corporativa habia que dejar que la tool escribiera su JSON
+    y sobrescribirlo despues a mano, confiando en que report.json siguiera
+    apuntando al mismo archivo. Cuando se pasa, `preset` no se usa.
+
+    `fonts`: {'title'|'body'|'callout': 'Familia'} -> textClasses del tema.
+    Se aplica SOBRE el preset o SOBRE theme_json, el que este en juego.
+
+    `data_colors` sustituye la paleta categorica.
+    """
+    if theme_json is not None:
+        if not isinstance(theme_json, dict) or not theme_json:
+            raise ThemeError(
+                "theme_json debe ser un objeto JSON de tema no vacio.")
+        tema = copy.deepcopy(theme_json)
+        return _con_extras(tema, name, data_colors, fonts)
+
     if preset not in PRESETS:
         raise ThemeError(
             f"Tema desconocido: '{preset}'. Disponibles: {sorted(PRESETS)}.",
@@ -184,6 +210,36 @@ def build_theme(preset: str = "control_room",
                  "deja de estar verificado contra daltonismo.", len(data_colors))
     if name:
         tema["name"] = name
+    return _con_extras(tema, None, None, fonts)
+
+
+def _con_extras(tema: Dict[str, Any], name: Optional[str],
+                data_colors: Optional[List[str]],
+                fonts: Optional[Dict[str, str]]) -> Dict[str, Any]:
+    """Aplica nombre, paleta y fuentes sobre un tema ya construido."""
+    if data_colors:
+        malos = [c for c in data_colors
+                 if not (isinstance(c, str) and c.startswith("#") and len(c) in (4, 7))]
+        if malos:
+            raise ThemeError(
+                f"Colores no validos (se esperaba #RRGGBB): {malos}.")
+        tema["dataColors"] = list(data_colors)
+    if name:
+        tema["name"] = name
+    if fonts:
+        desconocidas = sorted(set(fonts) - set(_CLASES_DE_FUENTE))
+        if desconocidas:
+            raise ThemeError(
+                f"Clases de fuente desconocidas: {desconocidas}. "
+                f"Validas: {sorted(_CLASES_DE_FUENTE)}.",
+                details={"valid": sorted(_CLASES_DE_FUENTE)})
+        clases = tema.setdefault("textClasses", {})
+        for amable, familia in fonts.items():
+            if not isinstance(familia, str) or not familia.strip():
+                raise ThemeError(f"La fuente de '{amable}' debe ser un nombre "
+                                 "de familia no vacio.")
+            clase = clases.setdefault(_CLASES_DE_FUENTE[amable], {})
+            clase["fontFace"] = familia.strip()
     return tema
 
 
@@ -291,6 +347,30 @@ def apply_theme(active: ActivePbip, tema: Dict[str, Any],
     informe["resourcePackages"] = _paquete_recursos(
         informe.get("resourcePackages"), nombre_archivo)
 
+    # Si habia un tema anterior y su contenido difiere del nuevo, se avisa: la
+    # sustitucion es legitima -un informe declara UN customTheme-, pero hacerla
+    # en silencio ya costo ediciones a mano una vez. No se bloquea: el archivo
+    # anterior queda en el backup de la transaccion, recuperable.
+    avisos: List[str] = []
+    anterior_path = None
+    if anterior:
+        try:
+            anterior_path = safe_paths.safe_join(
+                recursos_dir, str(anterior), kind="ruta del tema anterior")
+        except Exception:                                # noqa: BLE001
+            anterior_path = None
+    if anterior_path is not None and anterior_path.exists():
+        try:
+            previo = read_json(anterior_path)
+        except Exception:                                # noqa: BLE001
+            previo = None
+        if previo is not None and previo != tema:
+            avisos.append(
+                f"El tema anterior '{anterior}' tenia contenido DISTINTO al "
+                "nuevo (pudo estar editado a mano) y queda reemplazado. Su "
+                "version previa esta en el backup de esta transaccion; "
+                "recuperala de ahi si esas ediciones importaban.")
+
     # El archivo y sus dos declaraciones en report.json forman una sola unidad:
     # cualquiera de las dos mitades sin la otra hace que Desktop ignore el tema.
     # La misma puerta bloquea la escritura si la version PBIR no es soportada o
@@ -305,7 +385,7 @@ def apply_theme(active: ActivePbip, tema: Dict[str, Any],
         tx.write_json(informe_path, informe)
 
     log.info("Tema '%s' aplicado (%s)", tema.get("name"), nombre_archivo)
-    return {
+    salida = {
         "theme_name": tema.get("name"),
         "file": str(destino),
         "report_json": str(informe_path),
@@ -316,3 +396,6 @@ def apply_theme(active: ActivePbip, tema: Dict[str, Any],
         "transaction": cm.result,
         "validation_report": cm.validation,
     }
+    if avisos:
+        salida["warnings"] = avisos
+    return salida

--- a/src/horizun_pbi_mcp/powerbi/desktop_launcher.py
+++ b/src/horizun_pbi_mcp/powerbi/desktop_launcher.py
@@ -527,3 +527,44 @@ def close(opened: OpenedPbix, force: bool = False) -> Dict[str, Any]:
     return {"closed": not supervivientes, "pid": opened.desktop_pid,
             "killed": kill_requested, "children": len(hijos),
             "survivors": [p.pid for p in supervivientes]}
+
+
+def close_desktop_by_path(pbix_path: str | Path) -> Dict[str, Any]:
+    """Cierra SOLO la instancia de Desktop que tiene abierto ese archivo.
+
+    Existe porque el ciclo real de trabajo -editar, abrir, mirar, editar-
+    chocaba cinco veces por sesion con `project_open_in_desktop` sin ninguna
+    salida desde el MCP: habia que ir a PowerShell a matar el proceso. Eso, o
+    peor: matar PBIDesktop.exe a ciegas y llevarse la ventana de OTRO informe.
+
+    La identidad se verifica igual que en `close()`: nombre del proceso y hora
+    de arranque, nunca el PID a secas -Windows los recicla-. Y al final se
+    RE-COMPRUEBA que el archivo ya no este abierto, porque "terminate no
+    lanzo" no es "la ventana se cerro".
+    """
+    pbix = Path(pbix_path).expanduser().resolve()
+    if pbix.suffix.casefold() not in {".pbix", ".pbip"}:
+        raise ValidationError(
+            "Solo se cierran sesiones de archivos .pbix o .pbip.",
+            details={"path": str(pbix), "extension": pbix.suffix})
+
+    pid = proceso_con_archivo_abierto(pbix)
+    if not pid:
+        return {"closed": False, "was_open": False,
+                "reason": "el archivo no esta abierto en ningun Desktop",
+                "path": str(pbix)}
+
+    abierto = OpenedPbix(str(pbix), {}, pid, False, 0.0,
+                         desktop_started=_process_started(pid))
+    resultado = close(abierto, force=True)
+    resultado["path"] = str(pbix)
+    resultado["was_open"] = True
+
+    # Verificacion real: el archivo ya no puede estar abierto en NINGUN pid.
+    todavia = proceso_con_archivo_abierto(pbix)
+    resultado["verified_closed"] = todavia is None
+    if todavia is not None:
+        resultado["closed"] = False
+        resultado["reason"] = (f"otro proceso (pid {todavia}) sigue con el "
+                               "archivo abierto")
+    return resultado

--- a/src/horizun_pbi_mcp/services/guide.py
+++ b/src/horizun_pbi_mcp/services/guide.py
@@ -1,15 +1,15 @@
-"""Por donde se empieza. Un punto de entrada para 119 tools.
+"""Por donde se empieza. Un punto de entrada para 121 tools.
 
 El problema que cierra
 ----------------------
-Ciento diecinueve tools con buen nombre y buena descripcion siguen siendo
-ciento diecinueve tools. Quien llega no sabe si primero abre un proyecto o primero carga datos, ni
+Ciento veintiuna tools con buen nombre y buena descripcion siguen siendo
+ciento veintiuna tools. Quien llega no sabe si primero abre un proyecto o primero carga datos, ni
 que la escritura de TMDL exige Power BI Desktop CERRADO —y eso no lo dice
 ninguna lista alfabetica—. El catalogo estaba completo y el camino no existia.
 
 Aqui no se documenta nada nuevo: se MIRA el estado real y se responde a «¿y
 ahora que?» con tres o cuatro pasos concretos, cada uno con el nombre exacto de
-la tool y el motivo. Una lista de 119 opciones no es una respuesta a esa
+la tool y el motivo. Una lista de 121 opciones no es una respuesta a esa
 pregunta; tres si.
 
 La regla que lo mantiene util

--- a/src/horizun_pbi_mcp/services/workflows.py
+++ b/src/horizun_pbi_mcp/services/workflows.py
@@ -477,3 +477,265 @@ def prepare_delivery(active, model_data, *, dry_run: bool = True) -> Dict[str, A
         "prepare_delivery", etapas, applied=True,
         resumen=(f"{aplicado['applied']} correccion(es). Puntaje "
                  f"{auditoria['score']} -> {despues['score']}."))
+
+
+# ---------------------------------------------------------------------------
+# Renombrar una medida SIN romper el informe
+# ---------------------------------------------------------------------------
+
+def _bloques_de_medida(lines: List[str]) -> List[Dict[str, Any]]:
+    """Rangos [inicio, fin) de cada bloque `measure` de un archivo TMDL.
+
+    Se delimitan aqui y no con un regex global porque el reemplazo de
+    referencias DAX solo es seguro DENTRO de una medida: en la expresion de una
+    columna calculada, `[x]` sin calificar es una COLUMNA de su propia tabla, y
+    reescribirlo corromperia un calculo que no tiene nada que ver.
+    """
+    from horizun_pbi_mcp.pbip.tmdl_reader import _first_token, _indent, _unquote
+
+    bloques: List[Dict[str, Any]] = []
+    i = 0
+    while i < len(lines):
+        linea = lines[i]
+        if _indent(linea) == 1 and _first_token(linea) == "measure":
+            cabecera = linea.strip()[len("measure"):].strip()
+            nombre = _unquote(cabecera.split("=", 1)[0].strip())
+            j = i + 1
+            while j < len(lines):
+                lj = lines[j]
+                if lj.strip() and _indent(lj) <= 1:
+                    break
+                j += 1
+            bloques.append({"name": nombre, "start": i, "end": j})
+            i = j
+        else:
+            i += 1
+    return bloques
+
+
+def _reemplazar_ref_dax(texto: str, viejo: str, nuevo: str):
+    """Sustituye `[viejo]` SIN calificar por `[nuevo]`. `(texto, cuantas)`.
+
+    Solo la forma sin calificar: `Tabla[viejo]` o `'Tabla'[viejo]` puede ser
+    una COLUMNA homonima de otra tabla, y adivinar ahi es corromper. Las
+    calificadas que referencien de verdad a la medida las recoge el barrido
+    final y salen como aviso con su ubicacion, nunca en silencio.
+    """
+    import re
+
+    patron = re.compile(r"(?<![\w'\]])\[" + re.escape(viejo) + r"\]",
+                        re.IGNORECASE)
+    return patron.subn(f"[{nuevo}]", texto)
+
+
+def _barrido_de_restos(active, table: str, old_name: str) -> List[str]:
+    """Rutas del informe donde AUN se referencia la medida vieja.
+
+    Cubre lo que el plan de visuales no toca: bookmarks, filterConfig de
+    paginas o del informe, y cualquier JSON del arbol `.Report`. Encontrar
+    algo aqui no es fallo del renombrado: es la lista exacta de lo que hay
+    que revisar a mano, dicha en voz alta.
+    """
+    from pathlib import Path as _Path
+
+    from horizun_pbi_mcp.utils.json_utils import read_json
+
+    if not active.report_dir:
+        return []
+
+    def _tiene_ref(nodo) -> bool:
+        if isinstance(nodo, dict):
+            medida = nodo.get("Measure")
+            if isinstance(medida, dict):
+                prop = str(medida.get("Property") or "")
+                ent = (medida.get("Expression", {}) or {}).get(
+                    "SourceRef", {}) or {}
+                entidad = str(ent.get("Entity") or "")
+                if (prop.casefold() == old_name.casefold()
+                        and (not entidad or entidad.casefold() == table.casefold())):
+                    return True
+            return any(_tiene_ref(v) for v in nodo.values())
+        if isinstance(nodo, list):
+            return any(_tiene_ref(v) for v in nodo)
+        return False
+
+    base = _Path(active.report_dir) / "definition"
+    restos: List[str] = []
+    for ruta in sorted(base.rglob("*.json")):
+        try:
+            datos = read_json(ruta)
+        except Exception:                                # noqa: BLE001
+            continue
+        if _tiene_ref(datos):
+            restos.append(str(ruta.relative_to(base)).replace("\\", "/"))
+    return restos
+
+
+def rename_measure(active, model_data, *, table: str, old_name: str,
+                   new_name: str, dry_run: bool = True) -> Dict[str, Any]:
+    """Renombra una medida actualizando a la vez modelo e informe.
+
+    El caso que cierra: renombrar 8 medidas a nombres presentables obligaba a
+    reescribir el TMDL completo y re-aplicar la pagina entera, porque
+    cualquier referencia vieja quedaba rota EN SILENCIO -el visual abre y sale
+    vacio-. Aqui todo se compila primero y se escribe en UNA transaccion:
+    cabecera TMDL, expresiones DAX de otras medidas y visual.json del informe.
+    """
+    import copy as _copy
+
+    from horizun_pbi_mcp.pbip.tmdl_reader import find_table_file
+    from horizun_pbi_mcp.pbip.tmdl_writer import _render
+    from horizun_pbi_mcp.utils.validation import tmdl_quote_name, validate_object_name
+
+    etapas: List[Dict[str, Any]] = []
+    if not model_data:
+        raise ValidationError("Se necesita el modelo para renombrar con referencias.")
+
+    nuevo = validate_object_name(new_name, "medida")
+    viejo = str(old_name).strip()
+    if viejo == nuevo:
+        raise ValidationError("El nombre nuevo es identico al actual.")
+
+    # -- validaciones contra el modelo (la leccion del preflight: una colision
+    #    de nombres no falla al escribir; falla al ABRIR Desktop) --------------
+    medidas = model_data.get("measures") or []
+    la_medida = None
+    for m in medidas:
+        if (str(m.get("table", "")).casefold() == table.casefold()
+                and str(m.get("name", "")).casefold() == viejo.casefold()):
+            la_medida = m
+            break
+    if la_medida is None:
+        disponibles = sorted(str(m.get("name")) for m in medidas
+                             if str(m.get("table", "")).casefold() == table.casefold())
+        raise ValidationError(
+            f"La medida '{viejo}' no existe en la tabla '{table}'.",
+            details={"available": disponibles})
+    for m in medidas:
+        if (m is not la_medida
+                and str(m.get("name", "")).casefold() == nuevo.casefold()):
+            raise ValidationError(
+                f"Ya existe una medida '{m.get('name')}' en la tabla "
+                f"'{m.get('table')}': los nombres de medida son unicos en "
+                "todo el modelo.")
+    for t in model_data.get("tables") or []:
+        if str(t.get("name", "")).casefold() != table.casefold():
+            continue
+        for c in t.get("columns") or []:
+            if str(c.get("name", "")).casefold() == nuevo.casefold():
+                raise ValidationError(
+                    f"La tabla '{table}' ya tiene una COLUMNA '{c.get('name')}'. "
+                    "Power BI acepta escribirlo y despues rechaza el modelo al "
+                    "abrirlo: es la colision exacta que detecta el preflight.")
+
+    # -- plan TMDL: cabecera + referencias DAX en bloques de medida -----------
+    planes_tmdl: List[Dict[str, Any]] = []
+    total_refs_dax = 0
+    for t in model_data.get("tables") or []:
+        nombre_tabla = str(t.get("name"))
+        try:
+            ruta = find_table_file(active, nombre_tabla)
+        except Exception:                                # noqa: BLE001
+            continue
+        lineas = ruta.read_text(encoding="utf-8-sig").splitlines()
+        cambiado = False
+        refs_aqui = 0
+        for bloque in _bloques_de_medida(lineas):
+            ini, fin = bloque["start"], bloque["end"]
+            if (nombre_tabla.casefold() == table.casefold()
+                    and bloque["name"].casefold() == viejo.casefold()):
+                cab = lineas[ini]
+                _, _, resto = cab.partition("=")
+                lineas[ini] = f"\tmeasure {tmdl_quote_name(nuevo)} ={resto}"
+                cambiado = True
+            for k in range(ini, fin):
+                if k == ini:
+                    izq, sep, der = lineas[k].partition("=")
+                    if not sep:
+                        continue
+                    der2, n = _reemplazar_ref_dax(der, viejo, nuevo)
+                    if n:
+                        lineas[k] = izq + sep + der2
+                        refs_aqui += n
+                        cambiado = True
+                else:
+                    linea2, n = _reemplazar_ref_dax(lineas[k], viejo, nuevo)
+                    if n:
+                        lineas[k] = linea2
+                        refs_aqui += n
+                        cambiado = True
+        if cambiado:
+            planes_tmdl.append({"path": ruta, "text": _render(lineas),
+                                "table": nombre_tabla,
+                                "dax_refs": refs_aqui})
+            total_refs_dax += refs_aqui
+    etapas.append(_etapa("plan_modelo", {
+        "files": [{"table": p["table"], "dax_refs": p["dax_refs"]}
+                  for p in planes_tmdl],
+        "dax_references": total_refs_dax}))
+
+    # -- plan de visuales: contra el modelo YA renombrado en memoria ----------
+    modelo_renombrado = _copy.deepcopy(model_data)
+    for m in modelo_renombrado.get("measures") or []:
+        if (str(m.get("table", "")).casefold() == table.casefold()
+                and str(m.get("name", "")).casefold() == viejo.casefold()):
+            m["name"] = nuevo
+    ref_vieja = f"{table}[{viejo}]"
+    ref_nueva = f"{table}[{nuevo}]"
+    acciones: List[Dict[str, Any]] = []
+    for p in pbir_reader.list_pages(active):
+        for v in pbir_reader.list_visuals(active, p["name"], strict=True):
+            if any(str(r).casefold() == ref_vieja.casefold()
+                   for r in v.get("measures", [])):
+                acciones.append({"page": p["name"], "visual_id": v["id"]})
+    planes_visual = [pbir_edit.plan_replace_visual_field(
+        active, a["page"], a["visual_id"], ref_vieja, ref_nueva,
+        modelo_renombrado) for a in acciones]
+    etapas.append(_etapa("plan_informe", {"visuals": acciones}))
+
+    if dry_run:
+        return _informe(
+            "rename_measure", etapas, applied=False,
+            resumen=(f"'{viejo}' -> '{nuevo}': {len(planes_tmdl)} archivo(s) "
+                     f"TMDL ({total_refs_dax} referencia(s) DAX) y "
+                     f"{len(acciones)} visual(es). dry_run."))
+
+    # -- aplicar: UNA transaccion para modelo e informe -----------------------
+    destinos = [p["path"] for p in planes_tmdl] + [p["path"] for p in planes_visual]
+    pbir_edit.assert_escritura_pbir(active, "Renombrar una medida")
+    cm = txn_service.project_transaction(active, destinos,
+                                         tool="pbi_rename_measure")
+    with cm as tx:
+        for p in planes_tmdl:
+            tx.write_text(p["path"], p["text"])
+        for p in planes_visual:
+            tx.write_json(p["path"], p["data"])
+    etapas.append(_etapa("apply", {"tmdl_files": len(planes_tmdl),
+                                   "visuals": len(planes_visual),
+                                   "transaction": cm.result["journal"]}))
+
+    # -- verificacion: releer y barrer, nunca dar por hecho -------------------
+    releido = tmdl_reader.read_semantic_model(active, strict=False)
+    nombres = {(str(m.get("table", "")).casefold(), str(m.get("name", "")).casefold())
+               for m in releido.get("measures") or []}
+    renombrada = ((table.casefold(), nuevo.casefold()) in nombres
+                  and (table.casefold(), viejo.casefold()) not in nombres)
+    restos = _barrido_de_restos(active, table, viejo)
+    etapas.append(_etapa("verificacion", {"renamed_verified": renombrada,
+                                          "leftover_references": restos}))
+    avisos = []
+    if not renombrada:
+        avisos.append("La relectura del TMDL no confirma el renombrado: revisa "
+                      "el journal de la transaccion.")
+    if restos:
+        avisos.append(
+            f"Quedan referencias a '{viejo}' fuera de los visuales tratados "
+            f"(bookmarks o filtros): {restos}. Revisalas a mano; no se "
+            "adivinan porque una referencia calificada puede ser una columna "
+            "homonima de otra tabla.")
+    return _informe(
+        "rename_measure", etapas, applied=True,
+        resumen=(f"'{viejo}' -> '{nuevo}' renombrada. {total_refs_dax} "
+                 f"referencia(s) DAX y {len(planes_visual)} visual(es) "
+                 "actualizados en una transaccion."),
+        warnings=avisos)

--- a/src/horizun_pbi_mcp/tools/dax_tools.py
+++ b/src/horizun_pbi_mcp/tools/dax_tools.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from horizun_pbi_mcp.config import get_session
 from horizun_pbi_mcp.powerbi import dax_runner, desktop_discovery
+from horizun_pbi_mcp.powerbi.errors import ValidationError
 from horizun_pbi_mcp.powerbi.clr_bootstrap import diagnostics
 from horizun_pbi_mcp.tools._common import guard
 
@@ -188,3 +189,33 @@ def register(mcp) -> None:
         referenciarse entre si. Devuelve por cada una: valid, value (muestra) y error.
         """
         return guard(lambda: dax_runner.validate_measures(get_session(), measures))
+
+    @mcp.tool()
+    def pbi_close_desktop(path: str, confirm: bool = False,
+                          request_id: str = "") -> Dict[str, Any]:
+        """Cierra la instancia de Power BI Desktop que sirve ESE proyecto.
+
+        Es la salida que faltaba del ciclo editar-abrir-mirar-editar: escribir
+        el TMDL exige Desktop cerrado, y no habia forma de cerrarlo desde aqui
+        -tocaba matar el proceso a mano en PowerShell-.
+
+        Cierra SOLO la instancia con ese archivo abierto, verificando la
+        identidad del proceso (nombre + hora de arranque, nunca el PID a
+        secas). Al final re-comprueba que el archivo ya no este abierto y lo
+        dice en `verified_closed`.
+
+        DESTRUCTIVA: los cambios SIN GUARDAR de esa ventana se pierden -y en
+        un .pbip eso incluye los datos refrescados de la sesion-. Por eso
+        exige `confirm=true`. Si el archivo no estaba abierto, no hace nada y
+        lo dice (`was_open: false`).
+        """
+        def _impl():
+            if not confirm:
+                raise ValidationError(
+                    "Cerrar Desktop descarta lo no guardado de esa ventana "
+                    "(y en .pbip, los datos refrescados). Pasa confirm=true "
+                    "si es lo que quieres.")
+            from horizun_pbi_mcp.powerbi import desktop_launcher
+
+            return desktop_launcher.close_desktop_by_path(path)
+        return guard(_impl)

--- a/src/horizun_pbi_mcp/tools/design_tools.py
+++ b/src/horizun_pbi_mcp/tools/design_tools.py
@@ -25,7 +25,7 @@ def register(mcp) -> None:
     def pbi_start_here(request_id: str = "") -> Dict[str, Any]:
         """Por donde empezar. Mira el estado real y dice los siguientes pasos.
 
-        Ciento diecinueve tools con buen nombre siguen siendo ciento diecinueve tools.
+        Ciento veintiuna tools con buen nombre siguen siendo ciento veintiuna tools.
         Esta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada
         uno con el nombre exacto de la tool y **por que** toca ahora: si hay
         proyecto activo, si tiene modelo o solo informe, si esta vacio, y si

--- a/src/horizun_pbi_mcp/tools/measure_tools.py
+++ b/src/horizun_pbi_mcp/tools/measure_tools.py
@@ -127,3 +127,35 @@ def register(mcp) -> None:
                     session.require_active_pbip(), table, name),
             )
         return guard_mutation(_impl)
+
+    @mcp.tool()
+    def pbi_rename_measure(table: str, old_name: str, new_name: str,
+                           dry_run: bool = True,
+                           request_id: str = "") -> Dict[str, Any]:
+        """Renombra una medida actualizando TODO lo que la referencia.
+
+        Renombrar a mano rompe el informe en silencio: cualquier visual o
+        medida que apuntara al nombre viejo abre y sale VACIO, sin error. Esta
+        tool compila primero y escribe en UNA transaccion: la cabecera TMDL,
+        las expresiones DAX de otras medidas que usan `[old_name]`, y los
+        visual.json del informe. Devuelve la lista de lo tocado.
+
+        Limite honesto: las referencias DAX CALIFICADAS (`Tabla[old]`) no se
+        reescriben —pueden ser una columna homonima de otra tabla, y adivinar
+        seria corromper—; si quedan, salen en `warnings` con su ubicacion,
+        igual que las de bookmarks y filtros.
+
+        Solo `pbip` (escribe modelo E informe a la vez: exige Desktop
+        CERRADO). `dry_run=true` (defecto) devuelve el plan sin escribir.
+        """
+        from horizun_pbi_mcp.pbip import tmdl_reader as _tr
+        from horizun_pbi_mcp.services import workflows as _wf
+
+        def _impl():
+            session = get_session()
+            active = session.require_active_pbip()
+            modelo = _tr.read_semantic_model(active, strict=False)
+            return _wf.rename_measure(active, modelo, table=table,
+                                      old_name=old_name, new_name=new_name,
+                                      dry_run=dry_run)
+        return guard_mutation(_impl)

--- a/src/horizun_pbi_mcp/tools/report_tools.py
+++ b/src/horizun_pbi_mcp/tools/report_tools.py
@@ -130,6 +130,8 @@ def register(mcp) -> None:
     def pbi_apply_theme(preset: str = "control_room",
                         name: Optional[str] = None,
                         data_colors: Optional[List[str]] = None,
+                        theme_json: Optional[Dict[str, Any]] = None,
+                        fonts: Optional[Dict[str, str]] = None,
                         request_id: Optional[str] = None) -> Dict[str, Any]:
         """Aplica un tema de colores al informe .pbip activo.
 
@@ -141,6 +143,18 @@ def register(mcp) -> None:
         series por la tuya (#RRGGBB); ojo, entonces el orden deja de estar
         verificado contra daltonismo. `name`: nombre visible del tema.
 
+        `theme_json`: un tema COMPLETO tuyo (el objeto JSON), que se escribe
+        tal cual — para tipografia corporativa o formatos que los presets no
+        cubren, sin tener que sobrescribir el archivo a mano despues. Cuando lo
+        pasas, `preset` no se usa; `data_colors` y `fonts` se aplican encima.
+
+        `fonts`: {'title'|'body'|'callout': 'Familia'} fija las fuentes via
+        textClasses, sobre el preset o sobre tu theme_json.
+
+        Si el informe ya tenia un tema con contenido DISTINTO (p.ej. editado a
+        mano), se reemplaza avisandolo en `warnings`; la version anterior queda
+        recuperable en el backup de la transaccion.
+
         Requiere el proyecto CERRADO en Power BI Desktop.
         """
         from horizun_pbi_mcp.pbip import theme
@@ -148,7 +162,8 @@ def register(mcp) -> None:
         def _impl():
             activo = _tema_activo()
             construido = theme.build_theme(preset=preset, name=name,
-                                           data_colors=data_colors)
+                                           data_colors=data_colors,
+                                           theme_json=theme_json, fonts=fonts)
             return theme.apply_theme(activo, construido)
 
         return guard_mutation(_impl)

--- a/src/horizun_pbi_mcp/tools/risk.py
+++ b/src/horizun_pbi_mcp/tools/risk.py
@@ -46,7 +46,7 @@ llamadas iguales a `pbi_create_visual` crean dos visuales. Anunciar
 `idempotent=True` seria prometer una garantia que depende de que quien llama haga
 su parte.
 
-`openWorldHint` es `False` en las 119: este servidor habla con el disco local y
+`openWorldHint` es `False` en las 121: este servidor habla con el disco local y
 con un Power BI Desktop local. No hay dominio abierto.
 """
 from __future__ import annotations
@@ -163,6 +163,8 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_create_hierarchy": WRITE_REVERSIBLE,
     "pbi_create_html_visual": WRITE_REVERSIBLE,
     "pbi_create_measure": WRITE_REVERSIBLE,
+    # Renombra en modelo E informe dentro de una transaccion con journal.
+    "pbi_rename_measure": WRITE_REVERSIBLE,
     "pbi_create_page_from_spec": WRITE_REVERSIBLE,
     "pbi_create_pbip_project": WRITE_REVERSIBLE,
     "pbi_create_relationship": WRITE_REVERSIBLE,
@@ -195,6 +197,8 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_apply_plan": WRITE_DESTRUCTIVE,
     "pbi_delete_bookmark": WRITE_DESTRUCTIVE,
     "pbi_delete_measure": WRITE_DESTRUCTIVE,
+    # Cierra una ventana del usuario: lo no guardado se pierde.
+    "pbi_close_desktop": WRITE_DESTRUCTIVE,
     "pbi_delete_page": WRITE_DESTRUCTIVE,
     "pbi_delete_visual": WRITE_DESTRUCTIVE,
     "pbi_purge_backups": WRITE_DESTRUCTIVE,

--- a/tests/golden/tools_v1.json
+++ b/tests/golden/tools_v1.json
@@ -1,6 +1,6 @@
 {
   "contract_version": 1,
-  "tool_count": 119,
+  "tool_count": 121,
   "tools": [
     {
       "name": "pbi_add_custom_visual",
@@ -387,11 +387,16 @@
     },
     {
       "name": "pbi_apply_theme",
-      "description": "Aplica un tema de colores al informe .pbip activo.\n\nEscribe el JSON del tema en StaticResources/RegisteredResources y lo\ndeclara en report.json (themeCollection + resourcePackages). Sin las\ntres cosas Power BI Desktop lo ignora en silencio.\n\n`preset`: ver pbi_list_themes. `data_colors`: sustituye la paleta de\nseries por la tuya (#RRGGBB); ojo, entonces el orden deja de estar\nverificado contra daltonismo. `name`: nombre visible del tema.\n\nRequiere el proyecto CERRADO en Power BI Desktop.",
+      "description": "Aplica un tema de colores al informe .pbip activo.\n\nEscribe el JSON del tema en StaticResources/RegisteredResources y lo\ndeclara en report.json (themeCollection + resourcePackages). Sin las\ntres cosas Power BI Desktop lo ignora en silencio.\n\n`preset`: ver pbi_list_themes. `data_colors`: sustituye la paleta de\nseries por la tuya (#RRGGBB); ojo, entonces el orden deja de estar\nverificado contra daltonismo. `name`: nombre visible del tema.\n\n`theme_json`: un tema COMPLETO tuyo (el objeto JSON), que se escribe\ntal cual — para tipografia corporativa o formatos que los presets no\ncubren, sin tener que sobrescribir el archivo a mano despues. Cuando lo\npasas, `preset` no se usa; `data_colors` y `fonts` se aplican encima.\n\n`fonts`: {'title'|'body'|'callout': 'Familia'} fija las fuentes via\ntextClasses, sobre el preset o sobre tu theme_json.\n\nSi el informe ya tenia un tema con contenido DISTINTO (p.ej. editado a\nmano), se reemplaza avisandolo en `warnings`; la version anterior queda\nrecuperable en el backup de la transaccion.\n\nRequiere el proyecto CERRADO en Power BI Desktop.",
       "params": {
         "data_colors": {
           "required": false,
           "type": "array[string]|null",
+          "default": null
+        },
+        "fonts": {
+          "required": false,
+          "type": "null|object",
           "default": null
         },
         "name": {
@@ -407,6 +412,11 @@
         "request_id": {
           "required": false,
           "type": "null|string",
+          "default": null
+        },
+        "theme_json": {
+          "required": false,
+          "type": "null|object",
           "default": null
         }
       },
@@ -794,6 +804,44 @@
       "annotations": {
         "openWorldHint": false,
         "readOnlyHint": true
+      }
+    },
+    {
+      "name": "pbi_close_desktop",
+      "description": "Cierra la instancia de Power BI Desktop que sirve ESE proyecto.\n\nEs la salida que faltaba del ciclo editar-abrir-mirar-editar: escribir\nel TMDL exige Desktop cerrado, y no habia forma de cerrarlo desde aqui\n-tocaba matar el proceso a mano en PowerShell-.\n\nCierra SOLO la instancia con ese archivo abierto, verificando la\nidentidad del proceso (nombre + hora de arranque, nunca el PID a\nsecas). Al final re-comprueba que el archivo ya no este abierto y lo\ndice en `verified_closed`.\n\nDESTRUCTIVA: los cambios SIN GUARDAR de esa ventana se pierden -y en\nun .pbip eso incluye los datos refrescados de la sesion-. Por eso\nexige `confirm=true`. Si el archivo no estaba abierto, no hace nada y\nlo dice (`was_open: false`).",
+      "params": {
+        "confirm": {
+          "required": false,
+          "type": "boolean",
+          "default": false
+        },
+        "path": {
+          "required": true,
+          "type": "string"
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
       }
     },
     {
@@ -3496,6 +3544,54 @@
       }
     },
     {
+      "name": "pbi_rename_measure",
+      "description": "Renombra una medida actualizando TODO lo que la referencia.\n\nRenombrar a mano rompe el informe en silencio: cualquier visual o\nmedida que apuntara al nombre viejo abre y sale VACIO, sin error. Esta\ntool compila primero y escribe en UNA transaccion: la cabecera TMDL,\nlas expresiones DAX de otras medidas que usan `[old_name]`, y los\nvisual.json del informe. Devuelve la lista de lo tocado.\n\nLimite honesto: las referencias DAX CALIFICADAS (`Tabla[old]`) no se\nreescriben —pueden ser una columna homonima de otra tabla, y adivinar\nseria corromper—; si quedan, salen en `warnings` con su ubicacion,\nigual que las de bookmarks y filtros.\n\nSolo `pbip` (escribe modelo E informe a la vez: exige Desktop\nCERRADO). `dry_run=true` (defecto) devuelve el plan sin escribir.",
+      "params": {
+        "dry_run": {
+          "required": false,
+          "type": "boolean",
+          "default": true
+        },
+        "new_name": {
+          "required": true,
+          "type": "string"
+        },
+        "old_name": {
+          "required": true,
+          "type": "string"
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "table": {
+          "required": true,
+          "type": "string"
+        }
+      },
+      "required": [
+        "new_name",
+        "old_name",
+        "table"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      }
+    },
+    {
       "name": "pbi_rename_page",
       "description": "Cambia el nombre visible de una pagina. El id interno no cambia.",
       "params": {
@@ -4136,7 +4232,7 @@
     },
     {
       "name": "pbi_start_here",
-      "description": "Por donde empezar. Mira el estado real y dice los siguientes pasos.\n\nCiento diecinueve tools con buen nombre siguen siendo ciento diecinueve tools.\nEsta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada\nuno con el nombre exacto de la tool y **por que** toca ahora: si hay\nproyecto activo, si tiene modelo o solo informe, si esta vacio, y si\nPower BI Desktop lo tiene abierto —que impide escribir el TMDL—.\n\nDevuelve tambien `common_tasks`: tareas frecuentes y la secuencia de\ntools que las resuelve.\n\nNo escribe nada. Empieza por aqui cuando no sepas que sigue.",
+      "description": "Por donde empezar. Mira el estado real y dice los siguientes pasos.\n\nCiento veintiuna tools con buen nombre siguen siendo ciento veintiuna tools.\nEsta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada\nuno con el nombre exacto de la tool y **por que** toca ahora: si hay\nproyecto activo, si tiene modelo o solo informe, si esta vacio, y si\nPower BI Desktop lo tiene abierto —que impide escribir el TMDL—.\n\nDevuelve tambien `common_tasks`: tareas frecuentes y la secuencia de\ntools que las resuelve.\n\nNo escribe nada. Empieza por aqui cuando no sepas que sigue.",
       "params": {
         "request_id": {
           "required": false,

--- a/tests/test_close_desktop.py
+++ b/tests/test_close_desktop.py
@@ -1,0 +1,105 @@
+"""Cerrar la instancia de Desktop de UN proyecto, sin llevarse otra (#8).
+
+El ciclo real -editar, abrir, mirar, editar- chocaba cinco veces por sesion con
+`project_open_in_desktop` sin ninguna salida desde el MCP: habia que ir a
+PowerShell a matar el proceso. Y el atajo peligroso era matar PBIDesktop.exe a
+ciegas, llevandose la ventana de OTRO informe con trabajo sin guardar.
+
+Lo que se vigila: identidad verificada (nunca el PID a secas), verificacion
+final re-comprobando que el archivo ya no este abierto, y confirm obligatorio
+-cerrar descarta lo no guardado, y en .pbip eso incluye los datos refrescados-.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from horizun_pbi_mcp.powerbi import desktop_launcher as dl
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+
+
+@pytest.fixture
+def pbip(tmp_path):
+    f = tmp_path / "Proyecto.pbip"
+    f.write_text("{}", encoding="utf-8")
+    return f
+
+
+# ------------------------------------------------------------ la tool exige ---
+def test_sin_confirm_no_se_cierra_nada(monkeypatch, pbip):
+    from horizun_pbi_mcp.tools import dax_tools
+
+    class _Mcp:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self):
+            def dec(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+            return dec
+
+    mcp = _Mcp()
+    dax_tools.register(mcp)
+    llamado = {"n": 0}
+    monkeypatch.setattr(dl, "close_desktop_by_path",
+                        lambda p: llamado.update(n=llamado["n"] + 1))
+
+    salida = mcp.tools["pbi_close_desktop"](path=str(pbip))
+    assert salida["ok"] is False
+    assert "confirm" in salida["message"]
+    assert llamado["n"] == 0, "sin confirm no puede llegar a tocar el proceso"
+
+
+# ------------------------------------------------------- el servicio real ---
+def test_archivo_no_abierto_es_un_no_op_declarado(monkeypatch, pbip):
+    monkeypatch.setattr(dl, "proceso_con_archivo_abierto", lambda _p: None)
+    r = dl.close_desktop_by_path(pbip)
+    assert r == {"closed": False, "was_open": False,
+                 "reason": "el archivo no esta abierto en ningun Desktop",
+                 "path": str(pbip.resolve())}
+
+
+def test_extension_desconocida_se_rechaza(tmp_path):
+    with pytest.raises(ValidationError):
+        dl.close_desktop_by_path(tmp_path / "algo.docx")
+
+
+def test_cierra_y_verifica_que_ya_no_este_abierto(monkeypatch, pbip):
+    """El exito no es "terminate no lanzo": es que el archivo ya no este abierto."""
+    estados = iter([4242, None])   # abierto antes; cerrado en la re-comprobacion
+    monkeypatch.setattr(dl, "proceso_con_archivo_abierto",
+                        lambda _p: next(estados))
+    monkeypatch.setattr(dl, "_process_started", lambda _pid: 123.0)
+    cerrados = {}
+
+    def _close(abierto, force=False):
+        cerrados.update(pid=abierto.desktop_pid, force=force,
+                        started=abierto.desktop_started)
+        return {"closed": True, "pid": abierto.desktop_pid,
+                "killed": 0, "children": 0, "survivors": []}
+
+    monkeypatch.setattr(dl, "close", _close)
+    r = dl.close_desktop_by_path(pbip)
+
+    assert cerrados == {"pid": 4242, "force": True, "started": 123.0}, (
+        "la identidad (hora de arranque) tiene que viajar hasta close()")
+    assert r["closed"] is True and r["was_open"] is True
+    assert r["verified_closed"] is True
+
+
+def test_si_el_archivo_sigue_abierto_no_se_miente(monkeypatch, pbip):
+    """Un superviviente -u otro proceso con el archivo- degrada el resultado."""
+    estados = iter([4242, 5555])   # tras "cerrar", OTRO pid lo tiene abierto
+    monkeypatch.setattr(dl, "proceso_con_archivo_abierto",
+                        lambda _p: next(estados))
+    monkeypatch.setattr(dl, "_process_started", lambda _pid: 123.0)
+    monkeypatch.setattr(dl, "close", lambda a, force=False: {
+        "closed": True, "pid": a.desktop_pid, "killed": 0,
+        "children": 0, "survivors": []})
+
+    r = dl.close_desktop_by_path(pbip)
+    assert r["verified_closed"] is False
+    assert r["closed"] is False, "decir 'cerrado' con el archivo abierto es mentir"
+    assert "5555" in r["reason"]

--- a/tests/test_rename_measure.py
+++ b/tests/test_rename_measure.py
@@ -1,0 +1,176 @@
+"""Renombrar una medida sin romper el informe (#9 del reporte de campo).
+
+El caso real: renombrar 8 medidas a nombres presentables obligo a reescribir el
+TMDL completo y re-aplicar la pagina entera, porque cualquier referencia vieja
+quedaba rota EN SILENCIO -el visual abre y sale vacio, sin error-.
+
+Lo delicado no es renombrar: es decidir QUE referencias tocar. `[x]` sin
+calificar dentro de una medida es una medida; dentro de una columna calculada
+es una COLUMNA de su propia tabla; y `Tabla[x]` calificado puede ser una
+columna homonima de otra tabla. Tocar de mas corrompe; tocar de menos en
+silencio deja visuales vacios. La regla: reescribir solo lo inequivoco, y
+DECIR lo que quedo fuera.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from horizun_pbi_mcp.pbip import pbir_reader, project_locator, tmdl_reader
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+from horizun_pbi_mcp.services import workflows
+from tests.fixtures import synthetic
+
+
+@pytest.fixture
+def proyecto(session, tmp_path, isolated_settings):
+    pbip = synthetic.materialize(tmp_path)
+    project_locator.open_project(session, str(pbip))
+    active = session.require_active_pbip()
+    modelo = tmdl_reader.read_semantic_model(active, strict=False)
+    return active, modelo, pbip.parent
+
+
+def _fact_tmdl(raiz: Path) -> str:
+    return (raiz / "Demo.SemanticModel" / "definition" / "tables"
+            / "Fact.tmdl").read_text(encoding="utf-8")
+
+
+# ------------------------------------------------------------------ plan ---
+def test_el_dry_run_lista_todo_lo_que_va_a_tocar(proyecto):
+    active, modelo, _ = proyecto
+    r = workflows.rename_measure(active, modelo, table="Fact",
+                                 old_name="TotalAmount",
+                                 new_name="Importe Total", dry_run=True)
+    assert r["applied"] is False
+    plan_modelo = next(e for e in r["stages"] if e["stage"] == "plan_modelo")
+    assert plan_modelo["result"]["dax_references"] == 2, (
+        "Ratio Pct referencia [TotalAmount] dos veces")
+    plan_informe = next(e for e in r["stages"] if e["stage"] == "plan_informe")
+    assert len(plan_informe["result"]["visuals"]) == 2, (
+        "los dos visuales plantilla del fixture la usan")
+
+
+def test_el_dry_run_no_escribe_nada(proyecto):
+    active, modelo, raiz = proyecto
+    antes = _fact_tmdl(raiz)
+    workflows.rename_measure(active, modelo, table="Fact",
+                             old_name="TotalAmount",
+                             new_name="Importe Total", dry_run=True)
+    assert _fact_tmdl(raiz) == antes
+
+
+# ----------------------------------------------------------------- apply ---
+def test_renombra_modelo_dax_y_visuales_en_una_pasada(proyecto):
+    active, modelo, raiz = proyecto
+    r = workflows.rename_measure(active, modelo, table="Fact",
+                                 old_name="TotalAmount",
+                                 new_name="Importe Total", dry_run=False)
+    assert r["applied"] is True
+
+    tmdl = _fact_tmdl(raiz)
+    assert "measure 'Importe Total' =" in tmdl, "la cabecera se renombro"
+    assert "[TotalAmount]" not in tmdl, "las refs DAX de Ratio Pct se movieron"
+    assert "[Importe Total]" in tmdl
+
+    visuales = pbir_reader.list_visuals(active, synthetic.PAGE_ID, strict=True)
+    refs = [m for v in visuales for m in v.get("measures", [])]
+    assert "Fact[Importe Total]" in refs, "el card apunta al nombre nuevo"
+    assert "Fact[TotalAmount]" not in refs
+
+    verif = next(e for e in r["stages"] if e["stage"] == "verificacion")
+    assert verif["result"]["renamed_verified"] is True
+    assert verif["result"]["leftover_references"] == []
+    assert not r.get("warnings")
+
+
+def test_el_renombrado_se_verifica_releyendo_no_se_supone(proyecto):
+    active, modelo, _ = proyecto
+    r = workflows.rename_measure(active, modelo, table="Fact",
+                                 old_name="TotalAmount",
+                                 new_name="Nuevo Nombre", dry_run=False)
+    releido = tmdl_reader.read_semantic_model(active, strict=False)
+    nombres = {m["name"] for m in releido["measures"]}
+    assert "Nuevo Nombre" in nombres and "TotalAmount" not in nombres
+
+
+# ----------------------------------------------- lo que NO se debe tocar ---
+def test_una_referencia_calificada_no_se_reescribe():
+    """`Tabla[x]` puede ser una columna homonima de otra tabla: no se adivina."""
+    texto = "x := Fact[TotalAmount] + 'Fact'[TotalAmount] + [TotalAmount]"
+    nuevo, n = workflows._reemplazar_ref_dax(texto, "TotalAmount", "Nuevo")
+    assert n == 1, "solo la forma sin calificar"
+    assert "Fact[TotalAmount]" in nuevo
+    assert "'Fact'[TotalAmount]" in nuevo
+    assert "[Nuevo]" in nuevo
+
+
+def test_los_bloques_de_columna_quedan_intactos(proyecto):
+    """En una columna calculada, `[x]` es una COLUMNA de su tabla. Se anade una
+    columna calculada que usa [Amount] y se renombra una medida 'Amount' de
+    OTRA tabla... no: el caso minimo es que el barrido de bloques NO incluya
+    columnas."""
+    lineas = [
+        "table T",
+        "",
+        "\tmeasure M1 = [Viejo] + 1",
+        "\t\tformatString: 0",
+        "",
+        "\tcolumn C1 = [Viejo] * 2",
+        "\t\tdataType: double",
+        "",
+    ]
+    bloques = workflows._bloques_de_medida(lineas)
+    assert [b["name"] for b in bloques] == ["M1"], (
+        "el bloque de la columna calculada no puede entrar al reemplazo")
+    assert all(2 <= b["start"] < b["end"] <= 5 for b in bloques)
+
+
+# ------------------------------------------------------------- colisiones ---
+def test_renombrar_a_una_medida_existente_falla(proyecto):
+    active, modelo, _ = proyecto
+    with pytest.raises(ValidationError) as exc:
+        workflows.rename_measure(active, modelo, table="Fact",
+                                 old_name="TotalAmount",
+                                 new_name="Ratio Pct", dry_run=True)
+    assert "unicos en" in str(exc.value)
+
+
+def test_renombrar_a_una_columna_de_la_misma_tabla_falla(proyecto):
+    """La leccion del preflight: se escribe bien y Desktop rechaza al ABRIR."""
+    active, modelo, _ = proyecto
+    with pytest.raises(ValidationError) as exc:
+        workflows.rename_measure(active, modelo, table="Fact",
+                                 old_name="TotalAmount",
+                                 new_name="Amount", dry_run=True)
+    assert "COLUMNA" in str(exc.value)
+
+
+def test_medida_inexistente_dice_las_disponibles(proyecto):
+    active, modelo, _ = proyecto
+    with pytest.raises(ValidationError) as exc:
+        workflows.rename_measure(active, modelo, table="Fact",
+                                 old_name="NoExiste", new_name="X",
+                                 dry_run=True)
+    assert "TotalAmount" in str(exc.value.details.get("available", []))
+
+
+# --------------------------------------------------- el barrido de restos ---
+def test_una_referencia_en_un_bookmark_sale_avisada_no_silenciada(proyecto):
+    active, modelo, raiz = proyecto
+    marcadores = (raiz / "Demo.Report" / "definition" / "bookmarks")
+    marcadores.mkdir(parents=True)
+    (marcadores / "b1.json").write_text(json.dumps({
+        "filtro": {"field": {"Measure": {
+            "Expression": {"SourceRef": {"Entity": "Fact"}},
+            "Property": "TotalAmount"}}}}), encoding="utf-8")
+
+    r = workflows.rename_measure(active, modelo, table="Fact",
+                                 old_name="TotalAmount",
+                                 new_name="Importe Total", dry_run=False)
+    assert any("bookmarks/b1.json" in a for a in r["warnings"]), (
+        "una referencia que no se toco tiene que salir con su ubicacion")
+    verif = next(e for e in r["stages"] if e["stage"] == "verificacion")
+    assert "bookmarks/b1.json" in verif["result"]["leftover_references"]

--- a/tests/test_tema_propio.py
+++ b/tests/test_tema_propio.py
@@ -1,0 +1,120 @@
+"""Tema completo del llamante, fuentes corporativas y sustitucion avisada.
+
+El caso real (#6 del reporte de campo): para poner tipografia corporativa habia
+que dejar que la tool escribiera su JSON y luego SOBRESCRIBIRLO a mano,
+confiando en que report.json siguiera apuntando al mismo archivo. Y el riesgo
+no avisado: una segunda llamada a pbi_apply_theme se comia esas ediciones en
+silencio.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from horizun_pbi_mcp.config import ActivePbip
+from horizun_pbi_mcp.pbip import pbip_scaffold, theme
+from horizun_pbi_mcp.pbip.theme import ThemeError
+from horizun_pbi_mcp.utils.json_utils import read_json
+
+
+# ------------------------------------------------------------ theme_json ---
+def test_un_tema_completo_se_respeta_tal_cual():
+    propio = {"name": "Corporativo", "dataColors": ["#111111", "#222222"],
+              "propiedadRara": {"loQueSea": 1}}
+    construido = theme.build_theme(theme_json=propio)
+    assert construido["dataColors"] == ["#111111", "#222222"]
+    assert construido["propiedadRara"] == {"loQueSea": 1}, (
+        "lo que los presets no conocen tiene que sobrevivir intacto")
+
+
+def test_theme_json_no_muta_el_objeto_del_llamante():
+    propio = {"name": "X", "dataColors": ["#111111"]}
+    theme.build_theme(theme_json=propio, fonts={"title": "Segoe UI"})
+    assert "textClasses" not in propio
+
+
+def test_theme_json_vacio_o_no_dict_se_rechaza():
+    with pytest.raises(ThemeError):
+        theme.build_theme(theme_json={})
+    with pytest.raises(ThemeError):
+        theme.build_theme(theme_json="no soy un dict")  # type: ignore[arg-type]
+
+
+def test_data_colors_se_aplican_encima_del_theme_json():
+    construido = theme.build_theme(theme_json={"name": "X"},
+                                   data_colors=["#ABCDEF"])
+    assert construido["dataColors"] == ["#ABCDEF"]
+
+
+# ----------------------------------------------------------------- fonts ---
+def test_las_fuentes_van_a_las_clases_de_texto_reales():
+    """'body' es la clase 'label' en el esquema de temas: la traduccion es
+    nuestra responsabilidad, no del usuario."""
+    construido = theme.build_theme(preset=sorted(theme.PRESETS)[0],
+                                   fonts={"title": "Georgia",
+                                          "body": "Segoe UI",
+                                          "callout": "Arial Black"})
+    clases = construido["textClasses"]
+    assert clases["title"]["fontFace"] == "Georgia"
+    assert clases["label"]["fontFace"] == "Segoe UI"
+    assert clases["callout"]["fontFace"] == "Arial Black"
+
+
+def test_una_clase_de_fuente_desconocida_falla_con_las_validas():
+    with pytest.raises(ThemeError) as exc:
+        theme.build_theme(fonts={"subtitulo": "Arial"})
+    assert "body" in str(exc.value)
+
+
+def test_una_fuente_vacia_se_rechaza():
+    with pytest.raises(ThemeError):
+        theme.build_theme(fonts={"title": "   "})
+
+
+def test_fonts_sobre_un_preset_no_pierde_el_resto_del_tema():
+    base = theme.build_theme(preset=sorted(theme.PRESETS)[0])
+    con_fuente = theme.build_theme(preset=sorted(theme.PRESETS)[0],
+                                   fonts={"title": "Georgia"})
+    assert con_fuente["dataColors"] == base["dataColors"]
+
+
+# ----------------------------------------------- sustitucion con aviso ---
+@pytest.fixture
+def proyecto(tmp_path, session, isolated_settings):
+    r = pbip_scaffold.crear_proyecto(tmp_path, "Tema")
+    activo = ActivePbip(
+        pbip_path=str(Path(r["project_dir"]) / "Tema.pbip"),
+        project_dir=r["project_dir"], report_dir=r["report_dir"],
+        semantic_model_dir=r["semantic_model_dir"], report_name="Tema",
+        has_pbir=True, has_tmdl=True)
+    session.set_active_pbip(activo)
+    return activo
+
+
+def test_reaplicar_el_mismo_tema_no_avisa(proyecto):
+    tema = theme.build_theme(preset=sorted(theme.PRESETS)[0])
+    theme.apply_theme(proyecto, dict(tema))
+    salida = theme.apply_theme(proyecto, dict(tema))
+    assert "warnings" not in salida, (
+        "reaplicar identico no debe gritar: no se pierde nada")
+
+
+def test_sustituir_un_tema_editado_a_mano_avisa_y_donde_recuperarlo(proyecto):
+    """El riesgo real: las ediciones manuales se perdian en silencio."""
+    primero = theme.apply_theme(
+        proyecto, theme.build_theme(preset=sorted(theme.PRESETS)[0]))
+    # alguien edita el JSON a mano (tipografia corporativa, un color...)
+    archivo = Path(primero["file"])
+    editado = read_json(archivo)
+    editado["textClasses"] = {"title": {"fontFace": "Fuente Corporativa"}}
+    archivo.write_text(__import__("json").dumps(editado), encoding="utf-8")
+
+    segundo = theme.apply_theme(
+        proyecto, theme.build_theme(preset=sorted(theme.PRESETS)[-1]))
+
+    assert any("DISTINTO" in a for a in segundo.get("warnings", [])), (
+        "sustituir un tema con contenido distinto tiene que avisarse")
+    assert any("backup" in a or "recuperala" in a
+               for a in segundo["warnings"]), (
+        "el aviso debe decir DONDE esta la version anterior")

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -176,11 +176,22 @@ CICLO_TOOLS = [
     "pbi_open_and_refresh",
 ]
 
+#: Renombrar a mano rompia el informe en silencio: visual abierto y vacio.
+REFACTOR_TOOLS = [
+    "pbi_rename_measure",
+]
+
+#: La salida que faltaba del ciclo editar-abrir-mirar-editar.
+CIERRE_TOOLS = [
+    "pbi_close_desktop",
+]
+
 TOOLS_NUEVAS = (MACROFASE_A_TOOLS + MACROFASE_B_TOOLS + MACROFASE_C_TOOLS
                 + MACROFASE_D_TOOLS + MACROFASE_E_TOOLS + MACROFASE_F_TOOLS
                 + FASE_F_R5_TOOLS + CONVERSION_TOOLS + THEME_TOOLS
                 + VERIFICACION_TOOLS + CARGA_TOOLS + DISENO_TOOLS
-                + FILTRO_VISUAL_TOOLS + CICLO_TOOLS)
+                + FILTRO_VISUAL_TOOLS + CICLO_TOOLS + REFACTOR_TOOLS
+                + CIERRE_TOOLS)
 BASELINE_COUNT = 34
 EXPECTED_COUNT = BASELINE_COUNT + len(TOOLS_NUEVAS)
 


### PR DESCRIPTION
## What

Version **1.1.1**: the fourteen-item field report is now **fully closed**. Two new tools (121 total), zero breaking changes.

- **`theme_json` + `fonts`** on `pbi_apply_theme` — full caller themes written as-is, corporate typography via `textClasses`, and a warning (with recovery pointer) when replacing a hand-edited theme that used to be silently destroyed.
- **`pbi_rename_measure`** — TMDL header, DAX refs and report visuals in ONE transaction, verified by re-reading. Rewrites only what is unambiguous (unqualified refs, inside measure blocks only); everything else comes back in `warnings` with its location. Refuses collisions that pass the write and kill Desktop at open.
- **`pbi_close_desktop`** — the missing exit of the edit-open-look cycle. Identity-verified (name + start time), `confirm`-gated, and `verified_closed` re-checks the file is actually no longer open.
- `docs/BACKLOG.md` brought current; the `pbi_apply_plan` question is **decided** (the `plan_token` is the explicit approval).

## Verification

- 1744 tests passed, 3 skipped; contract check exit 0 (additive only); `doctor.py` exit 0.
- All eight behavioral paths mutation-verified: reverting each fails a named test.

**Merging does not publish.** The `v1.1.1` tag (separate step) triggers PyPI + MCP Registry — this release also replaces the PyPI sdist that still carries the client name inside `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
