### PR TITLE
Intent brief: what the dashboard is FOR, answered by its owner

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,4 +1,4 @@
-# Tool catalog — 121
+# Tool catalog — 123
 
 Generated from the contract frozen in `tests/golden/tools_v1.json`.
 The **34 baseline** tools keep their name, parameters, types, defaults and response shape since version 0.1.0.
@@ -29,7 +29,8 @@ tools registered.
 | M — work cycle | 1 |
 | N — refactoring | 1 |
 | O — session exit | 1 |
-| **Total** | **121** |
+| P — intent brief | 2 |
+| **Total** | **123** |
 
 ---
 
@@ -177,6 +178,8 @@ Close two gaps of the same kind: having the pieces isn't the same as knowing how
 | Tool | What it does |
 |---|---|
 | `pbi_start_here` | Looks at the real state and gives the next steps, with the reason for each |
+| `pbi_define_brief` | Writes the intent brief (`pbi-brief.json` next to the .pbip): what the dashboard is FOR, answered by the human. Proposals, design system and the guide consume it |
+| `pbi_get_brief` | Reads the brief, or returns the questions to ask the user when it doesn't exist |
 | `pbi_list_design_systems` | Available systems: each one decides theme, canvas, grid and text scale all at once |
 | `pbi_apply_design_system` | Applies the system and returns the grid, to place things by hand on the same guides |
 | `pbi_compose_page` | Composes an entire page on the grid from intent |

--- a/src/horizun_pbi_mcp/services/brief.py
+++ b/src/horizun_pbi_mcp/services/brief.py
@@ -1,0 +1,184 @@
+"""El brief de intencion: para que existe este tablero, dicho por su dueño.
+
+La pieza que faltaba un nivel por encima de todas las tools: el usuario sabe
+para que quiere el tablero y no habia donde ponerlo. Sin ese dato, la
+propuesta se deduce solo del modelo, el sistema de diseño se elige a ciegas y
+una auditoria puede decir "hay 12 hallazgos" pero nunca "esto no cumple lo que
+dijiste que querias".
+
+Decisiones de diseño (tomadas con el usuario, 2026-08-03):
+
+- **Vive como artefacto versionado DENTRO del proyecto** (`pbi-brief.json`,
+  junto al `.pbip`): sobrevive a la sesion, viaja con el repositorio, y el
+  tablero lleva dentro su porque. No en memoria del servidor ni en un
+  servicio externo.
+- **Las respuestas son del humano.** El agente PREGUNTA -para que es, quien
+  lo mira, que decisiones sostiene- y escribe lo que le contesten. Un brief
+  inventado por el agente es peor que ninguno: fija en un archivo con
+  autoridad lo que nadie dijo.
+- **Los consumidores son la razon de ser**: la guia lo enseña, la propuesta lo
+  adjunta y el sistema de diseño se recomienda desde `delivery`. Un brief que
+  nada lee es un formulario, no una herramienta.
+"""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from horizun_pbi_mcp.logging_config import get_logger
+from horizun_pbi_mcp.powerbi.errors import PowerBIMCPError, ValidationError
+
+log = get_logger("brief")
+
+#: Nombre del artefacto, junto al .pbip. FUERA de .Report/.SemanticModel a
+#: proposito: esos arboles los reescribe Power BI Desktop al guardar, y un
+#: archivo ajeno alli puede desaparecer sin aviso. La raiz del proyecto es del
+#: usuario (y de su git); Desktop no la toca.
+BRIEF_FILENAME = "pbi-brief.json"
+
+SCHEMA_VERSION = "1.0"
+
+#: Como se va a ver el tablero. Decide el sistema de diseño recomendado:
+#: no es una preferencia estetica, es legibilidad fisica (a que distancia se
+#: lee) — la misma razon por la que existen los tres sistemas.
+DELIVERY = ("pantalla_sala", "escritorio", "lectura_pdf", "movil")
+
+_DELIVERY_A_SISTEMA = {
+    "pantalla_sala": ("sala", "se lee a metros y con luz baja: lienzo "
+                      "1920x1080 y tipografia grande"),
+    "escritorio": ("informe", "se lee de cerca en pantalla: lienzo 1280x720 "
+                   "y tipografia de lectura"),
+    "lectura_pdf": ("informe", "se exporta y se lee de cerca: el sistema de "
+                    "lectura es el que aguanta la impresion"),
+    "movil": ("informe", "no hay sistema de lienzo movil todavia: 'informe' "
+              "es el que menos sufre reescalado — limite conocido, no "
+              "una recomendacion entusiasta"),
+}
+
+
+class BriefError(PowerBIMCPError):
+    code = "brief_error"
+
+
+def brief_path(active) -> Path:
+    return Path(active.project_dir) / BRIEF_FILENAME
+
+
+# ------------------------------------------------------------- validacion ---
+def _lista_de_textos(valor: Any, campo: str, obligatoria: bool = False) -> List[str]:
+    if valor is None:
+        if obligatoria:
+            raise ValidationError(f"El brief necesita '{campo}'.")
+        return []
+    if isinstance(valor, str):
+        valor = [valor]
+    if (not isinstance(valor, list)
+            or any(not isinstance(x, str) or not x.strip() for x in valor)):
+        raise ValidationError(
+            f"'{campo}' debe ser una lista de textos no vacios.")
+    return [x.strip() for x in valor]
+
+
+def validate_brief(datos: Dict[str, Any]) -> Dict[str, Any]:
+    """Normaliza y valida. Devuelve el brief canonico que se escribira."""
+    if not isinstance(datos, dict):
+        raise ValidationError("El brief debe ser un objeto.")
+
+    proposito = str(datos.get("purpose") or "").strip()
+    if not proposito:
+        raise ValidationError(
+            "El brief necesita 'purpose': para que existe este tablero. Si no "
+            "lo sabes, PREGUNTALO — un proposito inventado por el agente fija "
+            "con autoridad lo que nadie dijo.")
+    audiencia = str(datos.get("audience") or "").strip()
+    if not audiencia:
+        raise ValidationError(
+            "El brief necesita 'audience': quien lo va a mirar. Cambia el "
+            "sistema de diseño, el nivel de detalle y que es 'grave'.")
+
+    entrega = datos.get("delivery")
+    if entrega is not None:
+        entrega = str(entrega).strip().casefold()
+        if entrega not in DELIVERY:
+            raise ValidationError(
+                f"delivery '{datos.get('delivery')}' no existe. Opciones: "
+                f"{list(DELIVERY)}.")
+
+    criticos: List[Dict[str, Any]] = []
+    for i, c in enumerate(datos.get("critical_fields") or []):
+        if not isinstance(c, dict) or not str(c.get("field") or "").strip():
+            raise ValidationError(
+                f"critical_fields[{i}] necesita 'field' (Tabla[Campo] o "
+                "[Medida]).")
+        entrada = {"field": str(c["field"]).strip(),
+                   "why": str(c.get("why") or "").strip()}
+        for lim in ("min", "max"):
+            if c.get(lim) is not None:
+                if not isinstance(c[lim], (int, float)):
+                    raise ValidationError(
+                        f"critical_fields[{i}].{lim} debe ser numerico.")
+                entrada[lim] = c[lim]
+        criticos.append(entrada)
+
+    canonico: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "purpose": proposito,
+        "audience": audiencia,
+        "decisions": _lista_de_textos(datos.get("decisions"), "decisions"),
+        "key_questions": _lista_de_textos(datos.get("key_questions"),
+                                          "key_questions"),
+        "non_goals": _lista_de_textos(datos.get("non_goals"), "non_goals"),
+        "updated": date.today().isoformat(),
+    }
+    if entrega:
+        canonico["delivery"] = entrega
+    if datos.get("update_cadence"):
+        canonico["update_cadence"] = str(datos["update_cadence"]).strip()
+    if criticos:
+        canonico["critical_fields"] = criticos
+    return canonico
+
+
+# ------------------------------------------------------------ lectura/uso ---
+def read_brief(active) -> Optional[Dict[str, Any]]:
+    """El brief del proyecto, o None si no se ha definido. Nunca lanza por
+    ausencia; SI lanza por un brief corrupto -callarselo seria peor-."""
+    ruta = brief_path(active)
+    if not ruta.exists():
+        return None
+    from horizun_pbi_mcp.utils.json_utils import read_json
+
+    datos = read_json(ruta)
+    if not isinstance(datos, dict) or not datos.get("purpose"):
+        raise BriefError(
+            f"El brief en {BRIEF_FILENAME} existe pero no tiene 'purpose': "
+            "esta corrupto o editado a mano. Re-defínelo con pbi_define_brief.")
+    return datos
+
+
+def recommended_system(brief: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
+    """Sistema de diseño recomendado por el brief, con su motivo fisico."""
+    if not brief or not brief.get("delivery"):
+        return None
+    sistema, motivo = _DELIVERY_A_SISTEMA[brief["delivery"]]
+    return {"system": sistema, "why": motivo, "from_delivery": brief["delivery"]}
+
+
+def write_brief(active, datos: Dict[str, Any]) -> Dict[str, Any]:
+    """Valida y escribe el brief, transaccionado como todo lo del proyecto."""
+    from horizun_pbi_mcp.services import txn as txn_service
+
+    canonico = validate_brief(datos)
+    ruta = brief_path(active)
+    existia = ruta.exists()
+    cm = txn_service.project_transaction(active, [ruta],
+                                         tool="pbi_define_brief")
+    with cm as tx:
+        tx.write_json(ruta, canonico)
+    log.info("Brief %s: %s", "actualizado" if existia else "creado",
+             canonico["purpose"][:60])
+    return {"brief": canonico, "path": str(ruta),
+            "created": not existia, "updated": existia,
+            "recommended_design_system": recommended_system(canonico),
+            "transaction": cm.result}

--- a/src/horizun_pbi_mcp/services/guide.py
+++ b/src/horizun_pbi_mcp/services/guide.py
@@ -149,6 +149,16 @@ def situacion(session) -> Dict[str, Any]:
     informe = (_contar_informe(active) if active.has_pbir
                else {"pages": None, "visuals": None})
 
+    # El brief es el techo de todo lo demas: si existe, cada paso sirve a un
+    # proposito dicho por el dueño; si no, se sugiere definirlo ANTES de
+    # construir. Nunca lanza aqui: la guia es un diagnostico.
+    try:
+        from horizun_pbi_mcp.services import brief as brief_service
+
+        el_brief = brief_service.read_brief(active)
+    except Exception:                                    # noqa: BLE001
+        el_brief = None
+
     proyecto = {
         "path": active.pbip_path,
         "name": active.report_name,
@@ -159,10 +169,21 @@ def situacion(session) -> Dict[str, Any]:
         "pages": informe["pages"],
         "visuals": informe["visuals"],
         "desktop": estado.to_dict(),
+        "brief": ({"purpose": el_brief.get("purpose"),
+                   "audience": el_brief.get("audience")}
+                  if el_brief else None),
     }
 
     pasos: List[Dict[str, Any]] = []
     frases: List[str] = [f"Proyecto activo: {Path(active.pbip_path).name}."]
+    if el_brief:
+        frases.append(f"Proposito declarado: {el_brief['purpose']}")
+    else:
+        pasos.append(_paso(
+            "pbi_get_brief",
+            "El tablero no tiene brief de intencion: nadie ha dicho PARA QUE "
+            "existe. Pregunta al usuario y definelo antes de construir; la "
+            "propuesta y el sistema de diseño lo leen."))
 
     # --- lo que BLOQUEA va primero: no tiene sentido sugerir algo imposible --
     if estado.state == project_state.OPEN:

--- a/src/horizun_pbi_mcp/services/proposals.py
+++ b/src/horizun_pbi_mcp/services/proposals.py
@@ -214,8 +214,16 @@ def _proponer_tendencia(c: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 
 
 def propose(model_data: Optional[Dict[str, Any]],
-            theme_presets: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
-    """Propuestas de paginas y de tema, deducidas de lo que el modelo tiene."""
+            theme_presets: Optional[List[Dict[str, Any]]] = None,
+            brief: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Propuestas de paginas y de tema, deducidas de lo que el modelo tiene.
+
+    Con `brief`, las propuestas ya no son huerfanas: se adjuntan el proposito
+    y las preguntas clave DEL DUEÑO para que quien elija lo haga contra eso, y
+    el sistema de diseño recomendado sale de `delivery`. No se finge
+    alineacion semantica -emparejar preguntas con specs por palabras seria
+    adivinar-; se pone la vara al lado de cada propuesta y se deja juzgar.
+    """
     if not model_data:
         return {"proposals": [], "reason": "No hay modelo cargado que analizar."}
 
@@ -235,7 +243,29 @@ def propose(model_data: Optional[Dict[str, Any]],
             faltantes.extend(p.get("needs") or [])
 
     log.info("Propuestas generadas: %s", len(propuestas))
+    salida_brief: Dict[str, Any] = {}
+    if brief:
+        from horizun_pbi_mcp.services import brief as brief_service
+
+        salida_brief = {
+            "brief": {"purpose": brief.get("purpose"),
+                      "audience": brief.get("audience"),
+                      "key_questions": brief.get("key_questions") or [],
+                      "non_goals": brief.get("non_goals") or []},
+            "judge_against": ("Cada propuesta debe responder alguna de "
+                              "key_questions y ninguna caer en non_goals; "
+                              "descarta las que no."),
+            "recommended_design_system":
+                brief_service.recommended_system(brief),
+        }
+    else:
+        salida_brief = {"brief": None,
+                        "hint": ("No hay brief de intencion: estas propuestas "
+                                 "se deducen SOLO del modelo. Define uno con "
+                                 "pbi_define_brief para proponer con "
+                                 "proposito.")}
     return {
+        **salida_brief,
         "proposals": propuestas,
         "detected": {k: len(v) for k, v in clasificacion.items() if k != "families"},
         "families": clasificacion["families"],

--- a/src/horizun_pbi_mcp/tools/design_tools.py
+++ b/src/horizun_pbi_mcp/tools/design_tools.py
@@ -55,8 +55,21 @@ def register(mcp) -> None:
         recolocarlo todo.
         """
         def _impl():
-            return {"systems": design.list_systems(),
-                    "default": "informe"}
+            salida = {"systems": design.list_systems(),
+                      "default": "informe"}
+            # Si hay brief con `delivery`, la eleccion deja de ser a ciegas:
+            # el sistema es legibilidad fisica y el brief dice donde se lee.
+            try:
+                from horizun_pbi_mcp.services import brief as brief_service
+
+                el_brief = brief_service.read_brief(
+                    get_session().require_active_pbip())
+                rec = brief_service.recommended_system(el_brief)
+                if rec:
+                    salida["recommended_by_brief"] = rec
+            except Exception:                            # noqa: BLE001
+                pass
+            return salida
         return guard(_impl)
 
     @mcp.tool()
@@ -152,3 +165,76 @@ def register(mcp) -> None:
                     **{k: v for k, v in resultado.items() if k != "warnings"}}
 
         return guard(_impl) if dry_run else guard_mutation(_impl)
+
+    @mcp.tool()
+    def pbi_define_brief(purpose: str, audience: str,
+                         decisions: Optional[List[str]] = None,
+                         key_questions: Optional[List[str]] = None,
+                         delivery: Optional[str] = None,
+                         update_cadence: Optional[str] = None,
+                         critical_fields: Optional[List[Dict[str, Any]]] = None,
+                         non_goals: Optional[List[str]] = None,
+                         request_id: str = "") -> Dict[str, Any]:
+        """Escribe el BRIEF DE INTENCION del tablero: para que existe.
+
+        Es la pieza que gobierna a las demas: la propuesta de paginas, el
+        sistema de diseño y las auditorias leen este artefacto para servir a
+        un proposito en vez de deducirlo todo del modelo.
+
+        **Las respuestas son del HUMANO, no tuyas.** Antes de llamar, pregunta
+        en conversacion: ¿para que quieres este tablero? ¿quien lo va a mirar?
+        ¿que decisiones debe sostener? ¿como se va a ver (sala, escritorio,
+        PDF, movil)? Un brief inventado por el agente es peor que ninguno:
+        fija en un archivo con autoridad lo que nadie dijo.
+
+        `delivery`: pantalla_sala | escritorio | lectura_pdf | movil — decide
+        el sistema de diseño recomendado (legibilidad fisica, no estetica).
+        `critical_fields`: [{field, why, min?, max?}] — que campos son
+        criticos y sus umbrales; los usara el diagnostico de datos.
+
+        Se guarda como `pbi-brief.json` JUNTO al .pbip (fuera de .Report/
+        .SemanticModel, que Desktop reescribe al guardar): versionado con el
+        proyecto y editable en cualquier momento. Reescribirlo es normal:
+        los tableros cambian de proposito.
+        """
+        from horizun_pbi_mcp.services import brief as brief_service
+
+        def _impl():
+            active = get_session().require_active_pbip()
+            return brief_service.write_brief(active, {
+                "purpose": purpose, "audience": audience,
+                "decisions": decisions, "key_questions": key_questions,
+                "delivery": delivery, "update_cadence": update_cadence,
+                "critical_fields": critical_fields, "non_goals": non_goals,
+            })
+        return guard_mutation(_impl)
+
+    @mcp.tool()
+    def pbi_get_brief(request_id: str = "") -> Dict[str, Any]:
+        """Lee el brief de intencion del proyecto activo.
+
+        Devuelve `defined: false` si no existe —con las preguntas que hay que
+        hacerle al usuario para definirlo—, o el brief completo y el sistema
+        de diseño que recomienda. Consultalo ANTES de proponer paginas o
+        elegir sistema: es la diferencia entre servir al proposito del
+        tablero y deducirlo todo del modelo.
+        """
+        from horizun_pbi_mcp.services import brief as brief_service
+
+        def _impl():
+            active = get_session().require_active_pbip()
+            datos = brief_service.read_brief(active)
+            if datos is None:
+                return {"defined": False,
+                        "questions_for_the_user": [
+                            "¿Para que quieres este tablero? (purpose)",
+                            "¿Quien lo va a mirar? (audience)",
+                            "¿Que decisiones debe sostener? (decisions)",
+                            "¿Que preguntas debe responder? (key_questions)",
+                            "¿Como se vera: sala, escritorio, PDF o movil? "
+                            "(delivery)"],
+                        "define_with": "pbi_define_brief"}
+            return {"defined": True, "brief": datos,
+                    "recommended_design_system":
+                        brief_service.recommended_system(datos)}
+        return guard(_impl)

--- a/src/horizun_pbi_mcp/tools/page_tools.py
+++ b/src/horizun_pbi_mcp/tools/page_tools.py
@@ -65,9 +65,22 @@ def register(mcp) -> None:
         Usalo para ofrecer opciones al usuario en vez de decidir por el.
         """
         from horizun_pbi_mcp.pbip import theme
+        from horizun_pbi_mcp.services import brief as brief_service
         from horizun_pbi_mcp.services import proposals
 
-        return guard(lambda: proposals.propose(_model_data(), theme.list_presets()))
+        def _impl():
+            # El brief manda sobre la deduccion: si existe, cada propuesta
+            # viaja con el proposito del dueño al lado para juzgarla contra
+            # eso. Su ausencia tambien se dice: proponer sin proposito es
+            # legitimo, pero no debe parecer lo mismo.
+            try:
+                el_brief = brief_service.read_brief(
+                    get_session().require_active_pbip())
+            except Exception:                            # noqa: BLE001
+                el_brief = None
+            return proposals.propose(_model_data(), theme.list_presets(),
+                                     brief=el_brief)
+        return guard(_impl)
 
     @mcp.tool()
     def pbi_page_building_blocks() -> Dict[str, Any]:

--- a/src/horizun_pbi_mcp/tools/risk.py
+++ b/src/horizun_pbi_mcp/tools/risk.py
@@ -118,6 +118,7 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_report_capabilities": READ_ONLY,
     "pbi_search_model": READ_ONLY,
     "pbi_session_info": READ_ONLY,
+    "pbi_get_brief": READ_ONLY,
     "pbi_start_here": READ_ONLY,
     "pbi_test_connection": READ_ONLY,
     "pbi_validate_generated_page": READ_ONLY,
@@ -147,6 +148,8 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_add_table_from_file": WRITE_REVERSIBLE,
     "pbi_align_visuals": WRITE_REVERSIBLE,
     "pbi_apply_design_system": WRITE_REVERSIBLE,
+    # El brief es un artefacto del proyecto, con journal como todo.
+    "pbi_define_brief": WRITE_REVERSIBLE,
     "pbi_apply_page_spec": WRITE_REVERSIBLE,
     "pbi_apply_theme": WRITE_REVERSIBLE,
     "pbi_arrange_visuals": WRITE_REVERSIBLE,

--- a/tests/golden/tools_v1.json
+++ b/tests/golden/tools_v1.json
@@ -1,6 +1,6 @@
 {
   "contract_version": 1,
-  "tool_count": 121,
+  "tool_count": 123,
   "tools": [
     {
       "name": "pbi_add_custom_visual",
@@ -1709,6 +1709,74 @@
       }
     },
     {
+      "name": "pbi_define_brief",
+      "description": "Escribe el BRIEF DE INTENCION del tablero: para que existe.\n\nEs la pieza que gobierna a las demas: la propuesta de paginas, el\nsistema de diseño y las auditorias leen este artefacto para servir a\nun proposito en vez de deducirlo todo del modelo.\n\n**Las respuestas son del HUMANO, no tuyas.** Antes de llamar, pregunta\nen conversacion: ¿para que quieres este tablero? ¿quien lo va a mirar?\n¿que decisiones debe sostener? ¿como se va a ver (sala, escritorio,\nPDF, movil)? Un brief inventado por el agente es peor que ninguno:\nfija en un archivo con autoridad lo que nadie dijo.\n\n`delivery`: pantalla_sala | escritorio | lectura_pdf | movil — decide\nel sistema de diseño recomendado (legibilidad fisica, no estetica).\n`critical_fields`: [{field, why, min?, max?}] — que campos son\ncriticos y sus umbrales; los usara el diagnostico de datos.\n\nSe guarda como `pbi-brief.json` JUNTO al .pbip (fuera de .Report/\n.SemanticModel, que Desktop reescribe al guardar): versionado con el\nproyecto y editable en cualquier momento. Reescribirlo es normal:\nlos tableros cambian de proposito.",
+      "params": {
+        "audience": {
+          "required": true,
+          "type": "string"
+        },
+        "critical_fields": {
+          "required": false,
+          "type": "array[object]|null",
+          "default": null
+        },
+        "decisions": {
+          "required": false,
+          "type": "array[string]|null",
+          "default": null
+        },
+        "delivery": {
+          "required": false,
+          "type": "null|string",
+          "default": null
+        },
+        "key_questions": {
+          "required": false,
+          "type": "array[string]|null",
+          "default": null
+        },
+        "non_goals": {
+          "required": false,
+          "type": "array[string]|null",
+          "default": null
+        },
+        "purpose": {
+          "required": true,
+          "type": "string"
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "update_cadence": {
+          "required": false,
+          "type": "null|string",
+          "default": null
+        }
+      },
+      "required": [
+        "audience",
+        "purpose"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      }
+    },
+    {
       "name": "pbi_delete_bookmark",
       "description": "Borra un marcador y lo quita del indice. Destructiva: confirm=true.",
       "params": {
@@ -2306,6 +2374,31 @@
         "idempotentHint": false,
         "openWorldHint": false,
         "readOnlyHint": false
+      }
+    },
+    {
+      "name": "pbi_get_brief",
+      "description": "Lee el brief de intencion del proyecto activo.\n\nDevuelve `defined: false` si no existe —con las preguntas que hay que\nhacerle al usuario para definirlo—, o el brief completo y el sistema\nde diseño que recomienda. Consultalo ANTES de proponer paginas o\nelegir sistema: es la diferencia entre servir al proposito del\ntablero y deducirlo todo del modelo.",
+      "params": {
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
       }
     },
     {

--- a/tests/test_brief_de_intencion.py
+++ b/tests/test_brief_de_intencion.py
@@ -1,0 +1,170 @@
+"""El brief de intencion: para que existe el tablero, y quien lo consume.
+
+La pieza un nivel por encima de todas las tools: el usuario sabe para que
+quiere el tablero y no habia donde ponerlo. Las reglas que se vigilan:
+
+1. **Vive junto al .pbip**, fuera de `.Report/`/`.SemanticModel/` — esos
+   arboles los reescribe Desktop al guardar y un archivo ajeno alli puede
+   desaparecer sin aviso.
+2. **Sin proposito no hay brief.** El error lo dice con la instruccion de
+   PREGUNTAR: un brief inventado por el agente fija con autoridad lo que
+   nadie dijo.
+3. **Los consumidores existen de verdad.** Un brief que nada lee es un
+   formulario. La guia lo enseña, la propuesta lo adjunta con la vara para
+   juzgar, y el sistema de diseño se recomienda desde `delivery`.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from horizun_pbi_mcp.pbip import project_locator
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+from horizun_pbi_mcp.services import brief as brief_service
+from horizun_pbi_mcp.services import guide, proposals
+from tests.fixtures import synthetic
+
+
+@pytest.fixture
+def proyecto(session, tmp_path, isolated_settings):
+    pbip = synthetic.materialize(tmp_path)
+    project_locator.open_project(session, str(pbip))
+    return session.require_active_pbip(), session
+
+
+def _brief_minimo(**extra):
+    base = {"purpose": "Controlar el costo semanal de la obra",
+            "audience": "Direccion de proyecto"}
+    base.update(extra)
+    return base
+
+
+# ---------------------------------------------------------- donde vive ---
+def test_el_brief_vive_junto_al_pbip_no_dentro_del_report(proyecto):
+    active, _ = proyecto
+    r = brief_service.write_brief(active, _brief_minimo())
+    ruta = Path(r["path"])
+    assert ruta.parent == Path(active.project_dir)
+    assert ".Report" not in ruta.parts and ".SemanticModel" not in ruta.parts, (
+        "Desktop reescribe esos arboles al guardar: el brief moriria alli")
+    assert ruta.name == "pbi-brief.json"
+
+
+def test_escribir_y_releer_es_idempotente_en_contenido(proyecto):
+    active, _ = proyecto
+    brief_service.write_brief(active, _brief_minimo(
+        key_questions=["¿Vamos dentro del presupuesto?"],
+        delivery="pantalla_sala"))
+    leido = brief_service.read_brief(active)
+    assert leido["purpose"] == "Controlar el costo semanal de la obra"
+    assert leido["key_questions"] == ["¿Vamos dentro del presupuesto?"]
+    assert leido["delivery"] == "pantalla_sala"
+
+
+def test_reescribir_actualiza_y_lo_dice(proyecto):
+    active, _ = proyecto
+    r1 = brief_service.write_brief(active, _brief_minimo())
+    r2 = brief_service.write_brief(active, _brief_minimo(
+        purpose="Reporte mensual para el cliente"))
+    assert r1["created"] is True and r2["updated"] is True
+    assert brief_service.read_brief(active)["purpose"] == (
+        "Reporte mensual para el cliente")
+
+
+# ------------------------------------------------------- validacion dura ---
+def test_sin_proposito_el_error_manda_preguntar():
+    with pytest.raises(ValidationError) as exc:
+        brief_service.validate_brief({"audience": "alguien"})
+    assert "PREGUNTALO" in str(exc.value), (
+        "el error debe empujar a preguntar al humano, no a inventar")
+
+
+def test_sin_audiencia_tampoco_hay_brief():
+    with pytest.raises(ValidationError):
+        brief_service.validate_brief({"purpose": "algo"})
+
+
+def test_delivery_desconocido_lista_las_opciones():
+    with pytest.raises(ValidationError) as exc:
+        brief_service.validate_brief(_brief_minimo(delivery="holograma"))
+    assert "pantalla_sala" in str(exc.value)
+
+
+def test_umbral_no_numerico_se_rechaza():
+    with pytest.raises(ValidationError):
+        brief_service.validate_brief(_brief_minimo(
+            critical_fields=[{"field": "[CPI]", "min": "cero"}]))
+
+
+def test_un_brief_corrupto_no_se_calla(proyecto):
+    active, _ = proyecto
+    brief_service.brief_path(active).write_text('{"cosa": 1}', encoding="utf-8")
+    with pytest.raises(brief_service.BriefError):
+        brief_service.read_brief(active)
+
+
+# ----------------------------------------- delivery -> sistema de diseño ---
+@pytest.mark.parametrize("delivery,sistema", [
+    ("pantalla_sala", "sala"),
+    ("escritorio", "informe"),
+    ("lectura_pdf", "informe"),
+    ("movil", "informe"),
+])
+def test_la_recomendacion_es_legibilidad_fisica(delivery, sistema):
+    rec = brief_service.recommended_system(
+        brief_service.validate_brief(_brief_minimo(delivery=delivery)))
+    assert rec["system"] == sistema
+    assert rec["why"], "una recomendacion sin motivo es una orden"
+
+
+def test_sin_delivery_no_se_recomienda_nada():
+    rec = brief_service.recommended_system(
+        brief_service.validate_brief(_brief_minimo()))
+    assert rec is None, "recomendar sin saber donde se lee seria adivinar"
+
+
+# ----------------------------------------------------- los consumidores ---
+def test_la_guia_enseña_el_proposito_cuando_existe(proyecto):
+    active, session = proyecto
+    brief_service.write_brief(active, _brief_minimo())
+    s = guide.situacion(session)
+    assert s["project"]["brief"]["purpose"] == (
+        "Controlar el costo semanal de la obra")
+    assert "Proposito declarado" in s["situation"]
+
+
+def test_la_guia_sugiere_definirlo_cuando_falta(proyecto):
+    _active, session = proyecto
+    s = guide.situacion(session)
+    assert s["project"]["brief"] is None
+    assert any(p["tool"] == "pbi_get_brief" for p in s["next_steps"]), (
+        "sin brief, el primer hueco es no saber para que es el tablero")
+
+
+def test_la_propuesta_adjunta_la_vara_del_dueño(proyecto):
+    active, _ = proyecto
+    from horizun_pbi_mcp.pbip import tmdl_reader
+
+    modelo = tmdl_reader.read_semantic_model(active, strict=False)
+    el_brief = brief_service.validate_brief(_brief_minimo(
+        key_questions=["¿Vamos dentro del presupuesto?"],
+        non_goals=["Detalle por factura"],
+        delivery="pantalla_sala"))
+    salida = proposals.propose(modelo, brief=el_brief)
+    assert salida["brief"]["key_questions"] == ["¿Vamos dentro del presupuesto?"]
+    assert salida["brief"]["non_goals"] == ["Detalle por factura"]
+    assert salida["recommended_design_system"]["system"] == "sala"
+    assert "judge_against" in salida
+
+
+def test_la_propuesta_sin_brief_lo_dice_no_lo_disimula(proyecto):
+    active, _ = proyecto
+    from horizun_pbi_mcp.pbip import tmdl_reader
+
+    modelo = tmdl_reader.read_semantic_model(active, strict=False)
+    salida = proposals.propose(modelo, brief=None)
+    assert salida["brief"] is None
+    assert "pbi_define_brief" in salida["hint"], (
+        "proponer sin proposito es legitimo, pero no debe parecer lo mismo")

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -186,12 +186,18 @@ CIERRE_TOOLS = [
     "pbi_close_desktop",
 ]
 
+#: El brief de intencion: para que existe el tablero, dicho por su dueño.
+BRIEF_TOOLS = [
+    "pbi_define_brief",
+    "pbi_get_brief",
+]
+
 TOOLS_NUEVAS = (MACROFASE_A_TOOLS + MACROFASE_B_TOOLS + MACROFASE_C_TOOLS
                 + MACROFASE_D_TOOLS + MACROFASE_E_TOOLS + MACROFASE_F_TOOLS
                 + FASE_F_R5_TOOLS + CONVERSION_TOOLS + THEME_TOOLS
                 + VERIFICACION_TOOLS + CARGA_TOOLS + DISENO_TOOLS
                 + FILTRO_VISUAL_TOOLS + CICLO_TOOLS + REFACTOR_TOOLS
-                + CIERRE_TOOLS)
+                + CIERRE_TOOLS + BRIEF_TOOLS)
 BASELINE_COUNT = 34
 EXPECTED_COUNT = BASELINE_COUNT + len(TOOLS_NUEVAS)
 


### PR DESCRIPTION
## What

The first piece of the product vision, built on the decision already taken with the owner: the brief lives as a **versioned artifact inside the project** (`pbi-brief.json`, next to the `.pbip` — deliberately outside `.Report`/`.SemanticModel`, which Desktop rewrites on save).

Two new tools (123 total):

- **`pbi_define_brief`** — purpose, audience, decisions it must support, key questions, delivery (`pantalla_sala|escritorio|lectura_pdf|movil`), cadence, critical fields with thresholds, non-goals. The hard rule is in both validation and docstring: **the answers belong to the human**. An empty purpose errors with an instruction to ASK, not invent — an agent-invented brief authoritatively records what nobody said.
- **`pbi_get_brief`** — reads it, or returns the questions to ask the user when it doesn't exist.

And the consumers — the whole point; a brief nothing reads is a form:

- `pbi_start_here` shows the declared purpose; when missing, the project's first gap is *not knowing what it's for*.
- `pbi_propose_dashboard` attaches the owner's purpose, key questions and non-goals as the yardstick next to each proposal. No fake semantic alignment — keyword-matching questions to specs would be guessing; the yardstick is placed beside, judgment stays with the caller.
- `pbi_list_design_systems` recommends a system from `delivery` — physical legibility, not aesthetics. `movil` recommends `informe` while declaring the limitation.
- `critical_fields` thresholds are the ready-made input for phase 2 (content-level data diagnostics).

## Verification

- 17 new tests; 4/4 mutation-verified (guide ignoring the brief, proposal losing the yardstick, recommendation ignoring delivery, optional purpose — each reverted fix fails a named test).
- Full suite: 1761 passed, 3 skipped; contract: 2 additive tools, 0 breaks; `doctor.py` exit 0.

No version bump — rides in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
