### PR TITLE
Release v1.2.0: the four phases of the product vision

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "horizun-pbi-mcp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Power BI Desktop y PBIP desde Claude: DAX, TOM, TMDL, PBIR, visuales, auditoría y flujos seguros.",
   "author": {"name": "HorizunGroup", "url": "https://github.com/HorizunGroup"},
   "homepage": "https://github.com/HorizunGroup/horizun-pbi-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "horizun-pbi-mcp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Power BI Desktop y PBIP desde Codex: DAX, TOM, TMDL, PBIR, visuales, auditoría y flujos seguros.",
   "author": {"name": "HorizunGroup", "url": "https://github.com/HorizunGroup"},
   "homepage": "https://github.com/HorizunGroup/horizun-pbi-mcp",

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.HorizunGroup/horizun-pbi-mcp",
   "title": "Horizun PBI MCP",
   "description": "Open-source MCP server for Power BI Desktop, DAX, PBIP, TMDL and PBIR automation.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "repository": {
     "url": "https://github.com/HorizunGroup/horizun-pbi-mcp",
     "source": "github"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ Semantic versioning. **The contract of the original 34 tools is never broken.**
 
 ---
 
+## [1.2.0] — 2026-08-04
+
+The four phases of the product vision, shipped. Six new tools (127 total);
+zero breaking changes. They are not four loose features — they chain:
+
+    port keys -> brief critical_fields -> diagnostics escalate to error
+
+### Added
+
+- **Intent brief** (`pbi_define_brief`, `pbi_get_brief`) — what the dashboard
+  is FOR, as a versioned artifact next to the `.pbip`. **The answers belong to
+  the human**: an empty `purpose` errors with an instruction to ASK, and
+  `pbi_get_brief` on a project without one returns the questions to ask rather
+  than an empty form. Consumed by `pbi_start_here` (shows the declared
+  purpose; its absence is the project's first gap), `pbi_propose_dashboard`
+  (attaches purpose, key questions and non-goals as the yardstick — no fake
+  keyword matching) and `pbi_list_design_systems` (recommends from `delivery`,
+  which is physical legibility, not aesthetics).
+
+- **Content-level data diagnostics** (`pbi_diagnose_data`) — what breaks
+  dashboards and no metadata sees: orphan keys falling into the relationship's
+  (Blank) so totals quietly come up short (blank keys counted too), duplicated
+  grain on the one side that multiplies everything on join, calendar gaps
+  detected by key TYPE rather than by name, and the brief's `critical_fields`
+  thresholds. **Severity is the owner's call**: what they declared critical
+  escalates to `error` citing their own *why*; a critical field that no longer
+  exists is a finding, not silence. Every finding carries the DAX that proves
+  it and sample culprits.
+
+- **External sources** (`pbi_add_table_from_source`) — SQL Server, PostgreSQL,
+  OData, Web JSON. The M is the easy part; **credentials and privacy levels
+  live in Desktop's UI and are not stored in the `.pbip`**, so the warning
+  ships in every response: the query is written, the first refresh needs a
+  human, and this server cannot verify the connection. Columns are declared by
+  the caller — without credentials there is no schema to read, and columns are
+  never invented. `Value.NativeQuery` carries `EnableFolding=true`; `web_json`
+  pins culture to `en-US` because JSON writes numbers culture-free and using
+  the system's is the `10527.52` → ten million bug.
+
+- **The ecosystem port as a DATA CONTRACT** (`pbi_define_port_contract`,
+  `pbi_check_contract`) — deliberately not an API bus between Revit,
+  Navisworks and Project: four chained desktop apps is fragile in a way that
+  doesn't get fixed. Each tool emits a normalized dataset with a shared key;
+  the contract is validated against incoming files (structure only — and it
+  says so: uniqueness and orphans need the full data, which is
+  `pbi_diagnose_data`) and against the live model, which returns
+  `suggested_critical_fields` so the port keys reach the brief without being
+  typed twice.
+
+---
+
 ## [1.1.1] — 2026-08-04
 
 Closes the field-report queue completely (items 6, 8 and 9 were the last

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **MCP** (Model Context Protocol) server for working with **local Power BI Desktop** and **`.pbip`** projects from Claude Code.
 
-**v1.1.1** — 121 tools, 1744 tests passed (3 skipped, with their condition documented). Covers two complementary layers:
+**v1.2.0** — 127 tools, 1793 tests passed (3 skipped, with their condition documented). Covers two complementary layers:
 
 | Layer | For what | How |
 |---|---|---|
@@ -22,7 +22,7 @@
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Current architecture, structural debt and invariants |
 | [`docs/CAPABILITY_MATRIX.md`](docs/CAPABILITY_MATRIX.md) | Coexistence with other Power BI MCPs, with verification levels |
 | [`AGENTS.md`](AGENTS.md) | Rules for modifying this repository without breaking the contract |
-| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 121 tools by block, with their risk class |
+| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 127 tools by block, with their risk class |
 | [`docs/DUAL_MODE.md`](docs/DUAL_MODE.md) | Why `mode="both"` is blocked (R15) |
 | [`docs/VALIDATION.md`](docs/VALIDATION.md) | The two PBIR validation layers and their limits |
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | What is checked before publishing |
@@ -92,7 +92,7 @@ claude plugin install horizun-pbi-mcp@horizun
 
 When the first session opens, the plugin runs the full setup automatically in
 the background. Check `pbi_install_status`; once it finishes, restart the
-client and the 121 `pbi_*` tools will be available. There are no downloads or
+client and the 127 `pbi_*` tools will be available. There are no downloads or
 additional scripts the user needs to run manually.
 
 > **Honest technical limit:** there's no dedicated executable, but you do need
@@ -190,7 +190,7 @@ Exits with code **0** if everything mandatory is fine. It distinguishes missing 
 
 ---
 
-## Available tools (121)
+## Available tools (127)
 
 > Full catalog by block: [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md).
 > Baseline inventory with risk class and preconditions: [`docs/TOOL_INVENTORY.md`](docs/TOOL_INVENTORY.md).
@@ -354,7 +354,7 @@ horizun-pbi-mcp/
 python -m pytest -q
 ```
 
-**1699 tests, 3 skipped.** The skip is environmental and says how to run it:
+**1793 tests, 3 skipped.** The skip is environmental and says how to run it:
 
 | Skipped | Condition |
 |---|---|
@@ -369,7 +369,7 @@ python -m pytest -m live                # against an open Power BI Desktop
 python -m pytest -m live_validator      # against Microsoft's official CLI
 ```
 
-Verify the MCP contract (the 121 tools are frozen):
+Verify the MCP contract (the 127 tools are frozen):
 
 ```bash
 python -m tests.contract_utils

--- a/RELEASE_NOTES_1.2.0.md
+++ b/RELEASE_NOTES_1.2.0.md
@@ -1,0 +1,45 @@
+# Horizun PBI MCP v1.2.0
+
+The four phases of the product vision, shipped. Six new tools (127 total),
+zero breaking changes.
+
+They are not four loose features — they chain into one system:
+
+```
+port keys → brief critical_fields → diagnostics escalate to error
+```
+
+`pbi_check_contract` returns the port's keys; they go into `pbi_define_brief`;
+from then on an orphan key on `HRZ_COD_PRES` stops being a generic warning and
+comes back as an **error citing the owner's own reason**.
+
+## Added
+
+- **Intent brief** — `pbi_define_brief`, `pbi_get_brief`. What the dashboard is
+  FOR, versioned next to the `.pbip`. The answers belong to the human: an empty
+  purpose errors with an instruction to ask, and a project without a brief gets
+  the questions, not an empty form. Read by `pbi_start_here`,
+  `pbi_propose_dashboard` and `pbi_list_design_systems`.
+- **Content-level diagnostics** — `pbi_diagnose_data`. Orphan keys, duplicated
+  grain, calendar gaps and the brief's thresholds, each with the DAX that
+  proves it and sample culprits. Severity is the owner's call.
+- **External sources** — `pbi_add_table_from_source` (SQL Server, PostgreSQL,
+  OData, Web JSON), with the credentials truth up front in every response.
+- **Ecosystem port** — `pbi_define_port_contract`, `pbi_check_contract`. A data
+  contract with a shared key, not an API bus between desktop apps.
+
+## The discipline behind it
+
+Each phase had a chance to fake capability, and each one refuses in writing:
+
+- A diagnostic check that blows up lands in `skipped` — with skips the result
+  is never `clean`.
+- The server cannot verify an external connection, and says so every time.
+- The contract file check states what it did **not** check.
+
+## Evidence
+
+- 127 tools; MCP contract: additive only, golden updated.
+- 1793 tests passed, 3 skipped with their condition documented.
+- Every behavioral change mutation-verified: reverting it fails a named test.
+- `scripts/doctor.py` exit 0; CI green on Windows, Python 3.10 and 3.13.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,12 +3,15 @@
 What remains open, why it matters and how to check it. Ordered by what
 hurts the most.
 
-Updated on 2026-08-04 for **v1.1.1** (121 tools). The fourteen-item field
-report from the first real end-to-end session is now **fully closed**: the
-last three items landed as `theme_json`/`fonts` on `pbi_apply_theme`,
-`pbi_rename_measure` (model + DAX refs + report visuals in one transaction)
-and `pbi_close_desktop` (identity-verified, confirm-gated). The list below
-isn't a brainstorm: it's what we know is missing, with evidence.
+Updated on 2026-08-04 for **v1.2.0** (127 tools). Two things closed since
+1.0.1: the fourteen-item field report from the first real end-to-end session,
+and **the four phases of the product vision** — intent brief, content-level
+data diagnostics, external sources, and the ecosystem port as a data
+contract. They chain: port keys → brief `critical_fields` → diagnostics
+escalate those findings to `error` citing the owner's own reason.
+
+The list below isn't a brainstorm: it's what we know is missing, with
+evidence.
 
 ---
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -19,7 +19,7 @@ Every statement carries its **verification level**. They are not mixed.
 
 | Server | Version | Status | Highest level reached |
 |---|---|---|---|
-| **Horizun PBI MCP** (this repo) | 1.1.1 | Present, starts | **Tested** — stdio handshake, 121 tools, 1744 tests, live DAX, PBIR fixture and Desktop capture by PID |
+| **Horizun PBI MCP** (this repo) | 1.2.0 | Present, starts | **Tested** — stdio handshake, 127 tools, 1793 tests, live DAX, PBIR fixture and Desktop capture by PID |
 | **powerbi-report-mcp** | 0.9.6 | Present and built at `..\PowerBI MCP\powerbi-report-mcp\dist\index.js` | **Observed** — 57 tool names extracted from the bundle and the README. **Not run** |
 | **@microsoft/powerbi-modeling-mcp** | 0.5.0-beta.11 | Downloaded to a temp folder, extracted and read. **Not run** | **Declared** — README + CHANGELOG + `index.js`. Execution **halted** due to a stop condition (§2.1) |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,14 +17,14 @@ claude plugin install horizun-pbi-mcp@horizun
 
 Setup starts automatically on the first session. While it progresses
 you'll see `pbi_install_runtime` and `pbi_install_status`; after restarting
-the client the 121 tools will appear. Nothing needs to be downloaded or run
+the client the 127 tools will appear. Nothing needs to be downloaded or run
 separately. The runtime and verified downloads stay in the plugin's local
 data, outside the repository and your projects.
 
 Python 3.10+ is still a requirement: it's the local process that talks to
 Power BI Desktop. Node 20 is only needed for the optional PBIR validator.
 
-Reproducible guide from scratch. At the end, an MCP client should see 121 `pbi_*` tools.
+Reproducible guide from scratch. At the end, an MCP client should see 127 `pbi_*` tools.
 
 ---
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -106,7 +106,7 @@ On a **copy** outside OneDrive, never on the original:
 
 ## Tagging
 
-The stable version is **`v1.1.1`**. The exceptions below are documented
+The stable version is **`v1.2.0`**. The exceptions below are documented
 product limits, not hidden bugs or skipped criteria.
 
 The version declared in `branding.VERSION` / `pyproject.toml` must match the tag **before** tagging. Installing from a tag and getting a package that reports a different version is exactly what these checks exist to prevent.

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 - Repository: https://github.com/HorizunGroup/horizun-pbi-mcp
 - Latest stable release: https://github.com/HorizunGroup/horizun-pbi-mcp/releases/latest
 - Installation and client setup: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/INSTALL.md
-- Full tool catalogue (121 tools): https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TOOL_CATALOG.md
+- Full tool catalogue (127 tools): https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TOOL_CATALOG.md
 - Architecture and invariants: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/ARCHITECTURE.md
 - Security model: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/SECURITY.md
 - Tutorial, install to first dashboard: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TUTORIAL.md
@@ -29,7 +29,7 @@ model; visuals, pages and layout are never touched through it or through any
 live API — those are edited exclusively through PBIR files. The server
 enforces that separation instead of trying to move visuals live.
 
-v1.1.1 ships 121 tools, backed by 1744 passing tests (3 skipped, each with
+v1.2.0 ships 127 tools, backed by 1793 passing tests (3 skipped, each with
 its documented condition). Two validation layers check every PBIR edit
 before it is written, and non-read-only DAX is blocked by a fail-closed
 classifier.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "horizun-pbi-mcp"
 # PEP 440. Debe coincidir con branding.VERSION y con el tag de Git.
-version = "1.1.1"
+version = "1.2.0"
 description = "MCP server for Power BI: live semantic model (DAX/TOM), .pbip projects (TMDL/PBIR), report authoring, full auditing and workflows."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/plugin_bootstrap.py
+++ b/scripts/plugin_bootstrap.py
@@ -17,7 +17,7 @@ import venv
 from pathlib import Path
 from typing import Any
 
-VERSION = "1.1.1"
+VERSION = "1.2.0"
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 
 

--- a/skills/horizun-pbi-setup/SKILL.md
+++ b/skills/horizun-pbi-setup/SKILL.md
@@ -17,7 +17,7 @@ y descarga las DLL y esquemas fijados, verificando sus hashes.
 3. Consulta `pbi_install_status` hasta que indique `ready` o `failed`. No inicies
    procesos adicionales mientras esté `installing`.
 4. Si termina en `ready`, pide reiniciar Codex o Claude. Al volver, comprueba que
-   `tools/list` expone las 121 tools `pbi_*`, no solo las dos de instalación.
+   `tools/list` expone las 127 tools `pbi_*`, no solo las dos de instalación.
 5. Si falla, informa el paso y el mensaje devueltos por el status. No borres el
    runtime ni ocultes el error; una nueva llamada permite reintentar.
 

--- a/src/horizun_pbi_mcp/branding.py
+++ b/src/horizun_pbi_mcp/branding.py
@@ -3,7 +3,7 @@
 El nombre vive aqui y no repartido por el codigo: renombrar un producto no
 deberia obligar a buscar cadenas sueltas en veinte archivos.
 
-COMPATIBILIDAD: las 121 tools conservan el prefijo `pbi_`. Renombrarlas romperia
+COMPATIBILIDAD: las 127 tools conservan el prefijo `pbi_`. Renombrarlas romperia
 a cualquier cliente ya configurado, y el nombre comercial no es motivo
 suficiente para eso.
 """
@@ -20,11 +20,11 @@ MCP_SERVER_NAME = "horizun-pbi-mcp"
 PACKAGE_NAME = "horizun-pbi-mcp"
 #: Version VISIBLE del producto: la que anuncia serverInfo y la que coincide
 #: con el tag de Git.
-VERSION = "1.1.1"
+VERSION = "1.2.0"
 
 #: La misma version en el formato que exige PEP 440 para `pyproject.toml`.
 #: `1.0.0-rc.2` no es valido ahi; una release estable usa `1.0.1`.
-VERSION_PEP440 = "1.1.1"
+VERSION_PEP440 = "1.2.0"
 #: Logger raiz.
 LOGGER_NAME = "horizun_pbi_mcp"
 #: Prefijo de las tools. NO cambia: es contrato publico.

--- a/src/horizun_pbi_mcp/services/guide.py
+++ b/src/horizun_pbi_mcp/services/guide.py
@@ -1,15 +1,15 @@
-"""Por donde se empieza. Un punto de entrada para 121 tools.
+"""Por donde se empieza. Un punto de entrada para 127 tools.
 
 El problema que cierra
 ----------------------
-Ciento veintiuna tools con buen nombre y buena descripcion siguen siendo
-ciento veintiuna tools. Quien llega no sabe si primero abre un proyecto o primero carga datos, ni
+Ciento veintisiete tools con buen nombre y buena descripcion siguen siendo
+ciento veintisiete tools. Quien llega no sabe si primero abre un proyecto o primero carga datos, ni
 que la escritura de TMDL exige Power BI Desktop CERRADO —y eso no lo dice
 ninguna lista alfabetica—. El catalogo estaba completo y el camino no existia.
 
 Aqui no se documenta nada nuevo: se MIRA el estado real y se responde a «¿y
 ahora que?» con tres o cuatro pasos concretos, cada uno con el nombre exacto de
-la tool y el motivo. Una lista de 121 opciones no es una respuesta a esa
+la tool y el motivo. Una lista de 127 opciones no es una respuesta a esa
 pregunta; tres si.
 
 La regla que lo mantiene util

--- a/src/horizun_pbi_mcp/tools/design_tools.py
+++ b/src/horizun_pbi_mcp/tools/design_tools.py
@@ -25,7 +25,7 @@ def register(mcp) -> None:
     def pbi_start_here(request_id: str = "") -> Dict[str, Any]:
         """Por donde empezar. Mira el estado real y dice los siguientes pasos.
 
-        Ciento veintiuna tools con buen nombre siguen siendo ciento veintiuna tools.
+        Ciento veintisiete tools con buen nombre siguen siendo ciento veintisiete tools.
         Esta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada
         uno con el nombre exacto de la tool y **por que** toca ahora: si hay
         proyecto activo, si tiene modelo o solo informe, si esta vacio, y si

--- a/src/horizun_pbi_mcp/tools/risk.py
+++ b/src/horizun_pbi_mcp/tools/risk.py
@@ -46,7 +46,7 @@ llamadas iguales a `pbi_create_visual` crean dos visuales. Anunciar
 `idempotent=True` seria prometer una garantia que depende de que quien llama haga
 su parte.
 
-`openWorldHint` es `False` en las 121: este servidor habla con el disco local y
+`openWorldHint` es `False` en las 127: este servidor habla con el disco local y
 con un Power BI Desktop local. No hay dominio abierto.
 """
 from __future__ import annotations

--- a/tests/golden/tools_v1.json
+++ b/tests/golden/tools_v1.json
@@ -4521,7 +4521,7 @@
     },
     {
       "name": "pbi_start_here",
-      "description": "Por donde empezar. Mira el estado real y dice los siguientes pasos.\n\nCiento veintiuna tools con buen nombre siguen siendo ciento veintiuna tools.\nEsta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada\nuno con el nombre exacto de la tool y **por que** toca ahora: si hay\nproyecto activo, si tiene modelo o solo informe, si esta vacio, y si\nPower BI Desktop lo tiene abierto —que impide escribir el TMDL—.\n\nDevuelve tambien `common_tasks`: tareas frecuentes y la secuencia de\ntools que las resuelve.\n\nNo escribe nada. Empieza por aqui cuando no sepas que sigue.",
+      "description": "Por donde empezar. Mira el estado real y dice los siguientes pasos.\n\nCiento veintisiete tools con buen nombre siguen siendo ciento veintisiete tools.\nEsta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada\nuno con el nombre exacto de la tool y **por que** toca ahora: si hay\nproyecto activo, si tiene modelo o solo informe, si esta vacio, y si\nPower BI Desktop lo tiene abierto —que impide escribir el TMDL—.\n\nDevuelve tambien `common_tasks`: tareas frecuentes y la secuencia de\ntools que las resuelve.\n\nNo escribe nada. Empieza por aqui cuando no sepas que sigue.",
       "params": {
         "request_id": {
           "required": false,


### PR DESCRIPTION
## What

**v1.2.0** — the four phases of the product vision, shipped. Six new tools (127 total), zero breaking changes.

They chain into one system:

```
port keys → brief critical_fields → diagnostics escalate to error
```

- **Intent brief** (`pbi_define_brief`, `pbi_get_brief`) — what the dashboard is FOR, versioned next to the `.pbip`; the answers belong to the human.
- **Content diagnostics** (`pbi_diagnose_data`) — orphan keys, duplicated grain, calendar gaps, brief thresholds; each with its DAX proof and sample culprits.
- **External sources** (`pbi_add_table_from_source`) — SQL Server, PostgreSQL, OData, Web JSON, with the credentials truth up front.
- **Ecosystem port** (`pbi_define_port_contract`, `pbi_check_contract`) — a data contract with a shared key, not an API bus.

## Verification

1793 tests passed, 3 skipped; contract additive only, golden updated; `doctor.py` exit 0. Every behavioral change mutation-verified.

The `v1.2.0` tag (separate step after merge) triggers PyPI + MCP Registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
