### PR TITLE
Phases 3 & 4: external sources with the truth up front, and the ecosystem port as a data contract

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,4 +1,4 @@
-# Tool catalog — 124
+# Tool catalog — 127
 
 Generated from the contract frozen in `tests/golden/tools_v1.json`.
 The **34 baseline** tools keep their name, parameters, types, defaults and response shape since version 0.1.0.
@@ -31,7 +31,9 @@ tools registered.
 | O — session exit | 1 |
 | P — intent brief | 2 |
 | Q — data diagnostics | 1 |
-| **Total** | **124** |
+| R — external sources | 1 |
+| S — ecosystem port | 2 |
+| **Total** | **127** |
 
 ---
 
@@ -120,6 +122,8 @@ tools registered.
 |---|---|
 | `pbi_propose_dashboard` | Classifies the model and proposes complete designs, with their reasoning |
 | `pbi_profile_data` | Profiles the VALUES: out-of-range percentages, empty columns |
+| `pbi_add_table_from_source` | Table from SQL Server / PostgreSQL / OData / Web JSON. Columns are declared (no credentials ⇒ no schema read, and columns are never invented); the response always states that the first refresh needs a human in Desktop |
+| `pbi_define_port_contract` · `pbi_check_contract` | The ecosystem port as a DATA CONTRACT (not an API bus): datasets with a shared key, validated against incoming files (structure) and against the live model — returns the port keys ready as `critical_fields` for the brief |
 | `pbi_diagnose_data` | Content-level checks on the LIVE model: orphan keys, duplicated grain, calendar gaps, and the brief's critical-field thresholds — every finding carries its DAX proof and sample culprits |
 
 ## Report authoring (PBIR)

--- a/src/horizun_pbi_mcp/pbip/table_from_source.py
+++ b/src/horizun_pbi_mcp/pbip/table_from_source.py
@@ -1,0 +1,225 @@
+"""Tablas desde bases de datos y APIs: el M es lo facil; la verdad, primero.
+
+Fase 3 de la vision. La trampa que esta escrita en el roadmap desde el dia
+uno: generar el M para SQL Server u OData son cuatro lineas; lo que duele son
+las CREDENCIALES y los niveles de privacidad, que viven en la interfaz de
+Power BI Desktop y NO se guardan en el `.pbip`. Este modulo no finge lo
+contrario:
+
+- Escribe la consulta M y el TMDL correctos, transaccionados y validados como
+  todo lo demas.
+- Dice en la respuesta, siempre, que el PRIMER refresh lo hara una persona en
+  Desktop: autenticarse y elegir nivel de privacidad no es automatizable
+  desde aqui, y prometerlo seria mentir.
+- No conecta a la fuente ni infiere el esquema: sin credenciales no se puede,
+  asi que las columnas las declara el llamante -que conoce su base- y se
+  validan contra el conjunto de tipos TMDL. Inventar columnas esta prohibido
+  por la regla 5 de la casa.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from horizun_pbi_mcp.logging_config import get_logger
+from horizun_pbi_mcp.powerbi.errors import PowerBIMCPError, ValidationError
+from horizun_pbi_mcp.pbip.table_from_file import _literal_m, _tmdl_nombre
+
+log = get_logger("table_from_source")
+
+
+class TableFromSourceError(PowerBIMCPError):
+    code = "table_from_source_error"
+
+
+#: Tipos TMDL admitidos para columnas declaradas, y su tipo M para APIs.
+_TIPOS = {"string": "type text", "int64": "Int64.Type",
+          "double": "type number", "decimal": "Currency.Type",
+          "dateTime": "type datetime", "boolean": "type logical"}
+
+SOURCES = ("sqlserver", "postgresql", "odata", "web_json")
+
+#: El aviso que viaja SIEMPRE. Las credenciales no estan en el .pbip: estan en
+#: el almacen de Desktop, por usuario y por maquina.
+AVISO_CREDENCIALES = (
+    "La consulta quedo escrita, pero el PRIMER refresh lo completa una "
+    "persona en Power BI Desktop: pedira credenciales de la fuente y nivel "
+    "de privacidad, y ambos viven en Desktop (no en el .pbip). Hasta "
+    "entonces la tabla existe sin datos, y este servidor no puede verificar "
+    "la conexion.")
+
+
+def _validar_columnas(columns: Any) -> List[Dict[str, str]]:
+    if not isinstance(columns, list) or not columns:
+        raise ValidationError(
+            "Declara 'columns' ([{name, type}]): sin credenciales no se puede "
+            "leer el esquema de la fuente, y las columnas no se inventan. "
+            f"Tipos: {sorted(_TIPOS)}.")
+    salida = []
+    vistos = set()
+    for i, c in enumerate(columns):
+        if not isinstance(c, dict) or not str(c.get("name") or "").strip():
+            raise ValidationError(f"columns[{i}] necesita 'name'.")
+        tipo = str(c.get("type") or "string")
+        if tipo not in _TIPOS:
+            raise ValidationError(
+                f"columns[{i}].type '{tipo}' no es un tipo TMDL. "
+                f"Usa uno de: {sorted(_TIPOS)}.")
+        nombre = str(c["name"]).strip()
+        if nombre.casefold() in vistos:
+            raise ValidationError(f"Columna duplicada: '{nombre}'.")
+        vistos.add(nombre.casefold())
+        salida.append({"name": nombre, "data_type": tipo})
+    return salida
+
+
+# ------------------------------------------------------------ consultas M ---
+def _m_sqlserver(server: str, database: str, schema: str, source_table: str,
+                 native_query: Optional[str]) -> str:
+    origen = (f"    Origen = Sql.Database({_literal_m(server)}, "
+              f"{_literal_m(database)}),")
+    if native_query:
+        # EnableFolding=true: si el motor no puede plegar la consulta, que lo
+        # diga en el refresh en vez de traerse la tabla entera y filtrar local.
+        datos = (f"    Datos = Value.NativeQuery(Origen, "
+                 f"{_literal_m(native_query)}, null, [EnableFolding = true])")
+    else:
+        datos = (f"    Datos = Origen{{[Schema = {_literal_m(schema)}, "
+                 f"Item = {_literal_m(source_table)}]}}[Data]")
+    return f"let\n{origen}\n{datos}\nin\n    Datos"
+
+
+def _m_postgresql(server: str, database: str, schema: str,
+                  source_table: str) -> str:
+    return ("let\n"
+            f"    Origen = PostgreSQL.Database({_literal_m(server)}, "
+            f"{_literal_m(database)}),\n"
+            f"    Datos = Origen{{[Schema = {_literal_m(schema)}, "
+            f"Item = {_literal_m(source_table)}]}}[Data]\n"
+            "in\n    Datos")
+
+
+def _m_odata(url: str) -> str:
+    # La URL debe apuntar al ENTITY SET (…/odata/Presupuestos), no a la raiz
+    # del servicio: asi OData.Feed devuelve directamente la tabla.
+    return ("let\n"
+            f"    Origen = OData.Feed({_literal_m(url)}, null, "
+            "[Implementation = \"2.0\"])\n"
+            "in\n    Origen")
+
+
+def _m_web_json(url: str, json_path: Optional[List[str]],
+                columnas: List[Dict[str, str]]) -> str:
+    descenso = "".join(f"[{p}]" for p in (json_path or []))
+    tipos = ", ".join(
+        f"{{{_literal_m(c['name'])}, {_TIPOS[c['data_type']]}}}"
+        for c in columnas)
+    # La cultura va FIJA a en-US: el JSON escribe numeros sin cultura (punto
+    # decimal siempre), y dejar la del sistema es el bug del 10527.52 que se
+    # vuelve diez millones. Aqui no hay nada que deducir: es el estandar JSON.
+    return ("let\n"
+            f"    Origen = Json.Document(Web.Contents({_literal_m(url)})),\n"
+            f"    Registros = Origen{descenso},\n"
+            "    Tabla = Table.FromRecords(Registros),\n"
+            f"    #\"Tipo cambiado\" = Table.TransformColumnTypes(Tabla, "
+            f"{{{tipos}}}, \"en-US\")\n"
+            "in\n    #\"Tipo cambiado\"")
+
+
+# ------------------------------------------------------------------- TMDL ---
+def _tmdl(nombre: str, columnas: List[Dict[str, str]], consulta_m: str,
+          description: Optional[str]) -> str:
+    lineas: List[str] = []
+    if description:
+        lineas += [f"/// {l.strip()}" for l in str(description).splitlines()]
+    lineas.append(f"table {_tmdl_nombre(nombre)}")
+    lineas.append(f"\tlineageTag: {uuid.uuid4()}")
+    lineas.append("")
+    for c in columnas:
+        tipo = c["data_type"]
+        lineas.append(f"\tcolumn {_tmdl_nombre(c['name'])}")
+        lineas.append(f"\t\tdataType: {tipo}")
+        if tipo in ("int64", "double", "decimal"):
+            lineas.append("\t\tformatString: " + ("0" if tipo == "int64" else "0.00"))
+        elif tipo == "dateTime":
+            lineas.append("\t\tformatString: Short Date")
+        lineas.append(f"\t\tlineageTag: {uuid.uuid4()}")
+        lineas.append("\t\tsummarizeBy: " +
+                      ("sum" if tipo in ("int64", "double", "decimal") else "none"))
+        lineas.append(f"\t\tsourceColumn: {c['name']}")
+        lineas.append("")
+    lineas.append(f"\tpartition {_tmdl_nombre(nombre)} = m")
+    lineas.append("\t\tmode: import")
+    lineas.append("\t\tsource =")
+    lineas += ["\t\t\t\t" + l for l in consulta_m.split("\n")]
+    lineas.append("")
+    lineas.append("\tannotation PBI_ResultType = Table")
+    lineas.append("")
+    return "\n".join(lineas)
+
+
+# --------------------------------------------------------------- entrada ---
+def agregar_tabla_desde_fuente(
+        active: Any, source: str, table_name: str,
+        columns: List[Dict[str, Any]],
+        server: str = "", database: str = "", schema: str = "dbo",
+        source_table: str = "", url: str = "",
+        native_query: Optional[str] = None,
+        json_path: Optional[List[str]] = None,
+        description: Optional[str] = None,
+        overwrite: bool = False, dry_run: bool = False) -> Dict[str, Any]:
+    """Crea la tabla (TMDL + particion M) apuntando a una fuente externa."""
+    from horizun_pbi_mcp.pbip.model_author import ModelAuthorError, resolver_destino_tabla
+    from horizun_pbi_mcp.utils.validation import validate_object_name
+
+    fuente = str(source).strip().casefold()
+    if fuente not in SOURCES:
+        raise ValidationError(
+            f"Fuente '{source}' no soportada. Opciones: {list(SOURCES)}.")
+    columnas = _validar_columnas(columns)
+    nombre = validate_object_name(table_name, "tabla")
+
+    if fuente in ("sqlserver", "postgresql"):
+        if not server or not database:
+            raise ValidationError(
+                f"'{fuente}' necesita 'server' y 'database'.")
+        if not native_query and not source_table:
+            raise ValidationError(
+                "Indica 'source_table' (con 'schema', defecto dbo) o una "
+                "'native_query'.")
+        if fuente == "postgresql" and native_query:
+            raise ValidationError(
+                "native_query solo esta soportada en sqlserver por ahora; "
+                "para PostgreSQL usa 'source_table'.")
+        consulta = (_m_sqlserver(server, database, schema, source_table,
+                                 native_query)
+                    if fuente == "sqlserver"
+                    else _m_postgresql(server, database, schema, source_table))
+    else:
+        if not url:
+            raise ValidationError(f"'{fuente}' necesita 'url'.")
+        if not url.casefold().startswith(("https://", "http://")):
+            raise ValidationError("La 'url' debe ser http(s).")
+        consulta = (_m_odata(url) if fuente == "odata"
+                    else _m_web_json(url, json_path, columnas))
+
+    texto = _tmdl(nombre, columnas, consulta, description)
+    resumen: Dict[str, Any] = {
+        "table": nombre, "source": fuente,
+        "columns": columnas, "column_count": len(columnas),
+        "warnings": [AVISO_CREDENCIALES],
+    }
+    if dry_run:
+        return {**resumen, "dry_run": True, "tmdl": texto, "m": consulta}
+
+    try:
+        destino = resolver_destino_tabla(active, nombre, overwrite)
+    except ModelAuthorError as exc:
+        raise TableFromSourceError(exc.message, details=exc.details) from exc
+
+    from horizun_pbi_mcp.pbip.model_author import escribir_tabla_y_registrarla
+
+    salida = escribir_tabla_y_registrarla(
+        active, destino, texto.split("\n"), nombre,
+        "pbi_add_table_from_source")
+    return {**resumen, **salida}

--- a/src/horizun_pbi_mcp/services/port_contract.py
+++ b/src/horizun_pbi_mcp/services/port_contract.py
@@ -1,0 +1,243 @@
+"""El puerto del ecosistema: un CONTRATO de datos, no un bus de APIs.
+
+Fase 4 de la vision, con la decision de arquitectura ya tomada (2026-08-03):
+Revit, Navisworks y Project NO se conectan en vivo entre si -cuatro
+aplicaciones de escritorio encadenadas por APIs es fragil de una forma que no
+se arregla-. Lo que ya funciona en los proyectos reales es una LLAVE
+SEMANTICA compartida (`HRZ_COD_PRES`): cada herramienta EMITE un dataset
+normalizado y este MCP lo consume.
+
+El puerto es entonces un documento: que datasets existen, con que columnas y
+tipos, y cual es la llave de cada uno. Vive versionado junto al `.pbip`
+(`pbi-port-contract.json`), igual que el brief, y este modulo hace las dos
+mitades del apreton de manos:
+
+- **Validar un archivo entrante** (el export de Revit/Navisworks/Project)
+  ANTES de cargarlo: columnas que faltan, tipos que no cuadran, llave
+  ausente. Estructural y honesto: lo que exige leer los datos completos
+  (llaves duplicadas, huerfanas) es trabajo de `pbi_diagnose_data` con la
+  tabla ya cargada, y la respuesta lo dice en vez de fingir que lo comprobo.
+- **Validar el modelo activo** contra el contrato: que cada dataset este como
+  tabla, con sus columnas y tipos. Y regalar la integracion que cierra el
+  circulo: las llaves del contrato, listas como `critical_fields` para el
+  brief -asi el diagnostico las trata como criticas sin teclearlas dos veces-.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from horizun_pbi_mcp.logging_config import get_logger
+from horizun_pbi_mcp.powerbi.errors import PowerBIMCPError, ValidationError
+
+log = get_logger("port_contract")
+
+CONTRACT_FILENAME = "pbi-port-contract.json"
+SCHEMA_VERSION = "1.0"
+
+_TIPOS = ("string", "int64", "double", "decimal", "dateTime", "boolean")
+
+#: Compatibilidad de tipo INFERIDO del archivo -> tipo DECLARADO en contrato.
+#: `int64` satisface `double`/`decimal` (todo entero es un decimal valido);
+#: al reves NO: un double en una columna declarada int64 es perdida de datos.
+_COMPATIBLES = {
+    ("int64", "double"), ("int64", "decimal"), ("int64", "int64"),
+    ("double", "double"), ("double", "decimal"), ("decimal", "decimal"),
+    ("decimal", "double"), ("string", "string"), ("boolean", "boolean"),
+    ("dateTime", "dateTime"),
+}
+
+
+class ContractError(PowerBIMCPError):
+    code = "port_contract_error"
+
+
+def contract_path(active) -> Path:
+    return Path(active.project_dir) / CONTRACT_FILENAME
+
+
+# ------------------------------------------------------------- validacion ---
+def validate_contract(datos: Dict[str, Any]) -> Dict[str, Any]:
+    """Normaliza y valida el contrato. Devuelve la forma canonica."""
+    if not isinstance(datos, dict):
+        raise ValidationError("El contrato debe ser un objeto.")
+    datasets = datos.get("datasets")
+    if not isinstance(datasets, list) or not datasets:
+        raise ValidationError(
+            "El contrato necesita 'datasets': [{name, key, columns}]. Cada "
+            "herramienta del ecosistema emite uno y esa lista es el puerto.")
+
+    canonicos: List[Dict[str, Any]] = []
+    nombres = set()
+    for i, d in enumerate(datasets):
+        base = f"datasets[{i}]"
+        if not isinstance(d, dict) or not str(d.get("name") or "").strip():
+            raise ValidationError(f"{base} necesita 'name'.")
+        nombre = str(d["name"]).strip()
+        if nombre.casefold() in nombres:
+            raise ValidationError(f"Dataset duplicado: '{nombre}'.")
+        nombres.add(nombre.casefold())
+
+        columnas = d.get("columns")
+        if not isinstance(columnas, list) or not columnas:
+            raise ValidationError(f"{base} necesita 'columns' [{{name,type}}].")
+        cols_canon, vistos = [], set()
+        for j, c in enumerate(columnas):
+            if not isinstance(c, dict) or not str(c.get("name") or "").strip():
+                raise ValidationError(f"{base}.columns[{j}] necesita 'name'.")
+            tipo = str(c.get("type") or "string")
+            if tipo not in _TIPOS:
+                raise ValidationError(
+                    f"{base}.columns[{j}].type '{tipo}' no es un tipo TMDL. "
+                    f"Usa: {list(_TIPOS)}.")
+            cn = str(c["name"]).strip()
+            if cn.casefold() in vistos:
+                raise ValidationError(f"{base}: columna duplicada '{cn}'.")
+            vistos.add(cn.casefold())
+            entrada = {"name": cn, "type": tipo}
+            if c.get("required"):
+                entrada["required"] = True
+            cols_canon.append(entrada)
+
+        llave = d.get("key")
+        llaves = [llave] if isinstance(llave, str) else list(llave or [])
+        for k in llaves:
+            if str(k).casefold() not in vistos:
+                raise ValidationError(
+                    f"{base}: la llave '{k}' no esta entre sus columnas.")
+        if not llaves:
+            raise ValidationError(
+                f"{base} necesita 'key': sin llave no hay contrato -es lo que "
+                "permite cruzar los datasets del ecosistema entre si-.")
+
+        canon = {"name": nombre, "key": llaves, "columns": cols_canon}
+        if d.get("emitted_by"):
+            canon["emitted_by"] = str(d["emitted_by"]).strip()
+        if d.get("description"):
+            canon["description"] = str(d["description"]).strip()
+        canonicos.append(canon)
+
+    salida = {"schema_version": SCHEMA_VERSION, "datasets": canonicos}
+    if datos.get("name"):
+        salida["name"] = str(datos["name"]).strip()
+    return salida
+
+
+def read_contract(active) -> Optional[Dict[str, Any]]:
+    ruta = contract_path(active)
+    if not ruta.exists():
+        return None
+    from horizun_pbi_mcp.utils.json_utils import read_json
+
+    datos = read_json(ruta)
+    return validate_contract(datos)
+
+
+def write_contract(active, datos: Dict[str, Any]) -> Dict[str, Any]:
+    from horizun_pbi_mcp.services import txn as txn_service
+
+    canonico = validate_contract(datos)
+    ruta = contract_path(active)
+    existia = ruta.exists()
+    cm = txn_service.project_transaction(active, [ruta],
+                                         tool="pbi_define_port_contract")
+    with cm as tx:
+        tx.write_json(ruta, canonico)
+    return {"contract": canonico, "path": str(ruta),
+            "created": not existia, "updated": existia,
+            "transaction": cm.result}
+
+
+# -------------------------------------------------------------- chequeos ---
+def _dataset(contrato: Dict[str, Any], nombre: str) -> Dict[str, Any]:
+    for d in contrato["datasets"]:
+        if d["name"].casefold() == str(nombre).casefold():
+            return d
+    raise ValidationError(
+        f"El contrato no tiene el dataset '{nombre}'. Tiene: "
+        f"{[d['name'] for d in contrato['datasets']]}.")
+
+
+def check_file(contrato: Dict[str, Any], dataset: str,
+               source_path: str) -> Dict[str, Any]:
+    """Un archivo entrante contra su dataset del contrato. ESTRUCTURAL."""
+    from horizun_pbi_mcp.pbip.table_from_file import perfilar
+
+    spec = _dataset(contrato, dataset)
+    perfil = perfilar(source_path)
+    inferidas = {c["name"].casefold(): c["data_type"]
+                 for c in perfil["columns"]}
+    declaradas = {c["name"].casefold(): c for c in spec["columns"]}
+
+    faltan = [c["name"] for c in spec["columns"]
+              if c["name"].casefold() not in inferidas]
+    extras = [c["name"] for c in perfil["columns"]
+              if c["name"].casefold() not in declaradas]
+    tipos_mal = []
+    for c in spec["columns"]:
+        inf = inferidas.get(c["name"].casefold())
+        if inf is None:
+            continue
+        if (inf, c["type"]) not in _COMPATIBLES:
+            tipos_mal.append({"column": c["name"], "declared": c["type"],
+                              "inferred": inf})
+    llaves_ausentes = [k for k in spec["key"]
+                       if str(k).casefold() not in inferidas]
+
+    conforme = not faltan and not tipos_mal and not llaves_ausentes
+    return {
+        "dataset": spec["name"], "source": str(source_path),
+        "conformant": conforme,
+        "missing_columns": faltan,
+        "extra_columns": extras,       # informativo: extra no rompe el puerto
+        "type_mismatches": tipos_mal,
+        "missing_keys": llaves_ausentes,
+        "checked": "structure (columns, types, keys present)",
+        "not_checked": ("key uniqueness/blanks and referential integrity "
+                        "need the FULL data: load the table and run "
+                        "pbi_diagnose_data. This check reads structure only "
+                        "and saying otherwise would be pretending."),
+    }
+
+
+def check_model(contrato: Dict[str, Any],
+                model_data: Dict[str, Any]) -> Dict[str, Any]:
+    """El modelo activo contra el contrato, y el regalo del circulo cerrado:
+    las llaves del contrato como `critical_fields` listos para el brief."""
+    tablas = {str(t.get("name", "")).casefold(): t
+              for t in model_data.get("tables") or []}
+    resultados = []
+    for spec in contrato["datasets"]:
+        t = tablas.get(spec["name"].casefold())
+        if t is None:
+            resultados.append({"dataset": spec["name"], "present": False,
+                               "missing_columns": [c["name"]
+                                                   for c in spec["columns"]]})
+            continue
+        cols = {str(c.get("name", "")).casefold(): str(c.get("data_type") or "")
+                for c in t.get("columns") or []}
+        faltan = [c["name"] for c in spec["columns"]
+                  if c["name"].casefold() not in cols]
+        tipos_mal = [{"column": c["name"], "declared": c["type"],
+                      "model": cols[c["name"].casefold()]}
+                     for c in spec["columns"]
+                     if c["name"].casefold() in cols
+                     and (cols[c["name"].casefold()], c["type"]) not in _COMPATIBLES
+                     and cols[c["name"].casefold()] != c["type"]]
+        resultados.append({"dataset": spec["name"], "present": True,
+                           "missing_columns": faltan,
+                           "type_mismatches": tipos_mal})
+
+    sugeridos = [{"field": f"{d['name']}[{k}]",
+                  "why": f"llave del puerto ({d['name']})"}
+                 for d in contrato["datasets"] for k in d["key"]]
+    conforme = all(r.get("present") and not r.get("missing_columns")
+                   and not r.get("type_mismatches") for r in resultados)
+    return {
+        "conformant": conforme,
+        "datasets": resultados,
+        "suggested_critical_fields": sugeridos,
+        "next": ("Pass suggested_critical_fields to pbi_define_brief and run "
+                 "pbi_diagnose_data: the port keys become owner-critical and "
+                 "orphan/duplicate findings on them escalate to error."),
+    }

--- a/src/horizun_pbi_mcp/tools/audit_tools.py
+++ b/src/horizun_pbi_mcp/tools/audit_tools.py
@@ -201,3 +201,74 @@ def register(mcp) -> None:
             return data_diagnose.diagnose(session, modelo, brief=el_brief,
                                           tables=tables)
         return guard(_impl)
+
+    @mcp.tool()
+    def pbi_define_port_contract(datasets: List[Dict[str, Any]],
+                                 name: str = "",
+                                 request_id: str = "") -> Dict[str, Any]:
+        """Escribe el CONTRATO del puerto del ecosistema (pbi-port-contract.json).
+
+        El puerto NO es un bus de APIs entre Revit/Navisworks/Project —eso es
+        fragil sin arreglo—: es un contrato de datos. Cada herramienta EMITE
+        un dataset normalizado con una llave compartida, y este MCP lo valida
+        y lo consume.
+
+        `datasets`: [{name, key, columns: [{name, type, required?}],
+        emitted_by?, description?}]. La llave es obligatoria: es lo que
+        permite cruzar los datasets entre si (p.ej. HRZ_COD_PRES entre el
+        modelo BIM, el presupuesto y el cronograma).
+
+        Vive versionado junto al .pbip, como el brief. Se valida con
+        pbi_check_contract: archivos entrantes antes de cargar, y el modelo
+        activo despues.
+        """
+        from horizun_pbi_mcp.services import port_contract
+
+        def _impl():
+            active = get_session().require_active_pbip()
+            datos: Dict[str, Any] = {"datasets": datasets}
+            if name:
+                datos["name"] = name
+            return port_contract.write_contract(active, datos)
+        return guard_mutation(_impl)
+
+    @mcp.tool()
+    def pbi_check_contract(source_path: str = "", dataset: str = "",
+                           request_id: str = "") -> Dict[str, Any]:
+        """Valida contra el contrato del puerto: un archivo entrante o el modelo.
+
+        Con `source_path` (+ `dataset`): el export de Revit/Navisworks/Project
+        ANTES de cargarlo — columnas que faltan, tipos incompatibles, llave
+        ausente. Chequeo ESTRUCTURAL y honesto: unicidad y huerfanas de la
+        llave exigen los datos completos, y eso es pbi_diagnose_data con la
+        tabla ya cargada; la respuesta lo dice en `not_checked`.
+
+        Sin `source_path`: el MODELO activo contra el contrato entero, y el
+        circulo que cierra todo: `suggested_critical_fields` — las llaves del
+        puerto listas para pbi_define_brief, de modo que el diagnostico las
+        trate como criticas del dueño sin teclearlas dos veces.
+        """
+        from horizun_pbi_mcp.services import port_contract
+
+        def _impl():
+            active = get_session().require_active_pbip()
+            contrato = port_contract.read_contract(active)
+            if contrato is None:
+                return {"defined": False,
+                        "define_with": "pbi_define_port_contract",
+                        "hint": ("No hay pbi-port-contract.json en el "
+                                 "proyecto: el puerto aun no tiene contrato.")}
+            if source_path:
+                if not dataset:
+                    raise ValidationError(
+                        "Con source_path indica tambien 'dataset': contra "
+                        "cual spec del contrato se valida el archivo.")
+                return {"defined": True,
+                        **port_contract.check_file(contrato, dataset,
+                                                   source_path)}
+            from horizun_pbi_mcp.pbip import tmdl_reader
+
+            modelo = tmdl_reader.read_semantic_model(active, strict=False)
+            return {"defined": True,
+                    **port_contract.check_model(contrato, modelo)}
+        return guard(_impl)

--- a/src/horizun_pbi_mcp/tools/model_edit_tools.py
+++ b/src/horizun_pbi_mcp/tools/model_edit_tools.py
@@ -481,3 +481,47 @@ def register(mcp) -> None:
             return model_edit.set_auto_datetime_pbip(
                 session.require_active_pbip(), enabled)
         return guard_mutation(_impl)
+
+    @mcp.tool()
+    def pbi_add_table_from_source(source: str, table_name: str,
+                                  columns: List[Dict[str, Any]],
+                                  server: str = "", database: str = "",
+                                  schema: str = "dbo", source_table: str = "",
+                                  url: str = "",
+                                  native_query: Optional[str] = None,
+                                  json_path: Optional[List[str]] = None,
+                                  description: str = "",
+                                  overwrite: bool = False,
+                                  dry_run: bool = False,
+                                  request_id: str = "") -> Dict[str, Any]:
+        """Crea una tabla apuntando a una BASE DE DATOS o API externa.
+
+        `source`: sqlserver | postgresql | odata | web_json.
+        - sqlserver/postgresql: `server` + `database` + (`schema`/`source_table`
+          o, solo en sqlserver, `native_query` con plegado activado).
+        - odata: `url` del ENTITY SET (…/odata/Presupuestos), no la raiz.
+        - web_json: `url` que devuelve un array de objetos; `json_path`
+          desciende hasta el (["data","rows"]). Tipado con cultura en-US fija:
+          JSON escribe numeros sin cultura, y la del sistema es el bug del
+          10527.52 que se vuelve diez millones.
+
+        `columns` ([{name, type}]) es OBLIGATORIO: sin credenciales no se
+        puede leer el esquema de la fuente, y las columnas no se inventan.
+
+        **La verdad de las credenciales, por delante**: la consulta queda
+        escrita y validada, pero el PRIMER refresh lo completa una persona en
+        Desktop —pedira credenciales y nivel de privacidad, que viven en
+        Desktop, no en el .pbip—. Hasta entonces la tabla existe sin datos y
+        este servidor no puede verificar la conexion. Prometer otra cosa
+        seria mentir.
+
+        Escribe TMDL: requiere el proyecto CERRADO en Desktop.
+        """
+        from horizun_pbi_mcp.pbip import table_from_source
+
+        return guard_mutation(lambda: table_from_source.agregar_tabla_desde_fuente(
+            _proyecto_activo(), source, table_name, columns,
+            server=server, database=database, schema=schema,
+            source_table=source_table, url=url, native_query=native_query,
+            json_path=json_path, description=description or None,
+            overwrite=overwrite, dry_run=dry_run))

--- a/src/horizun_pbi_mcp/tools/risk.py
+++ b/src/horizun_pbi_mcp/tools/risk.py
@@ -81,6 +81,7 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_detect_layout_issues": READ_ONLY,
     # DAX de solo lectura contra el modelo vivo; sin ficheros.
     "pbi_diagnose_data": READ_ONLY,
+    "pbi_check_contract": READ_ONLY,
     "pbi_diff_page_spec": READ_ONLY,
     "pbi_generate_page_spec": READ_ONLY,
     "pbi_get_object": READ_ONLY,
@@ -148,6 +149,9 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_add_custom_visual": WRITE_REVERSIBLE,
     "pbi_add_image_resource": WRITE_REVERSIBLE,
     "pbi_add_table_from_file": WRITE_REVERSIBLE,
+    "pbi_add_table_from_source": WRITE_REVERSIBLE,
+    # El contrato del puerto es un artefacto del proyecto.
+    "pbi_define_port_contract": WRITE_REVERSIBLE,
     "pbi_align_visuals": WRITE_REVERSIBLE,
     "pbi_apply_design_system": WRITE_REVERSIBLE,
     # El brief es un artefacto del proyecto, con journal como todo.

--- a/tests/golden/tools_v1.json
+++ b/tests/golden/tools_v1.json
@@ -1,6 +1,6 @@
 {
   "contract_version": 1,
-  "tool_count": 124,
+  "tool_count": 127,
   "tools": [
     {
       "name": "pbi_add_custom_visual",
@@ -133,6 +133,99 @@
       },
       "required": [
         "path"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      }
+    },
+    {
+      "name": "pbi_add_table_from_source",
+      "description": "Crea una tabla apuntando a una BASE DE DATOS o API externa.\n\n`source`: sqlserver | postgresql | odata | web_json.\n- sqlserver/postgresql: `server` + `database` + (`schema`/`source_table`\n  o, solo en sqlserver, `native_query` con plegado activado).\n- odata: `url` del ENTITY SET (…/odata/Presupuestos), no la raiz.\n- web_json: `url` que devuelve un array de objetos; `json_path`\n  desciende hasta el ([\"data\",\"rows\"]). Tipado con cultura en-US fija:\n  JSON escribe numeros sin cultura, y la del sistema es el bug del\n  10527.52 que se vuelve diez millones.\n\n`columns` ([{name, type}]) es OBLIGATORIO: sin credenciales no se\npuede leer el esquema de la fuente, y las columnas no se inventan.\n\n**La verdad de las credenciales, por delante**: la consulta queda\nescrita y validada, pero el PRIMER refresh lo completa una persona en\nDesktop —pedira credenciales y nivel de privacidad, que viven en\nDesktop, no en el .pbip—. Hasta entonces la tabla existe sin datos y\neste servidor no puede verificar la conexion. Prometer otra cosa\nseria mentir.\n\nEscribe TMDL: requiere el proyecto CERRADO en Desktop.",
+      "params": {
+        "columns": {
+          "required": true,
+          "type": "array[object]"
+        },
+        "database": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "description": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "dry_run": {
+          "required": false,
+          "type": "boolean",
+          "default": false
+        },
+        "json_path": {
+          "required": false,
+          "type": "array[string]|null",
+          "default": null
+        },
+        "native_query": {
+          "required": false,
+          "type": "null|string",
+          "default": null
+        },
+        "overwrite": {
+          "required": false,
+          "type": "boolean",
+          "default": false
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "schema": {
+          "required": false,
+          "type": "string",
+          "default": "dbo"
+        },
+        "server": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "source": {
+          "required": true,
+          "type": "string"
+        },
+        "source_table": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "table_name": {
+          "required": true,
+          "type": "string"
+        },
+        "url": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "columns",
+        "source",
+        "table_name"
       ],
       "output_shape": {
         "type": "object",
@@ -791,6 +884,41 @@
       "name": "pbi_capabilities",
       "description": "Que puede hacerse AHORA MISMO, y que no, con el motivo.\n\nUn agente deberia consultarla antes de planificar: dice si la capa en\nvivo esta disponible, si se puede escribir en el .pbip, y que\ncapacidades dependen de la version del motor.",
       "params": {},
+      "required": [],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      }
+    },
+    {
+      "name": "pbi_check_contract",
+      "description": "Valida contra el contrato del puerto: un archivo entrante o el modelo.\n\nCon `source_path` (+ `dataset`): el export de Revit/Navisworks/Project\nANTES de cargarlo — columnas que faltan, tipos incompatibles, llave\nausente. Chequeo ESTRUCTURAL y honesto: unicidad y huerfanas de la\nllave exigen los datos completos, y eso es pbi_diagnose_data con la\ntabla ya cargada; la respuesta lo dice en `not_checked`.\n\nSin `source_path`: el MODELO activo contra el contrato entero, y el\ncirculo que cierra todo: `suggested_critical_fields` — las llaves del\npuerto listas para pbi_define_brief, de modo que el diagnostico las\ntrate como criticas del dueño sin teclearlas dos veces.",
+      "params": {
+        "dataset": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "source_path": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        }
+      },
       "required": [],
       "output_shape": {
         "type": "object",
@@ -1759,6 +1887,44 @@
       "required": [
         "audience",
         "purpose"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      }
+    },
+    {
+      "name": "pbi_define_port_contract",
+      "description": "Escribe el CONTRATO del puerto del ecosistema (pbi-port-contract.json).\n\nEl puerto NO es un bus de APIs entre Revit/Navisworks/Project —eso es\nfragil sin arreglo—: es un contrato de datos. Cada herramienta EMITE\nun dataset normalizado con una llave compartida, y este MCP lo valida\ny lo consume.\n\n`datasets`: [{name, key, columns: [{name, type, required?}],\nemitted_by?, description?}]. La llave es obligatoria: es lo que\npermite cruzar los datasets entre si (p.ej. HRZ_COD_PRES entre el\nmodelo BIM, el presupuesto y el cronograma).\n\nVive versionado junto al .pbip, como el brief. Se valida con\npbi_check_contract: archivos entrantes antes de cargar, y el modelo\nactivo despues.",
+      "params": {
+        "datasets": {
+          "required": true,
+          "type": "array[object]"
+        },
+        "name": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "datasets"
       ],
       "output_shape": {
         "type": "object",

--- a/tests/test_fuentes_y_puerto.py
+++ b/tests/test_fuentes_y_puerto.py
@@ -1,0 +1,221 @@
+"""Fases 3 y 4: fuentes externas y el puerto del ecosistema.
+
+**Fase 3 — la verdad por delante.** Generar el M para SQL u OData son cuatro
+lineas; lo que duele son las credenciales y los niveles de privacidad, que
+viven en la interfaz de Desktop y NO se guardan en el .pbip. Lo que se vigila
+aqui es que el servidor no finja lo contrario: el aviso viaja SIEMPRE, y las
+columnas se declaran (sin credenciales no hay esquema que leer, y las columnas
+no se inventan — regla 5 de la casa).
+
+**Fase 4 — contrato, no bus.** El puerto no conecta cuatro aplicaciones de
+escritorio por API: define datasets normalizados con una llave compartida. Lo
+que se vigila: que el chequeo de un archivo diga QUE comprobo y que NO, porque
+unicidad y huerfanas exigen los datos completos; y que el chequeo del modelo
+cierre el circulo devolviendo las llaves listas para el brief.
+"""
+from __future__ import annotations
+
+import pytest
+
+from horizun_pbi_mcp.pbip import table_from_source as tfs
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+from horizun_pbi_mcp.services import port_contract as pc
+
+
+_COLS = [{"name": "HRZ_COD_PRES", "type": "string"},
+         {"name": "Importe", "type": "double"}]
+
+
+# ======================================================== FASE 3: fuentes ===
+def test_el_aviso_de_credenciales_viaja_siempre():
+    r = tfs.agregar_tabla_desde_fuente(
+        None, "sqlserver", "Presupuesto", _COLS,
+        server="sql01", database="Obras", source_table="Presupuesto",
+        dry_run=True)
+    assert r["warnings"], "el aviso no es opcional"
+    assert "Desktop" in r["warnings"][0] and "credenciales" in r["warnings"][0]
+    assert "no puede verificar" in r["warnings"][0], (
+        "hay que decir que este servidor NO comprueba la conexion")
+
+
+def test_sin_columnas_declaradas_se_rechaza_con_el_motivo():
+    with pytest.raises(ValidationError) as exc:
+        tfs.agregar_tabla_desde_fuente(None, "sqlserver", "T", [],
+                                       server="s", database="d",
+                                       source_table="t", dry_run=True)
+    assert "no se inventan" in str(exc.value)
+
+
+def test_sqlserver_por_tabla_y_por_consulta_nativa():
+    por_tabla = tfs.agregar_tabla_desde_fuente(
+        None, "sqlserver", "T", _COLS, server="sql01", database="Obras",
+        schema="dbo", source_table="Presupuesto", dry_run=True)["m"]
+    assert 'Sql.Database("sql01", "Obras")' in por_tabla
+    assert 'Item = "Presupuesto"' in por_tabla
+
+    nativa = tfs.agregar_tabla_desde_fuente(
+        None, "sqlserver", "T", _COLS, server="sql01", database="Obras",
+        native_query="SELECT * FROM dbo.Presupuesto", dry_run=True)["m"]
+    assert "Value.NativeQuery" in nativa
+    assert "EnableFolding = true" in nativa, (
+        "sin plegado el motor se trae la tabla entera y filtra en local")
+
+
+def test_web_json_fija_la_cultura_en_us():
+    """JSON escribe numeros sin cultura: dejar la del sistema es el bug del
+    10527.52 que se vuelve diez millones."""
+    m = tfs.agregar_tabla_desde_fuente(
+        None, "web_json", "T", _COLS, url="https://api.x/v1/datos",
+        json_path=["data", "rows"], dry_run=True)["m"]
+    assert '"en-US"' in m
+    assert "[data][rows]" in m
+
+
+def test_odata_y_url_no_http_se_rechaza():
+    m = tfs.agregar_tabla_desde_fuente(
+        None, "odata", "T", _COLS, url="https://svc/odata/Presupuestos",
+        dry_run=True)["m"]
+    assert "OData.Feed" in m
+    with pytest.raises(ValidationError):
+        tfs.agregar_tabla_desde_fuente(None, "odata", "T", _COLS,
+                                       url="ftp://svc/odata", dry_run=True)
+
+
+def test_fuente_desconocida_lista_las_soportadas():
+    with pytest.raises(ValidationError) as exc:
+        tfs.agregar_tabla_desde_fuente(None, "oracle", "T", _COLS,
+                                       dry_run=True)
+    assert "sqlserver" in str(exc.value)
+
+
+def test_tipo_de_columna_invalido_se_rechaza():
+    with pytest.raises(ValidationError):
+        tfs.agregar_tabla_desde_fuente(
+            None, "odata", "T", [{"name": "X", "type": "guid"}],
+            url="https://s/odata/X", dry_run=True)
+
+
+def test_el_tmdl_declara_la_particion_y_las_columnas():
+    r = tfs.agregar_tabla_desde_fuente(
+        None, "odata", "Presupuesto", _COLS,
+        url="https://svc/odata/Presupuestos", dry_run=True)
+    tmdl = r["tmdl"]
+    assert "table Presupuesto" in tmdl
+    assert "column HRZ_COD_PRES" in tmdl and "dataType: string" in tmdl
+    assert "partition Presupuesto = m" in tmdl and "mode: import" in tmdl
+    assert "annotation PBI_ResultType = Table" in tmdl
+
+
+# ========================================================= FASE 4: puerto ===
+def _contrato():
+    return {"datasets": [
+        {"name": "Presupuesto", "key": "HRZ_COD_PRES",
+         "emitted_by": "Excel APU",
+         "columns": [{"name": "HRZ_COD_PRES", "type": "string"},
+                     {"name": "Importe", "type": "double"}]},
+        {"name": "Avance", "key": ["HRZ_COD_PRES"],
+         "emitted_by": "Revit",
+         "columns": [{"name": "HRZ_COD_PRES", "type": "string"},
+                     {"name": "Cantidad", "type": "double"}]}]}
+
+
+def test_un_dataset_sin_llave_se_rechaza():
+    """Sin llave no hay contrato: es lo que permite cruzar el ecosistema."""
+    with pytest.raises(ValidationError) as exc:
+        pc.validate_contract({"datasets": [
+            {"name": "X", "columns": [{"name": "A", "type": "string"}]}]})
+    assert "cruzar" in str(exc.value)
+
+
+def test_una_llave_que_no_esta_entre_sus_columnas_se_rechaza():
+    with pytest.raises(ValidationError):
+        pc.validate_contract({"datasets": [
+            {"name": "X", "key": "NoExiste",
+             "columns": [{"name": "A", "type": "string"}]}]})
+
+
+def test_el_contrato_canonico_normaliza_la_llave_a_lista():
+    c = pc.validate_contract(_contrato())
+    assert c["datasets"][0]["key"] == ["HRZ_COD_PRES"]
+    assert c["schema_version"] == "1.0"
+
+
+def test_un_archivo_conforme_pasa(tmp_path):
+    f = tmp_path / "presupuesto.csv"
+    f.write_text("HRZ_COD_PRES,Importe\nD01-A2,1500.50\nD01-A3,220.00\n",
+                 encoding="utf-8")
+    r = pc.check_file(pc.validate_contract(_contrato()), "Presupuesto", str(f))
+    assert r["conformant"] is True
+    assert r["missing_columns"] == [] and r["missing_keys"] == []
+
+
+def test_un_archivo_sin_la_llave_no_pasa_y_lo_nombra(tmp_path):
+    f = tmp_path / "malo.csv"
+    f.write_text("Codigo,Importe\nD01-A2,1500.50\n", encoding="utf-8")
+    r = pc.check_file(pc.validate_contract(_contrato()), "Presupuesto", str(f))
+    assert r["conformant"] is False
+    assert "HRZ_COD_PRES" in r["missing_keys"]
+    assert "HRZ_COD_PRES" in r["missing_columns"]
+
+
+def test_columnas_extra_no_rompen_el_puerto(tmp_path):
+    f = tmp_path / "extra.csv"
+    f.write_text("HRZ_COD_PRES,Importe,Notas\nD01-A2,1500.50,ok\n",
+                 encoding="utf-8")
+    r = pc.check_file(pc.validate_contract(_contrato()), "Presupuesto", str(f))
+    assert r["conformant"] is True, "traer de mas no incumple el contrato"
+    assert r["extra_columns"] == ["Notas"]
+
+
+def test_un_entero_satisface_un_double_declarado(tmp_path):
+    """Todo entero es un decimal valido; al reves seria perdida de datos."""
+    f = tmp_path / "enteros.csv"
+    f.write_text("HRZ_COD_PRES,Importe\nD01-A2,1500\nD01-A3,220\n",
+                 encoding="utf-8")
+    r = pc.check_file(pc.validate_contract(_contrato()), "Presupuesto", str(f))
+    assert r["type_mismatches"] == []
+    assert r["conformant"] is True
+
+
+def test_el_chequeo_de_archivo_declara_lo_que_NO_comprobo(tmp_path):
+    """Unicidad y huerfanas exigen los datos completos: decirlo es la regla."""
+    f = tmp_path / "p.csv"
+    f.write_text("HRZ_COD_PRES,Importe\nD01-A2,1\n", encoding="utf-8")
+    r = pc.check_file(pc.validate_contract(_contrato()), "Presupuesto", str(f))
+    assert "pbi_diagnose_data" in r["not_checked"]
+    assert "structure" in r["checked"]
+
+
+def test_un_dataset_inexistente_lista_los_del_contrato(tmp_path):
+    f = tmp_path / "p.csv"
+    f.write_text("A\n1\n", encoding="utf-8")
+    with pytest.raises(ValidationError) as exc:
+        pc.check_file(pc.validate_contract(_contrato()), "NoExiste", str(f))
+    assert "Presupuesto" in str(exc.value)
+
+
+# ------------------------------------------------- el circulo que cierra ---
+def test_el_modelo_conforme_devuelve_las_llaves_para_el_brief():
+    modelo = {"tables": [
+        {"name": "Presupuesto", "columns": [
+            {"name": "HRZ_COD_PRES", "data_type": "string"},
+            {"name": "Importe", "data_type": "double"}]},
+        {"name": "Avance", "columns": [
+            {"name": "HRZ_COD_PRES", "data_type": "string"},
+            {"name": "Cantidad", "data_type": "double"}]}]}
+    r = pc.check_model(pc.validate_contract(_contrato()), modelo)
+    assert r["conformant"] is True
+    campos = {c["field"] for c in r["suggested_critical_fields"]}
+    assert campos == {"Presupuesto[HRZ_COD_PRES]", "Avance[HRZ_COD_PRES]"}
+    assert "pbi_define_brief" in r["next"], (
+        "el valor esta en encadenar puerto -> brief -> diagnostico")
+
+
+def test_una_tabla_del_contrato_que_falta_en_el_modelo_se_reporta():
+    modelo = {"tables": [{"name": "Presupuesto", "columns": [
+        {"name": "HRZ_COD_PRES", "data_type": "string"},
+        {"name": "Importe", "data_type": "double"}]}]}
+    r = pc.check_model(pc.validate_contract(_contrato()), modelo)
+    assert r["conformant"] is False
+    avance = [d for d in r["datasets"] if d["dataset"] == "Avance"][0]
+    assert avance["present"] is False

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -197,12 +197,24 @@ DIAGNOSTICO_TOOLS = [
     "pbi_diagnose_data",
 ]
 
+#: Fase 3: fuentes externas (el M es facil; las credenciales viven en Desktop).
+FUENTES_TOOLS = [
+    "pbi_add_table_from_source",
+]
+
+#: Fase 4: el puerto del ecosistema como CONTRATO de datos, no bus de APIs.
+PUERTO_TOOLS = [
+    "pbi_define_port_contract",
+    "pbi_check_contract",
+]
+
 TOOLS_NUEVAS = (MACROFASE_A_TOOLS + MACROFASE_B_TOOLS + MACROFASE_C_TOOLS
                 + MACROFASE_D_TOOLS + MACROFASE_E_TOOLS + MACROFASE_F_TOOLS
                 + FASE_F_R5_TOOLS + CONVERSION_TOOLS + THEME_TOOLS
                 + VERIFICACION_TOOLS + CARGA_TOOLS + DISENO_TOOLS
                 + FILTRO_VISUAL_TOOLS + CICLO_TOOLS + REFACTOR_TOOLS
-                + CIERRE_TOOLS + BRIEF_TOOLS + DIAGNOSTICO_TOOLS)
+                + CIERRE_TOOLS + BRIEF_TOOLS + DIAGNOSTICO_TOOLS
+                + FUENTES_TOOLS + PUERTO_TOOLS)
 BASELINE_COUNT = 34
 EXPECTED_COUNT = BASELINE_COUNT + len(TOOLS_NUEVAS)
 


### PR DESCRIPTION
## Phase 3 — external sources (`pbi_add_table_from_source`)

SQL Server, PostgreSQL, OData, Web JSON. Writing the M is the easy part; what hurts is **credentials and privacy levels, which live in Desktop's UI and are NOT stored in the `.pbip`**. This doesn't pretend otherwise:

- The warning ships in **every** response: the query is written, but the **first refresh needs a human in Desktop**, and this server *cannot verify the connection*. Promising otherwise would be lying.
- Columns are **declared by the caller** and validated — without credentials there's no schema to read, and columns are never invented (house rule 5).
- `Value.NativeQuery` carries `EnableFolding=true`: without folding the engine drags the whole table and filters locally, and you don't find out until a refresh takes ten minutes.
- `web_json` pins culture to `en-US` deliberately: JSON writes numbers culture-free, and using the system's is exactly the `10527.52` → ten million bug.

## Phase 4 — the port as a DATA CONTRACT

Not an API bus between Revit/Navisworks/Project — four chained desktop apps is fragile in a way that doesn't get fixed. Each tool **emits a normalized dataset with a shared key** (`HRZ_COD_PRES`); this MCP validates and consumes it.

- `pbi_define_port_contract` → `pbi-port-contract.json` next to the `.pbip`, like the brief. The key is mandatory: without it there's no contract, because the key is what lets datasets cross.
- `pbi_check_contract` validates an **incoming file before loading** — and states what it checked and what it did **not**: key uniqueness and orphans need the full data, which is `pbi_diagnose_data` on the loaded table. A structural check presented as complete would be the same sin phase 3 avoids.
- **It closes the loop**: validating the model returns `suggested_critical_fields` — the port keys ready for `pbi_define_brief`, so phase 2's diagnostics treat them as owner-critical without typing them twice. **port → brief → diagnostics.**

Type compatibility with judgment: `int64` satisfies a declared `double` (every integer is a valid decimal); the reverse is not, because it's data loss. Extra columns don't break the contract.

## Verification

- 19 tests; **7/7 mutation-verified**. Full suite 1793 passed; contract 3 additive tools (127), 0 breaks; doctor exit 0.
- Process note: a same-length mutation (`en-US`→`es-ES`) restored within the same second left a stale `.pyc` that failed the suite with correct source — diagnosed by comparing source against output, not by re-running blindly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
