### PR TITLE
Support custom visuals when writing pages (PBIR)

### DIFF
--- a/ISSUE_visuales_personalizados.md
+++ b/ISSUE_visuales_personalizados.md
@@ -1,0 +1,132 @@
+# Soportar visuales personalizados en la escritura de páginas (PBIR)
+
+**Repo:** PowerBI-MCP (v1.2.0)
+**Prioridad:** alta — bloquea armar tableros BIM completos desde el MCP
+**Reportado:** 2026-08-04, montando el tablero 5D del curso POWERBIM 5
+
+---
+
+## Problema
+
+`pbi_apply_page_spec`, `pbi_create_visual` y `pbi_compose_page` no pueden
+escribir visuales PERSONALIZADOS. En un informe que ya tiene instalados el
+visor APS de Horizun y el buildMotion, el spec se rechaza:
+
+```
+$.visuals[5].type — Tipo no soportado:
+'aPSModelViewer02FA0CE460E64F779B012F5831EB091C'.
+Soportados: ['actionButton', 'areaChart', ... 'waterfallChart']
+```
+
+Consecuencia práctica: en un tablero 4D/5D el MCP monta KPIs, curvas y tablas,
+pero NO el visor 3D ni la línea de tiempo — que son justamente el motivo de
+conectar BIM con Power BI. Hoy hay que dejar recuadros marcadores y pedirle al
+usuario que pegue los visuales a mano.
+
+## Reproducir
+
+1. Abrir un `.pbip` que tenga `CustomVisuals/` con al menos un visual instalado
+2. Llamar `pbi_validate_page_spec` con un visual cuyo `type` sea ese GUID
+3. Falla en la etapa `schema`
+
+## Causa raíz
+
+`src/services/page_spec.py:179`
+
+```python
+elif str(v["type"]).lower() not in visual_factory.TYPE_MAP:
+    errores.append(_err(
+        f"{base}.type", f"Tipo no soportado: '{v['type']}'.",
+        f"Soportados: {visual_factory.SUPPORTED}"))
+```
+
+`TYPE_MAP` (`src/pbip/visual_factory.py:82`) se deriva de `REAL_TYPES`, una
+tupla fija de 29 tipos nativos, más `ALIASES`. Un GUID de visual personalizado
+nunca puede estar ahí porque cada informe instala los suyos.
+
+## Diseño propuesto
+
+No hardcodear: **descubrir**. Cada `.pbip` ya declara sus personalizados en
+
+```
+<Report>/CustomVisuals/<GUID>/resources/<GUID>.pbiviz.json
+```
+
+y ese archivo trae `capabilities.dataRoles`, o sea los nombres de rol reales.
+
+### 1. Descubrimiento
+Nueva función que lea `CustomVisuals/` del informe activo y devuelva
+`{guid: [roles]}`. Cachear por ruta + mtime.
+
+### 2. Registro dinámico
+Que `TYPE_MAP` se resuelva contra nativos + GUID descubiertos. `SUPPORTED`
+debe anunciarlos, para que el mensaje de error liste lo que de verdad se
+puede usar en ESE informe.
+
+### 3. Roles verbatim
+Para tipos personalizados, saltar `ROLE_MAP`, `REQUIRED_ROLES`,
+`MAX_PER_ROLE` y `ROLE_KINDS`: esos contratos se verificaron uno a uno contra
+el catálogo oficial de Microsoft y no aplican aquí. El rol se escribe tal cual
+en `queryState`.
+
+Validar contra los roles declarados en el `.pbiviz.json` y rechazar los
+desconocidos con la lista de válidos — mismo criterio que ya se usa con los
+nativos, solo que la fuente de verdad es el manifiesto del visual.
+
+### 4. Preservar `objects`
+Al clonar una plantilla existente hay que conservar bloques de configuración
+propios del visual. En el visor APS, `objects.connection` lleva `baseUrl` y el
+token `mt`: sin eso el visual carga vacío.
+
+Descartar sí los `dataColors` que traen `selector.data`, porque son restos de
+una selección puntual del usuario y no configuración reutilizable.
+
+## Criterios de aceptación
+
+- [ ] `pbi_report_capabilities` sigue listando los personalizados presentes
+- [ ] `pbi_validate_page_spec` acepta un GUID instalado y rechaza uno que no
+- [ ] `pbi_apply_page_spec` escribe un visor APS con sus 4 roles
+      (`dbids`, `modelId`, `colorBy`, `externalIds`) y el informe abre
+- [ ] `pbi_apply_page_spec` escribe un buildMotion con `timelineDate`
+- [ ] El validador oficial (`@microsoft/powerbi-report-authoring-cli`)
+      pasa con 0 errores
+- [ ] Un rol inexistente para ese GUID se rechaza con mensaje útil
+- [ ] Cubierto en `tests/test_generadores_abren.py`
+
+## Prueba de que el enfoque funciona
+
+Se escribieron 4 `visual.json` a mano en un informe real — 3 visores APS y
+1 buildMotion, repartidos en 3 páginas — clonando los existentes y ajustando
+solo `name` y `position`. El informe abre en Power BI Desktop y los visuales
+renderizan con datos.
+
+Eso es exactamente lo que debería generar el MCP: el trabajo consiste en
+llevarlo al factory con validación de roles.
+
+### Estructura de referencia (visor APS)
+
+```json
+{
+  "name": "<id 20 hex>",
+  "position": { "x": 24, "y": 257, "width": 816, "height": 250, "z": 0, "tabOrder": 0 },
+  "visual": {
+    "visualType": "aPSModelViewer02FA0CE460E64F779B012F5831EB091C",
+    "query": { "queryState": {
+      "dbids":       { "projections": [ { "field": { "Column": { "Expression": { "SourceRef": { "Entity": "Modelo" } }, "Property": "dbids" } }, "queryRef": "Modelo.dbids", "nativeQueryRef": "dbids" } ] },
+      "modelId":     { "projections": [ ... "Property": "model_id" ... ] },
+      "colorBy":     { "projections": [ ... "Property": "Categoria" ... ] },
+      "externalIds": { "projections": [ ... "Property": "external_id" ... ] }
+    } },
+    "objects": {
+      "connection": [ { "properties": {
+        "baseUrl": { "expr": { "Literal": { "Value": "'https://pbim.horizunhub.com'" } } },
+        "mt":      { "expr": { "Literal": { "Value": "'<token>'" } } }
+      } } ]
+    },
+    "drillFilterOtherVisuals": true
+  }
+}
+```
+
+El buildMotion es el mismo patrón con un solo rol:
+`timelineDate` → `Cronograma[Comienzo]`.

--- a/src/horizun_pbi_mcp/pbip/custom_visuals.py
+++ b/src/horizun_pbi_mcp/pbip/custom_visuals.py
@@ -1,0 +1,161 @@
+"""Visuales PERSONALIZADOS del informe: se descubren, no se codifican.
+
+El generador conoce 29 tipos nativos porque su contrato se verifico uno a uno
+contra el catalogo oficial de Microsoft. Un visual personalizado no puede
+estar en esa lista: cada informe instala los suyos, y su identificador es un
+GUID distinto en cada uno.
+
+Consecuencia practica, y el motivo de este modulo: en un tablero 4D/5D el MCP
+podia montar KPIs, curvas y tablas, pero NO el visor 3D ni la linea de tiempo
+—justo lo que motiva conectar BIM con Power BI—. Habia que dejar recuadros
+marcadores y pedirle a una persona que los pegara a mano.
+
+La fuente de verdad ya existe dentro del propio informe:
+
+    <Report>/CustomVisuals/<GUID>/resources/<GUID>.pbiviz.json
+
+Ese archivo declara `capabilities.dataRoles`, o sea los nombres de rol REALES
+que el visual acepta. Con eso se puede validar igual de estricto que con los
+nativos —un rol inventado se rechaza con la lista de los validos— sin inventar
+ningun contrato: el contrato lo publica el propio visual.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from horizun_pbi_mcp.logging_config import get_logger
+
+log = get_logger("custom_visuals")
+
+CUSTOM_DIR = "CustomVisuals"
+
+#: Cache por (ruta del informe, huella de mtimes). Un informe puede instalar o
+#: quitar visuales entre llamadas, y releer el disco en cada validacion de rol
+#: seria un coste absurdo; pero cachear solo por ruta serviria datos viejos
+#: justo despues de instalar uno. La huella resuelve las dos cosas.
+_cache: Dict[str, Any] = {}
+_lock = threading.Lock()
+
+
+def custom_dir(report_dir: Path | str) -> Path:
+    return Path(report_dir) / CUSTOM_DIR
+
+
+def _huella(directorio: Path) -> tuple:
+    """mtime+tamaño de cada pbiviz. Cambia si se instala, quita o actualiza."""
+    marcas = []
+    try:
+        for p in sorted(directorio.glob("*/resources/*.pbiviz.json")):
+            try:
+                st = p.stat()
+                marcas.append((p.name, int(st.st_mtime), st.st_size))
+            except OSError:                              # pragma: no cover
+                marcas.append((p.name, 0, 0))
+    except OSError:                                      # pragma: no cover
+        return ()
+    return tuple(marcas)
+
+
+def _leer_pbiviz(ruta: Path) -> Optional[Dict[str, Any]]:
+    """Un pbiviz ilegible NO tumba el informe: se avisa y se sigue.
+
+    Es metadato de un visual de terceros; que uno venga corrupto no puede
+    impedir escribir el resto de la pagina.
+    """
+    try:
+        # utf-8-sig: varios .pbiviz.json reales vienen con BOM.
+        datos = json.loads(ruta.read_text(encoding="utf-8-sig"))
+    except (OSError, ValueError) as exc:
+        log.warning("No se pudo leer %s: %s", ruta.name, exc)
+        return None
+    if not isinstance(datos, dict):
+        return None
+
+    visual = datos.get("visual") or {}
+    guid = str(visual.get("guid") or "").strip()
+    if not guid:
+        # Sin GUID no hay con que referenciarlo desde un visual.json.
+        log.warning("%s no declara visual.guid; se ignora", ruta.name)
+        return None
+
+    roles = []
+    for r in (datos.get("capabilities") or {}).get("dataRoles") or []:
+        nombre = str((r or {}).get("name") or "").strip()
+        if nombre:
+            roles.append({"name": nombre,
+                          "kind": str(r.get("kind") or ""),
+                          "display_name": str(r.get("displayName") or nombre)})
+    return {
+        "guid": guid,
+        "display_name": str(visual.get("displayName") or guid),
+        "version": str(visual.get("version") or ""),
+        "roles": roles,
+        "manifest": str(ruta),
+    }
+
+
+def discover(report_dir: Path | str) -> Dict[str, Dict[str, Any]]:
+    """{GUID: {display_name, version, roles:[{name,kind,display_name}]}}.
+
+    Devuelve `{}` si el informe no tiene `CustomVisuals/` — que es el caso
+    normal y no es un error.
+    """
+    directorio = custom_dir(report_dir)
+    clave = str(Path(report_dir).resolve())
+    huella = _huella(directorio)
+
+    with _lock:
+        previo = _cache.get(clave)
+        if previo is not None and previo[0] == huella:
+            return previo[1]
+
+    encontrados: Dict[str, Dict[str, Any]] = {}
+    try:
+        manifiestos = sorted(directorio.glob("*/resources/*.pbiviz.json"))
+    except OSError:                                      # pragma: no cover
+        manifiestos = []
+    for ruta in manifiestos:
+        info = _leer_pbiviz(ruta)
+        if info:
+            encontrados[info["guid"]] = info
+
+    with _lock:
+        _cache[clave] = (huella, encontrados)
+    if encontrados:
+        log.info("Visuales personalizados descubiertos en %s: %s",
+                 Path(report_dir).name, sorted(encontrados))
+    return encontrados
+
+
+def discover_for(active) -> Dict[str, Dict[str, Any]]:
+    """Los del proyecto activo. `{}` si no tiene carpeta de informe."""
+    if active is None or not getattr(active, "report_dir", None):
+        return {}
+    return discover(active.report_dir)
+
+
+def role_names(info: Dict[str, Any]) -> List[str]:
+    return [r["name"] for r in info.get("roles") or []]
+
+
+def resolve_guid(report_dir: Path | str, visual_type: str) -> Optional[str]:
+    """El GUID tal cual si esta instalado. Compara sin distinguir mayusculas.
+
+    Devuelve el GUID CANONICO (como lo escribe el manifiesto), no lo que se
+    tecleo: `visualType` en el visual.json tiene que coincidir exactamente con
+    el nombre de la carpeta o Power BI no encuentra el visual.
+    """
+    pedido = str(visual_type or "").strip().casefold()
+    for guid in discover(report_dir):
+        if guid.casefold() == pedido:
+            return guid
+    return None
+
+
+def invalidate_cache() -> None:
+    """Para las pruebas y para tras instalar un visual en la misma sesion."""
+    with _lock:
+        _cache.clear()

--- a/src/horizun_pbi_mcp/pbip/visual_factory.py
+++ b/src/horizun_pbi_mcp/pbip/visual_factory.py
@@ -276,13 +276,44 @@ def roles_de(actual_type: str) -> Dict[str, str]:
 SUPPORTED = sorted(REAL_TYPES + tuple(ALIASES), key=str.lower)
 
 
-def resolve_type(visual_type: str) -> str:
+def resolve_type(visual_type: str, active: Any = None) -> str:
+    """Nombre canonico del tipo. Con `active`, admite los PERSONALIZADOS.
+
+    Los 29 nativos viven en `TYPE_MAP` porque su contrato se verifico contra
+    el catalogo oficial. Un visual personalizado no puede estar ahi -su GUID
+    es distinto en cada informe-, asi que se resuelve contra los que el
+    informe tiene instalados en `CustomVisuals/`. Sin `active` se conserva el
+    comportamiento de siempre: solo nativos.
+    """
     key = str(visual_type).strip().lower()
-    if key not in TYPE_MAP:
+    if key in TYPE_MAP:
+        return TYPE_MAP[key]
+
+    if active is not None and getattr(active, "report_dir", None):
+        from horizun_pbi_mcp.pbip import custom_visuals
+
+        guid = custom_visuals.resolve_guid(active.report_dir, visual_type)
+        if guid:
+            # El GUID CANONICO del manifiesto, no lo que se tecleo: el
+            # `visualType` tiene que coincidir exacto o Power BI no lo
+            # encuentra.
+            return guid
+        instalados = sorted(custom_visuals.discover_for(active))
         raise VisualFactoryError(
-            f"Tipo de visual no soportado: '{visual_type}'. "
-            f"Soportados: {SUPPORTED}.")
-    return TYPE_MAP[key]
+            f"Tipo de visual no soportado: '{visual_type}'. Nativos: "
+            f"{SUPPORTED}. Personalizados instalados en este informe: "
+            f"{instalados or 'ninguno'}.",
+            details={"visual_type": visual_type, "native": SUPPORTED,
+                     "custom_installed": instalados})
+
+    raise VisualFactoryError(
+        f"Tipo de visual no soportado: '{visual_type}'. "
+        f"Soportados: {SUPPORTED}.")
+
+
+def es_personalizado(actual_type: str) -> bool:
+    """Un tipo que no esta entre los nativos es un personalizado."""
+    return actual_type not in set(REAL_TYPES)
 
 
 def normalizar_referencia(ref: Any) -> str:
@@ -409,11 +440,54 @@ def _normalizar_roles(actual_type: str,
     return normalizado
 
 
+def _roles_personalizados(actual_type: str, fields: Dict[str, Any],
+                          roles_declarados: List[str]) -> Dict[str, List[Any]]:
+    """Roles de un visual PERSONALIZADO: verbatim, validados contra su manifiesto.
+
+    No se pasa por `ROLE_MAP` ni por los contratos de cardinalidad y clase de
+    campo: esos se verificaron contra el catalogo oficial de Microsoft y no
+    dicen nada de un visual de terceros. El contrato aqui lo publica el propio
+    visual en `capabilities.dataRoles`, y se aplica con el mismo rigor: un rol
+    que ese GUID no declara se RECHAZA con la lista de los validos, igual que
+    con los nativos.
+    """
+    validos = {r.casefold(): r for r in roles_declarados}
+    salida: Dict[str, List[Any]] = {}
+    for rol_pedido, refs in (fields or {}).items():
+        canonico = validos.get(str(rol_pedido).strip().casefold())
+        if canonico is None:
+            raise VisualFactoryError(
+                f"El visual personalizado '{actual_type}' no declara un rol "
+                f"'{rol_pedido}'. Roles que acepta: {sorted(roles_declarados)}.",
+                details={"visual_type": actual_type, "role": rol_pedido,
+                         "valid_roles": sorted(roles_declarados),
+                         "source": "capabilities.dataRoles del .pbiviz.json"})
+        if not refs:
+            continue
+        if isinstance(refs, (str, dict)):
+            salida[canonico] = [refs]
+        elif isinstance(refs, (list, tuple)):
+            salida[canonico] = list(refs)
+        else:
+            raise VisualFactoryError(
+                f"El rol '{rol_pedido}' espera un campo o una lista de campos; "
+                f"se recibio {type(refs).__name__}.")
+    return salida
+
+
 def _build_query(actual_type: str, fields: Dict[str, Any],
                  measure_index: Optional[Dict[str, str]],
-                 warnings: List[str]) -> Dict[str, Any]:
-    role_map = ROLE_MAP.get(actual_type, {"values": "Values"})
-    normalizado = _normalizar_roles(actual_type, fields)
+                 warnings: List[str],
+                 roles_personalizados: Optional[List[str]] = None) -> Dict[str, Any]:
+    if roles_personalizados is not None:
+        normalizado = _roles_personalizados(actual_type, fields,
+                                            roles_personalizados)
+        # El orden lo fija el manifiesto: dos specs equivalentes deben producir
+        # el mismo visual.json byte a byte.
+        role_map = {r: r for r in roles_personalizados}
+    else:
+        role_map = ROLE_MAP.get(actual_type, {"values": "Values"})
+        normalizado = _normalizar_roles(actual_type, fields)
 
     # Se emite en el orden del mapa, no en el que llegaron los roles: dos specs
     # equivalentes tienen que producir el MISMO visual.json byte a byte, o el
@@ -458,7 +532,16 @@ def _build_query(actual_type: str, fields: Dict[str, Any],
 
 
 def _validate_role_contract(actual_type: str, query: Dict[str, Any]) -> None:
-    """Exige obligatoriedad y cardinalidad antes de buscar una plantilla."""
+    """Exige obligatoriedad y cardinalidad antes de buscar una plantilla.
+
+    Solo para NATIVOS. Los contratos de abajo (roles obligatorios, cardinalidad
+    maxima, clase de campo) salieron del catalogo oficial de Microsoft; aplicar
+    esas tablas a un visual de terceros seria inventarle un contrato que nadie
+    publico y rechazar visuales perfectamente validos. Lo suyo ya se valido
+    contra su `.pbiviz.json` en `_roles_personalizados`.
+    """
+    if es_personalizado(actual_type):
+        return
     estados = query.get("queryState") or {}
     faltantes = [rol for rol in REQUIRED_ROLES.get(actual_type, ())
                  if not (estados.get(rol) or {}).get("projections")]
@@ -547,9 +630,22 @@ def _quitar_selectores_de_campos_obsoletos(
         vis: Dict[str, Any], query: Dict[str, Any], warnings: List[str]) -> None:
     """Descarta formato acotado a campos que ya no estan en la consulta.
 
-    `selector.metadata` es un queryRef. Clonarlo junto con una consulta nueva
-    deja reglas de formato condicional apuntando al campo de la plantilla; el
-    esquema no lo denuncia porque el bloque `objects` es abierto.
+    Dos formas del mismo defecto, y el esquema no denuncia ninguna porque el
+    bloque `objects` es abierto:
+
+    - `selector.metadata` es un queryRef. Clonarlo junto con una consulta
+      nueva deja reglas de formato condicional apuntando al campo de la
+      plantilla.
+    - `selector.data` con `scopeId` fija puntos CONCRETOS: es el rastro de
+      que alguien pincho un elemento en la plantilla y le puso un color. En un
+      visual nuevo esos identificadores no significan nada. Se vio en el visor
+      APS real, cuyo `dataColors` arrastraba la seleccion del original. Un
+      `dataViewWildcard` en cambio se conserva: significa "todos los puntos",
+      no uno.
+
+    Lo que NO lleva selector se conserva intacto, y esa distincion es la que
+    salva la configuracion propia del visual: `objects.connection` del visor
+    APS lleva `baseUrl` y el token `mt`, y sin ellos el visual carga vacio.
     """
     referencias = {
         proyeccion.get("queryRef")
@@ -571,6 +667,16 @@ def _quitar_selectores_de_campos_obsoletos(
             metadata = selector.get("metadata") if isinstance(selector, dict) else None
             if metadata is not None and (
                     not isinstance(metadata, str) or metadata not in referencias):
+                eliminados += 1
+                continue
+            datos_sel = selector.get("data") if isinstance(selector, dict) else None
+            if isinstance(datos_sel, list) and any(
+                    isinstance(d, dict) and "scopeId" in d for d in datos_sel):
+                # Seleccion PUNTUAL heredada de la plantilla: sus scopeIds
+                # apuntan a filas concretas que este visual no tiene por que
+                # contener. Ojo con la distincion, que costo un test: un
+                # `dataViewWildcard` NO es una seleccion puntual -significa
+                # "todos los puntos"- y debe conservarse.
                 eliminados += 1
                 continue
             vigentes.append(bloque)
@@ -1072,6 +1178,77 @@ def _rutas_formato_generadas(vis: Dict[str, Any], *, completas: bool,
     return rutas
 
 
+#: Tipo NATIVO que se usa como referencia del marco al clonar un personalizado.
+#: Los `visualContainerObjects` (titulo, fondo, borde, sombra) son cromo del
+#: contenedor y son COMPARTIDOS entre tipos —lo dice el propio format_oracle—,
+#: asi que el catalogo de cualquier nativo sirve de patron. Hace falta porque
+#: `catalog describe <GUID>` NO funciona para un visual de terceros:
+#: comprobado, el CLI oficial no lo conoce.
+_TIPO_REFERENCIA_MARCO = "barChart"
+
+
+def _sanear_marco_heredado(vis: Dict[str, Any], actual_type: str,
+                           warnings: List[str]) -> None:
+    """Quita del marco CLONADO lo que el catalogo oficial rechaza.
+
+    Caso real, y la razon de que esto exista: varios visores APS del informe
+    traen `visualContainerObjects.dropShadow.preset = 'Outer'`, valor que el
+    catalogo oficial no admite (acepta BottomRight, Bottom, ... Custom). Power
+    BI Desktop lo tolera —el informe abre y el visual pinta—, pero el
+    validador oficial lo marca. Al clonar, ese defecto PREEXISTENTE viajaba a
+    cada visual nuevo: un error mas por visual, y la transaccion se bloqueaba
+    con razon por dejar el informe peor de como estaba.
+
+    No es culpa de quien llama ni algo que deba fallar: se DESCARTA lo
+    invalido heredado y se avisa.
+
+    Se juzga contra el catalogo de un NATIVO porque el marco es compartido, y
+    solo si el CLI oficial esta disponible de verdad: el snapshot local es un
+    subconjunto minimo y usarlo aqui borraria formato legitimo por el simple
+    hecho de no estar en la muestra. Sin oraculo real no se sanea nada —mejor
+    propagar y que el guard bloquee, que mutilar en silencio—.
+    """
+    marco = vis.get("visualContainerObjects")
+    if not isinstance(marco, dict) or not marco:
+        return
+    from horizun_pbi_mcp.services import format_oracle
+
+    catalogo = format_oracle._load_catalog(_TIPO_REFERENCIA_MARCO)
+    if not catalogo:
+        return
+    definiciones = catalogo.get("visualContainerObjects") or {}
+    if not definiciones:
+        return
+
+    quitadas: List[str] = []
+    for grupo, bloques in list(marco.items()):
+        grupo_def = definiciones.get(grupo)
+        if not isinstance(grupo_def, dict):
+            continue  # grupo que el patron no cubre: no se toca
+        for bloque in bloques if isinstance(bloques, list) else []:
+            props = bloque.get("properties") if isinstance(bloque, dict) else None
+            if not isinstance(props, dict):
+                continue
+            for prop, valor in list(props.items()):
+                definicion = grupo_def.get(prop)
+                if not isinstance(definicion, dict):
+                    continue
+                if not format_oracle._matches_kind(valor, definicion):
+                    props.pop(prop, None)
+                    quitadas.append(f"{grupo}.{prop}")
+        if isinstance(bloques, list) and all(
+                not (b.get("properties") or {}) for b in bloques
+                if isinstance(b, dict)):
+            marco.pop(grupo, None)
+
+    if quitadas:
+        warnings.append(
+            "Del marco heredado de la plantilla se descartaron propiedades que "
+            f"el catalogo oficial no admite: {sorted(set(quitadas))}. Ya "
+            "estaban mal en el visual original; copiarlas habria sumado un "
+            "error por cada visual nuevo.")
+
+
 def _comprobar_formato_generado(documento: Dict[str, Any], *, completas: bool,
                                 actual_type: str, title: Optional[str],
                                 opciones: Dict[str, Any],
@@ -1082,7 +1259,14 @@ def _comprobar_formato_generado(documento: Dict[str, Any], *, completas: bool,
     porque el oraculo solo comprueba lo que se le declara: una ruta escrita y
     no declarada pasaria sin mirar, que es como se colaron en su dia los
     `objects` invalidos.
+
+    NO aplica a los personalizados: el oraculo es el catalogo de formato
+    OFICIAL de Microsoft y no conoce las propiedades de un visual de terceros
+    -`connection.baseUrl` del visor APS, por ejemplo-. Preguntarle por ellas
+    daria un falso positivo y bloquearia una escritura correcta.
     """
+    if es_personalizado(actual_type):
+        return
     from horizun_pbi_mcp.services import format_oracle
 
     rutas = _rutas_formato_generadas(
@@ -1120,8 +1304,28 @@ def build_visual(
     options: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Devuelve (visual_dict, meta) donde meta incluye warnings y origen."""
-    actual_type = resolve_type(visual_type)
+    actual_type = resolve_type(visual_type, active)
     warnings: List[str] = []
+
+    # Un personalizado trae su propio contrato de roles en el manifiesto que el
+    # informe ya tiene instalado. Se lee aqui una vez y viaja hasta la consulta.
+    roles_custom: Optional[List[str]] = None
+    if es_personalizado(actual_type):
+        from horizun_pbi_mcp.pbip import custom_visuals
+
+        info = custom_visuals.discover_for(active).get(actual_type)
+        if info is None:                                  # pragma: no cover
+            raise VisualFactoryError(
+                f"'{actual_type}' no esta instalado en este informe.",
+                details={"visual_type": actual_type})
+        roles_custom = custom_visuals.role_names(info)
+        if not roles_custom:
+            raise VisualFactoryError(
+                f"El visual personalizado '{actual_type}' no declara ningun "
+                "rol de datos en su .pbiviz.json; no se puede saber donde "
+                "poner los campos.",
+                details={"visual_type": actual_type,
+                         "manifest": info.get("manifest")})
 
     pos = _normalizar_posicion(position)
 
@@ -1154,7 +1358,8 @@ def build_visual(
                 "origin": "elemento de composicion",
                 "warnings": warnings}
 
-    query = _build_query(actual_type, fields or {}, measure_index, warnings)
+    query = _build_query(actual_type, fields or {}, measure_index, warnings,
+                         roles_personalizados=roles_custom)
     _validate_role_contract(actual_type, query)
     template = find_template(active, actual_type)
     if template is not None:
@@ -1172,6 +1377,7 @@ def build_visual(
         else:
             _quitar_titulo_heredado(vis)
         _quitar_selectores_de_campos_obsoletos(vis, query, warnings)
+        _sanear_marco_heredado(vis, actual_type, warnings)
         if actual_type in ("card", "cardVisual"):
             _aplicar_opciones_de_tarjeta(vis, actual_type, options or {})
         _aplicar_estilo_contenedor(vis, options or {})

--- a/src/horizun_pbi_mcp/services/page_spec.py
+++ b/src/horizun_pbi_mcp/services/page_spec.py
@@ -135,8 +135,13 @@ def _err(path: str, mensaje: str, sugerencia: str = "") -> Dict[str, str]:
     return e
 
 
-def validate_schema(spec: Any) -> List[Dict[str, str]]:
-    """Valida la FORMA del spec. Devuelve la lista de errores con su JSON path."""
+def validate_schema(spec: Any, active: Any = None) -> List[Dict[str, str]]:
+    """Valida la FORMA del spec. Devuelve la lista de errores con su JSON path.
+
+    Con `active` se admiten ademas los visuales PERSONALIZADOS que ese
+    informe tenga instalados: su identificador es un GUID distinto en cada
+    proyecto, asi que no puede vivir en una tabla fija.
+    """
     errores: List[Dict[str, str]] = []
     if not isinstance(spec, dict):
         return [_err("$", "El spec debe ser un objeto JSON.")]
@@ -177,9 +182,22 @@ def validate_schema(spec: Any) -> List[Dict[str, str]]:
                 errores.append(_err(f"{base}.type", "Falta 'type'.",
                                     f"Soportados: {visual_factory.SUPPORTED}"))
             elif str(v["type"]).lower() not in visual_factory.TYPE_MAP:
-                errores.append(_err(
-                    f"{base}.type", f"Tipo no soportado: '{v['type']}'.",
-                    f"Soportados: {visual_factory.SUPPORTED}"))
+                # Puede ser un personalizado instalado en ESTE informe.
+                guid = None
+                instalados: List[str] = []
+                if active is not None and getattr(active, "report_dir", None):
+                    from horizun_pbi_mcp.pbip import custom_visuals
+
+                    guid = custom_visuals.resolve_guid(active.report_dir, v["type"])
+                    instalados = sorted(custom_visuals.discover_for(active))
+                if guid is None:
+                    sugerencia = f"Nativos: {visual_factory.SUPPORTED}."
+                    if active is not None:
+                        sugerencia += (" Personalizados instalados en este "
+                                       f"informe: {instalados or 'ninguno'}.")
+                    errores.append(_err(
+                        f"{base}.type", f"Tipo no soportado: '{v['type']}'.",
+                        sugerencia))
             campos = v.get("fields")
             if campos is not None and not isinstance(campos, dict):
                 errores.append(_err(f"{base}.fields",
@@ -440,7 +458,7 @@ def compile_spec(active: ActivePbip, spec: Dict[str, Any],
     No escribe nada. Es el paso comun a preview, diff y apply, para que los
     tres describan exactamente lo mismo.
     """
-    errores = validate_schema(spec)
+    errores = validate_schema(spec, active)
     if errores:
         raise SpecValidationError(
             f"El spec tiene {len(errores)} error(es) de esquema.",

--- a/src/horizun_pbi_mcp/services/pbir_edit.py
+++ b/src/horizun_pbi_mcp/services/pbir_edit.py
@@ -168,6 +168,20 @@ def report_capabilities(active: ActivePbip) -> Dict[str, Any]:
             if entrada["template"] is None:
                 entrada["template"] = {"page": pagina["name"], "visual_id": v["id"]}
 
+    # Los personalizados INSTALADOS, con los roles que declara cada manifiesto.
+    # `public_custom_visuals` (de report.json) solo dice que el informe los
+    # descarga de AppSource; esto dice cuales estan de verdad en el proyecto y
+    # QUE roles aceptan, que es lo que hace falta para escribir uno.
+    from horizun_pbi_mcp.pbip import custom_visuals as _cv
+
+    instalados = _cv.discover_for(active)
+    personalizados = {
+        guid: {"display_name": info["display_name"],
+               "version": info["version"],
+               "roles": _cv.role_names(info)}
+        for guid, info in sorted(instalados.items())
+    }
+
     return {
         "pbir_version": version,
         # Coherente con assert_pbir_soportado: sin version NO es soportado.
@@ -177,10 +191,13 @@ def report_capabilities(active: ActivePbip) -> Dict[str, Any]:
         "writable": version in VERSIONES_SOPORTADAS,
         "theme": tema,
         "public_custom_visuals": custom,
+        "custom_visuals_installed": personalizados,
         "visual_types_present": tipos,
         "clonable_types": sorted(tipos),
         "note": ("Solo se pueden crear visuales de tipos ya presentes en el "
-                 "informe: se clona una estructura real en vez de inventarla."),
+                 "informe: se clona una estructura real en vez de inventarla. "
+                 "Los de `custom_visuals_installed` se pueden usar por su GUID "
+                 "en `type`, con los roles que ahi se listan."),
     }
 
 

--- a/src/horizun_pbi_mcp/tools/spec_tools.py
+++ b/src/horizun_pbi_mcp/tools/spec_tools.py
@@ -108,7 +108,14 @@ def register(mcp) -> None:
         que se puedan corregir sin adivinar. No escribe nada.
         """
         def _impl():
-            errores = page_spec.validate_schema(spec)
+            # Con el proyecto activo, la validacion admite ademas los
+            # visuales personalizados que ESE informe tiene instalados.
+            activo = None
+            try:
+                activo = get_session().require_active_pbip()
+            except Exception:                        # noqa: BLE001
+                pass
+            errores = page_spec.validate_schema(spec, activo)
             if errores:
                 return {"valid": False, "stage": "schema", "errors": errores,
                         "schema_version": page_spec.SCHEMA_VERSION}

--- a/tests/test_visuales_personalizados.py
+++ b/tests/test_visuales_personalizados.py
@@ -1,0 +1,277 @@
+"""Visuales PERSONALIZADOS: se descubren del informe, no se codifican.
+
+El bloqueo que cierra: `pbi_apply_page_spec` rechazaba un GUID de visual
+personalizado porque `TYPE_MAP` es una tupla fija de nativos. En un tablero
+4D/5D eso significaba poder montar KPIs, curvas y tablas pero NO el visor 3D
+ni la linea de tiempo —justo el motivo de conectar BIM con Power BI—.
+
+Las reglas que se vigilan aqui:
+
+1. **El contrato lo publica el visual**, no nosotros: los roles validos salen
+   de `capabilities.dataRoles` del `.pbiviz.json` que el informe ya tiene
+   instalado. Un rol que ese GUID no declara se rechaza con la lista de los
+   validos, con el mismo rigor que con un nativo.
+2. **Los contratos NATIVOS no se aplican a un tercero.** `REQUIRED_ROLES`,
+   `MAX_PER_ROLE` y `ROLE_KINDS` salieron del catalogo oficial de Microsoft;
+   imponerlos a un visual de terceros seria inventarle un contrato.
+3. **Se conserva su configuracion propia.** `objects.connection` del visor APS
+   lleva `baseUrl` y el token `mt`: sin eso el visual carga vacio. Lo que SI
+   se descarta es la seleccion puntual heredada (`selector.data` con
+   `scopeId`) y el formato de marco que el catalogo oficial rechaza.
+
+Los fixtures son SINTETICOS: el informe real con el visor y el buildMotion no
+puede entrar al repositorio.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from horizun_pbi_mcp.config import ActivePbip
+from horizun_pbi_mcp.pbip import custom_visuals, visual_factory
+from horizun_pbi_mcp.powerbi.errors import VisualFactoryError
+from horizun_pbi_mcp.services import page_spec
+
+GUID_VISOR = "aPSModelViewer02FA0CE460E64F779B012F5831EB091C"
+GUID_TIMELINE = "buildMotionFull9BE91111D3D84D37B27DA2B9B03293AD"
+
+POS = {"x": 0, "y": 0, "width": 600, "height": 400}
+
+
+def _pbiviz(guid: str, display: str, roles: list) -> dict:
+    return {"visual": {"guid": guid, "displayName": display, "version": "1.0.0"},
+            "capabilities": {"dataRoles": [
+                {"name": r, "kind": "Grouping", "displayName": r} for r in roles]}}
+
+
+@pytest.fixture
+def informe(tmp_path):
+    """Informe minimo con dos visuales personalizados instalados."""
+    custom_visuals.invalidate_cache()
+    report = tmp_path / "Demo.Report"
+    (report / "definition" / "pages").mkdir(parents=True)
+    for guid, nombre, roles in (
+            (GUID_VISOR, "PowerBIM Viewer",
+             ["dbids", "modelId", "colorBy", "externalIds"]),
+            (GUID_TIMELINE, "BuildMotion Timeline", ["timelineDate", "label"])):
+        d = report / "CustomVisuals" / guid / "resources"
+        d.mkdir(parents=True)
+        (d / f"{guid}.pbiviz.json").write_text(
+            json.dumps(_pbiviz(guid, nombre, roles)), encoding="utf-8")
+    active = ActivePbip(pbip_path=str(tmp_path / "Demo.pbip"),
+                        project_dir=str(tmp_path), report_dir=str(report),
+                        report_name="Demo", has_pbir=True, has_tmdl=True)
+    yield active
+    custom_visuals.invalidate_cache()
+
+
+def _plantilla(informe, guid: str, objects: dict | None = None,
+               vco: dict | None = None) -> None:
+    """Escribe un visual del tipo dado para que sirva de plantilla.
+
+    Incluye `page.json` y `pages.json`: `list_pages` se niega -con razon- a
+    trabajar sobre un inventario incompleto del informe.
+    """
+    from pathlib import Path
+
+    paginas = Path(informe.report_dir) / "definition" / "pages"
+    paginas.mkdir(parents=True, exist_ok=True)
+    (paginas / "pages.json").write_text(json.dumps({
+        "$schema": ("https://developer.microsoft.com/json-schemas/fabric/item/"
+                    "report/definition/pagesMetadata/1.0.0/schema.json"),
+        "pageOrder": ["p1"], "activePageName": "p1"}), encoding="utf-8")
+    (paginas / "p1").mkdir(exist_ok=True)
+    (paginas / "p1" / "page.json").write_text(json.dumps({
+        "$schema": ("https://developer.microsoft.com/json-schemas/fabric/item/"
+                    "report/definition/page/2.1.0/schema.json"),
+        "name": "p1", "displayName": "Pagina", "displayOption": "FitToPage",
+        "height": 720, "width": 1280}), encoding="utf-8")
+    d = paginas / "p1" / "visuals" / "plantilla0000000000aa"
+    d.mkdir(parents=True, exist_ok=True)
+    vis = {"visualType": guid, "query": {"queryState": {}},
+           "drillFilterOtherVisuals": True}
+    if objects is not None:
+        vis["objects"] = objects
+    if vco is not None:
+        vis["visualContainerObjects"] = vco
+    (d / "visual.json").write_text(json.dumps({
+        "$schema": visual_factory.SCHEMA_VISUAL, "name": "plantilla0000000000aa",
+        "position": POS, "visual": vis}), encoding="utf-8")
+
+
+# ------------------------------------------------------------ descubrimiento ---
+def test_descubre_los_instalados_con_sus_roles(informe):
+    hallados = custom_visuals.discover_for(informe)
+    assert set(hallados) == {GUID_VISOR, GUID_TIMELINE}
+    assert custom_visuals.role_names(hallados[GUID_VISOR]) == [
+        "dbids", "modelId", "colorBy", "externalIds"]
+
+
+def test_un_informe_sin_custom_visuals_no_es_un_error(tmp_path):
+    custom_visuals.invalidate_cache()
+    (tmp_path / "R.Report").mkdir(parents=True)
+    assert custom_visuals.discover(tmp_path / "R.Report") == {}
+
+
+def test_un_manifiesto_corrupto_no_tumba_a_los_demas(informe, tmp_path):
+    """Metadato de un visual de terceros: que uno venga roto no puede impedir
+    escribir el resto de la pagina."""
+    from pathlib import Path
+
+    malo = (Path(informe.report_dir) / "CustomVisuals" / "roto" / "resources")
+    malo.mkdir(parents=True)
+    (malo / "roto.pbiviz.json").write_text("{esto no es json", encoding="utf-8")
+    custom_visuals.invalidate_cache()
+    assert set(custom_visuals.discover_for(informe)) == {GUID_VISOR, GUID_TIMELINE}
+
+
+def test_la_cache_se_entera_de_una_instalacion_nueva(informe):
+    from pathlib import Path
+
+    assert len(custom_visuals.discover_for(informe)) == 2
+    guid = "otroVisual1234567890ABCDEF1234567890ABCD"
+    d = Path(informe.report_dir) / "CustomVisuals" / guid / "resources"
+    d.mkdir(parents=True)
+    (d / f"{guid}.pbiviz.json").write_text(
+        json.dumps(_pbiviz(guid, "Otro", ["x"])), encoding="utf-8")
+    assert guid in custom_visuals.discover_for(informe), (
+        "cachear solo por ruta serviria datos viejos tras instalar un visual")
+
+
+# ------------------------------------------------------- validacion del tipo ---
+def test_el_spec_acepta_un_guid_instalado(informe):
+    spec = {"schema_version": "1.0", "page": {"name": "P"},
+            "visuals": [{"type": GUID_VISOR,
+                         "fields": {"dbids": ["Modelo[dbids]"]}}]}
+    assert page_spec.validate_schema(spec, informe) == []
+
+
+def test_el_spec_rechaza_un_guid_que_no_esta_instalado(informe):
+    spec = {"schema_version": "1.0", "page": {"name": "P"},
+            "visuals": [{"type": "guidQueNadieInstalo", "fields": {}}]}
+    errores = page_spec.validate_schema(spec, informe)
+    assert errores and errores[0]["path"] == "$.visuals[0].type"
+    assert GUID_VISOR in errores[0]["hint"], (
+        "el error debe listar lo que SI se puede usar en este informe")
+
+
+def test_sin_proyecto_activo_solo_se_admiten_nativos():
+    spec = {"schema_version": "1.0", "page": {"name": "P"},
+            "visuals": [{"type": GUID_VISOR, "fields": {}}]}
+    assert page_spec.validate_schema(spec) != []
+
+
+def test_el_guid_se_escribe_canonico_no_como_se_teclee(informe):
+    """`visualType` tiene que coincidir exacto o Power BI no lo encuentra."""
+    assert visual_factory.resolve_type(GUID_VISOR.lower(), informe) == GUID_VISOR
+
+
+# ------------------------------------------------------------ roles verbatim ---
+def test_los_roles_se_escriben_tal_cual_los_declara_el_manifiesto(informe):
+    r = visual_factory.build_visual(
+        informe, GUID_VISOR,
+        {"dbids": ["M[a]"], "modelId": ["M[b]"], "colorBy": ["M[c]"],
+         "externalIds": ["M[d]"]}, POS, measure_index={})
+    estados = r["visual"]["visual"]["query"]["queryState"]
+    assert sorted(estados) == ["colorBy", "dbids", "externalIds", "modelId"]
+
+
+def test_un_rol_que_el_visual_no_declara_se_rechaza(informe):
+    with pytest.raises(VisualFactoryError) as exc:
+        visual_factory.build_visual(informe, GUID_TIMELINE,
+                                    {"category": ["M[a]"]}, POS, measure_index={})
+    assert "no declara un rol 'category'" in str(exc.value)
+    assert "timelineDate" in str(exc.value.details["valid_roles"])
+
+
+def test_los_contratos_nativos_no_se_le_imponen_a_un_tercero(informe):
+    """Un solo rol basta: REQUIRED_ROLES es del catalogo oficial, no suyo."""
+    r = visual_factory.build_visual(informe, GUID_TIMELINE,
+                                    {"timelineDate": ["Cal[Fecha]"]}, POS,
+                                    measure_index={})
+    assert sorted(r["visual"]["visual"]["query"]["queryState"]) == ["timelineDate"]
+
+
+def test_el_guard_de_contratos_nativos_protege_de_verdad(informe, monkeypatch):
+    """Prueba el GUARD, no su ausencia de efecto.
+
+    Con las tablas nativas tal cual, `_validate_role_contract` ya es un no-op
+    para un tipo desconocido -todos los `.get(tipo, vacio)` fallan al mismo
+    sitio-, asi que quitar el `return` temprano no cambiaba nada y la prueba
+    anterior pasaba igual: no verificaba nada. Aqui se pone a proposito una
+    entrada nativa para ese GUID y se exige que NO se le aplique. Si alguien
+    quita el guard, esto falla.
+    """
+    monkeypatch.setitem(visual_factory.REQUIRED_ROLES, GUID_TIMELINE,
+                        ("RolQueNadieVaAMandar",))
+    monkeypatch.setitem(visual_factory.MAX_PER_ROLE, GUID_TIMELINE,
+                        {"timelineDate": 0})
+    r = visual_factory.build_visual(informe, GUID_TIMELINE,
+                                    {"timelineDate": ["Cal[Fecha]"]}, POS,
+                                    measure_index={})
+    assert sorted(r["visual"]["visual"]["query"]["queryState"]) == ["timelineDate"]
+
+
+def test_un_personalizado_sin_roles_declarados_se_acusa(tmp_path):
+    from pathlib import Path
+
+    custom_visuals.invalidate_cache()
+    report = tmp_path / "R.Report"
+    guid = "sinRoles1234567890ABCDEF1234567890ABCDEF"
+    d = report / "CustomVisuals" / guid / "resources"
+    d.mkdir(parents=True)
+    (d / f"{guid}.pbiviz.json").write_text(
+        json.dumps({"visual": {"guid": guid, "displayName": "X"},
+                    "capabilities": {}}), encoding="utf-8")
+    (report / "definition" / "pages").mkdir(parents=True)
+    active = ActivePbip(pbip_path=str(tmp_path / "R.pbip"),
+                        project_dir=str(tmp_path), report_dir=str(report),
+                        report_name="R", has_pbir=True, has_tmdl=True)
+    with pytest.raises(VisualFactoryError) as exc:
+        visual_factory.build_visual(active, guid, {"x": ["A[b]"]}, POS,
+                                    measure_index={})
+    assert "no declara ningun rol" in str(exc.value)
+    custom_visuals.invalidate_cache()
+
+
+# --------------------------------------------- lo propio del visual se conserva ---
+def test_se_conserva_la_configuracion_propia_del_visual(informe):
+    """`connection` lleva baseUrl y el token: sin eso el visor carga vacio."""
+    _plantilla(informe, GUID_VISOR, objects={
+        "connection": [{"properties": {
+            "baseUrl": {"expr": {"Literal": {"Value": "'https://ejemplo'"}}},
+            "mt": {"expr": {"Literal": {"Value": "'token123'"}}}}}],
+        "viewer": [{"properties": {
+            "showBrand": {"expr": {"Literal": {"Value": "true"}}}}}]})
+    r = visual_factory.build_visual(informe, GUID_VISOR,
+                                    {"dbids": ["M[a]"]}, POS, measure_index={})
+    objetos = r["visual"]["visual"]["objects"]
+    props = objetos["connection"][0]["properties"]
+    assert "baseUrl" in props and "mt" in props
+    assert "viewer" in objetos
+
+
+def test_se_descarta_la_seleccion_puntual_heredada(informe):
+    """scopeIds de la plantilla: apuntan a filas que este visual no tiene."""
+    _plantilla(informe, GUID_VISOR, objects={
+        "connection": [{"properties": {
+            "baseUrl": {"expr": {"Literal": {"Value": "'https://ejemplo'"}}}}}],
+        "dataColors": [{"properties": {}, "selector": {"data": [
+            {"scopeId": {"Comparison": {"ComparisonKind": 0}}}]}}]})
+    r = visual_factory.build_visual(informe, GUID_VISOR,
+                                    {"dbids": ["M[a]"]}, POS, measure_index={})
+    objetos = r["visual"]["visual"]["objects"]
+    assert "dataColors" not in objetos
+    assert "connection" in objetos, "lo propio del visual NO se toca"
+
+
+def test_un_wildcard_no_es_una_seleccion_puntual(informe):
+    """`dataViewWildcard` significa 'todos los puntos': se conserva."""
+    _plantilla(informe, GUID_VISOR, objects={
+        "dataColors": [{"properties": {"fill": {"solid": {"color": {
+            "expr": {"Literal": {"Value": "'#FF0000'"}}}}}},
+            "selector": {"data": [{"dataViewWildcard": {"matchingOption": 1}}]}}]})
+    r = visual_factory.build_visual(informe, GUID_VISOR,
+                                    {"dbids": ["M[a]"]}, POS, measure_index={})
+    assert "dataColors" in r["visual"]["visual"]["objects"]


### PR DESCRIPTION
Closes the blocker in `ISSUE_visuales_personalizados.md`.

## What was wrong

`pbi_apply_page_spec` / `pbi_create_visual` / `pbi_compose_page` rejected custom-visual GUIDs. In a 4D/5D dashboard that meant the MCP could build KPIs, curves and tables but **not the 3D viewer or the timeline** — precisely why BIM gets connected to Power BI.

Widening a list doesn't fix it: `TYPE_MAP` comes from a fixed tuple of 29 natives, and a custom visual's id is a different GUID in every report.

## The design: discover, don't hardcode

The source of truth already lives inside the project — `<Report>/CustomVisuals/<GUID>/resources/<GUID>.pbiviz.json` declares `capabilities.dataRoles`. So custom visuals are validated **as strictly as natives without inventing any contract**: the contract is published by the visual itself.

- Discovery cached by path + mtime (path-only caching would serve stale data right after installing one); a corrupt manifest is warned about and skipped — third-party metadata can't block writing the rest of the page.
- `resolve_type` returns the **canonical** GUID from the manifest, not what was typed: `visualType` must match exactly or Power BI won't find it.
- **Roles verbatim**, validated against the manifest. Native contracts (`REQUIRED_ROLES`, `MAX_PER_ROLE`, `ROLE_KINDS`) are *not* imposed — they came from Microsoft's official catalog and say nothing about a third-party visual.
- `pbi_report_capabilities` now announces `custom_visuals_installed` with their roles, and the type error lists what *can* be used in this report.

## What the official validator caught, and reasoning didn't

Cloning propagated `dropShadow.preset='Outer'` from the template — invalid per the official catalog, tolerated by Desktop. Every new visual added an error, so the transaction guard blocked the write (correctly: the report would get worse).

Inherited container chrome is now sanitized against a **native** catalog (`visualContainerObjects` are shared chrome; `catalog describe <GUID>` doesn't work for third parties — verified), and only when the real CLI is available: the local snapshot is a minimal subset and using it would strip legitimate formatting.

The visual's own config is preserved (`objects.connection` carries `baseUrl` and the `mt` token — without them the viewer loads empty). Inherited **point** selections (`selector.data` with `scopeId`) are dropped; a `dataViewWildcard` is not a point selection and is kept — caught by a pre-existing test my first version broke.

## Acceptance criteria

- ✅ `pbi_report_capabilities` lists installed custom visuals
- ✅ `pbi_validate_page_spec` accepts an installed GUID, rejects an uninstalled one
- ✅ APS viewer written with its 4 roles (`dbids`, `modelId`, `colorBy`, `externalIds`)
- ✅ buildMotion written with `timelineDate`
- ✅ **Official CLI: 0 new errors** — verified on the real report (36 → 36, doesn't block), `connection` intact
- ✅ An invalid role is rejected listing the valid ones
- ✅ 16 tests with a synthetic fixture; 6/6 mutation-verified

One mutation initially escaped: native contracts are a no-op for an unknown type, so the guard's removal changed nothing observable. The test was rewritten to prove the **guard**, not its lack of effect.

Suite: 1811 passed. Contract unchanged. `doctor.py` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
