### PR TITLE
The two server states can no longer diverge silently

### DIFF
--- a/FEEDBACK_sesion_tablero_5D.md
+++ b/FEEDBACK_sesion_tablero_5D.md
@@ -1,0 +1,243 @@
+# Feedback de uso — Horizun PBI MCP v1.0.1
+
+**Fecha:** 2026-08-04
+**Escenario:** construir de cero un tablero 5D BIM de 4 páginas (portada,
+presupuesto, 4D cronograma, 5D valor ganado) sobre un `.pbix` existente con
+modelo BIM + cronograma de MS Project + costos de ERP.
+**Volumen:** ~120 llamadas al MCP, 22 medidas creadas, 4 páginas, 2 conversiones
+de formato, 3 rediseños completos.
+
+---
+
+## Lo que funcionó bien
+
+Vale la pena decirlo antes de la lista de problemas, porque estas decisiones
+se notan y son las que hicieron el trabajo posible:
+
+- **El bloqueo por "Desktop tiene el proyecto abierto"** evitó al menos dos
+  pérdidas de trabajo. El mensaje explica *por qué* bloquea (que el Ctrl+S del
+  usuario sobrescribiría) en vez de solo negarse. Excelente.
+- **Transacciones con journal y backup** en cada escritura. Da confianza para
+  operar sobre el archivo de trabajo de alguien.
+- **`pbi_validate_tmdl`** con el aviso de `tmdl_transform_without_culture`
+  detectó, sin ejecutar nada, el riesgo del separador decimal — que resultó ser
+  un error real (valores ×100 en el ERP).
+- **Los mensajes de error accionables.** `pbi_convert_pbix_to_pbip` no dijo
+  "ruta demasiado larga": dijo *"mide 310 caracteres, elige un out_dir al menos
+  51 caracteres más corto (p.ej. C:\pbip)"*. Se resolvió al primer intento.
+- **`pbi_run_dax`** fue la herramienta más usada de todas. Poder verificar cada
+  número contra el modelo en vivo cambió por completo la calidad del trabajo.
+
+---
+
+## 1. CRÍTICO — Proyecto activo y modelo activo pueden ser archivos distintos
+
+### Observación
+`pbi_select_model` apuntaba al modelo en vivo de `Sesion9.pbix`, mientras
+`pbi_start_here` reportaba:
+
+```
+Proyecto activo: Control_Acceso.pbip
+```
+
+Un archivo **completamente distinto**, de otro cliente. `pbi_report_capabilities`
+devolvió los visuales y el tema de `Control_Acceso`, no del informe en el que
+estábamos trabajando.
+
+### Impacto
+Estuve a punto de escribir 4 páginas nuevas dentro del informe equivocado.
+Solo lo detecté porque el conteo de visuales no cuadraba con lo que había
+inspeccionado minutos antes.
+
+En un uso desatendido —o con alguien con menos contexto— esto corrompe el
+trabajo de otro proyecto de forma silenciosa.
+
+### Sugerencia
+- Que `pbi_start_here` y `pbi_health_check` marquen en ROJO cuando
+  `active_model` y `active_pbip` no correspondan al mismo archivo.
+- Que las herramientas de informe (`pbi_apply_page_spec`, `pbi_compose_page`,
+  `pbi_create_visual`) **se nieguen** si hay desajuste, igual que se niegan
+  cuando Desktop tiene el proyecto abierto. El precedente ya existe y funciona.
+- Alternativa mínima: incluir el nombre del proyecto destino en la respuesta de
+  toda herramienta que escriba en el informe.
+
+---
+
+## 2. CRÍTICO — `mode='live'` produce medidas efímeras que rompen informes
+
+### Observación
+Creé 5 medidas con `pbi_create_measure(mode='live')`. La respuesta avisa:
+
+> "Cambio aplicado en el modelo en memoria. Para que quede guardado usa Ctrl+S."
+
+El usuario cerró Desktop sin guardar. Las medidas desaparecieron. Las páginas
+que ya las referenciaban quedaron con **"Hubo un problema con uno o más
+campos"** en 4 tarjetas.
+
+### Impacto
+Estado inconsistente entre el informe (en disco) y el modelo (en memoria), que
+ninguna validación detecta porque cada mitad es válida por separado.
+
+### Sugerencia
+- Que `mode='live'` devuelva `"persisted": false` de forma **prominente**, no
+  como nota al pie, y que lo repita en la respuesta de cualquier herramienta que
+  después referencie esa medida.
+- Que `pbi_apply_page_spec` valide las referencias contra el **modelo
+  persistido** (TMDL), no solo contra el vivo. Una página en disco que apunta a
+  una medida que solo existe en memoria es una bomba de tiempo.
+- Considerar un `pbi_persist_live_changes` que serialice el modelo vivo a TMDL
+  sin depender del Ctrl+S del usuario.
+
+---
+
+## 3. ALTO — `sync_mode='merge'` deja huérfanos al cambiar el lienzo
+
+### Observación
+Apliqué `pbi_apply_design_system('sala')` (1920×1080), compuse 4 páginas, y
+después cambié a `informe` (1280×720) y recompuse. Con `merge` (el defecto),
+los visuales de la composición anterior **se conservaron fuera del lienzo**:
+
+```
+"not_removed": ["5423ec9e284a415f8222", "6691c6aa4ee14658894f", ...]
+PBIR_LAYOUT_OUT_OF_BOUNDS_WIDTH  ×3
+PBIR_LAYOUT_OUT_OF_BOUNDS_HEIGHT ×1
+```
+
+### Impacto
+La página queda con basura invisible que sí se lleva al render y a la
+publicación. Hay que descubrirlo con `pbi_detect_layout_issues` y limpiar a mano.
+
+### Sugerencia
+- Detectar que el lienzo cambió de tamaño y **avisar** que `merge` va a dejar
+  visuales fuera de límites, proponiendo `replace`.
+- O reflujar automáticamente los conservados a la nueva rejilla.
+
+---
+
+## 4. ALTO — Cambiar el sistema de diseño después no tiene camino de vuelta
+
+### Observación
+La documentación de `pbi_list_design_systems` avisa:
+
+> "Elígelo ANTES de la primera página; cambiarlo después obliga a recolocarlo todo."
+
+Es un aviso honesto, pero en la práctica el usuario **sí cambia de opinión**
+(en esta sesión pasó: oscuro → claro a mitad del trabajo). Y cuando pasa, la
+herramienta no ayuda: hay que recomponer cada página a mano.
+
+Además hay un detalle no obvio: los `textbox` de título que genera
+`pbi_compose_page` llevan el color **hardcodeado** (`#FFFFFF` con el tema
+oscuro). Al cambiar a tema claro quedan blancos sobre blanco — invisibles.
+Recomponer la página los arregla, pero no está dicho en ninguna parte.
+
+### Sugerencia
+- Un `pbi_reflow_pages(system=...)` que reescale posiciones y recalcule los
+  colores de texto de los elementos decorativos.
+- Como mínimo, que `pbi_apply_design_system` avise cuántas páginas existen ya
+  con otro lienzo y qué va a pasar con ellas.
+
+---
+
+## 5. MEDIO — `pbi_compose_page` tiene una sola forma posible
+
+### Observación
+La composición es siempre título → KPIs → hero → supports → detail. Está
+documentado como decisión deliberada ("la coherencia sale de que ninguna
+página pueda inventarse su propio orden"), y para 3 de las 4 páginas funcionó.
+
+Pero para la portada —que necesitaba nombre de proyecto grande, un visor 3D
+protagonista y navegación— tuve que abandonarla y bajar a `pbi_apply_page_spec`
+con posiciones calculadas a mano.
+
+### Sugerencia
+No romper la opinión de la herramienta, pero añadir 2-3 arquetipos más:
+`portada` (título grande + navegación + cifras), `detalle` (tabla dominante),
+`monitor` (un visual a pantalla completa + KPIs al margen). Que el usuario elija
+arquetipo, no geometría.
+
+---
+
+## 6. MEDIO — Sin validación de propiedades de formato
+
+### Observación
+*Este hallazgo salió de escribir PBIR a mano, no del MCP — pero es directamente
+relevante para su diseño.*
+
+Escribí formato de `tableEx` con propiedades plausibles pero no verificadas
+(`backColorPrimary`, `rowPadding`, `gridVerticalColor`, `total`). Resultado:
+
+- **Tarjetas y gráficos**: ignoran en silencio la propiedad desconocida.
+- **`tableEx`**: **no renderiza en absoluto**. Tabla vacía y error en pantalla.
+
+O sea, la tolerancia a propiedades inválidas **no es uniforme entre tipos de
+visual**.
+
+También me mordió `labelPrecision: 0` en `card`: es válida, pero sobrescribe el
+`formatString` de la medida. Puse 0 para que el presupuesto no llevara
+decimales y terminó mostrando SPI 0,88 como **1**.
+
+### Sugerencia
+- Aplicar a las propiedades de formato la misma disciplina que ya se aplica a
+  los roles: validar contra el catálogo antes de escribir.
+- Advertir cuando una propiedad de formato del visual **anula** el
+  `formatString` de la medida (`labelPrecision`, `labelDisplayUnits`).
+
+---
+
+## 7. MEDIO — Muchos ciclos cerrar/abrir Desktop
+
+### Observación
+El bloqueo por proyecto abierto es correcto, pero en esta sesión obligó a
+**5 ciclos** de cerrar Desktop → escribir → reabrir → refrescar. Cada uno cuesta
+~40 s más la atención del usuario, y en dos de ellos se perdió el refresco.
+
+### Sugerencia
+- Poder **encolar** varias operaciones de escritura y ejecutarlas en un solo
+  cierre (`pbi_batch_report_edits`).
+- O que `pbi_open_in_desktop` tenga `refresh_after=true` para no perder el
+  refresco en cada ciclo.
+
+---
+
+## 8. BAJO — El navegador de páginas muestra las páginas ocultas
+
+### Observación
+Marqué 5 páginas con `"visibility": "HiddenInViewMode"` en `page.json` para que
+el visual `pageNavigator` mostrara solo las 4 reales. En modo edición las siguió
+mostrando, con los nombres en vertical por falta de ancho. Hubo que borrarlas.
+
+### Sugerencia
+Documentar que `pageNavigator` respeta `visibility` solo en modo vista, o
+exponer su opción de excluir páginas ocultas.
+
+---
+
+## 9. Petición de función — Visuales personalizados
+
+Ver documento aparte: **`ISSUE_visuales_personalizados.md`**.
+
+Resumen: `page_spec.py:179` valida contra `visual_factory.TYPE_MAP`, una tupla
+fija de 29 tipos nativos. Los visuales personalizados del informe (visor APS,
+buildMotion) no se pueden escribir, y son justamente el motivo de conectar BIM
+con Power BI. La solución propuesta es descubrirlos leyendo
+`CustomVisuals/*/resources/*.pbiviz.json`, que ya declara sus roles.
+
+---
+
+## Resumen priorizado
+
+| # | Severidad | Hallazgo |
+|---|---|---|
+| 1 | Crítico | Proyecto activo ≠ modelo activo, sin aviso |
+| 2 | Crítico | `mode='live'` efímero rompe informes en disco |
+| 9 | Alto | Visuales personalizados no soportados |
+| 3 | Alto | `merge` deja huérfanos al cambiar lienzo |
+| 4 | Alto | Cambiar sistema de diseño no tiene reflujo |
+| 5 | Medio | `compose_page` con una sola forma |
+| 6 | Medio | Sin validación de propiedades de formato |
+| 7 | Medio | Demasiados ciclos cerrar/abrir Desktop |
+| 8 | Bajo | `pageNavigator` ignora `visibility` en edición |
+
+**Los dos críticos comparten causa raíz:** el MCP mantiene dos estados
+(modelo vivo y proyecto en disco) que pueden divergir, y ninguna validación
+cruza los dos. Es donde yo pondría el siguiente esfuerzo.

--- a/src/horizun_pbi_mcp/powerbi/model_writer.py
+++ b/src/horizun_pbi_mcp/powerbi/model_writer.py
@@ -35,6 +35,32 @@ LIVE_NOTE = (
     "guardado en el archivo, usa Ctrl+S en Power BI Desktop."
 )
 
+#: Aviso PROMINENTE de que lo escrito es efimero.
+#:
+#: Antes esto viajaba solo como `note`, una nota al pie que se lee al final o
+#: no se lee. Paso lo previsible: se crearon cinco medidas en vivo, Desktop se
+#: cerro sin guardar, y las paginas que YA las referenciaban quedaron con
+#: "Hubo un problema con uno o mas campos" en cuatro tarjetas. Ninguna
+#: validacion lo detecta porque cada mitad -informe en disco y modelo en
+#: memoria- es valida por separado.
+#:
+#: Ahora sale `persisted: False` y un warning, que ademas hace que el envelope
+#: marque la respuesta como WARNING en vez de exito limpio: quien la lea por
+#: encima ve igualmente que algo queda pendiente.
+_AVISO_EFIMERO = (
+    "NO PERSISTIDO: este cambio vive SOLO en la memoria de Power BI Desktop. "
+    "Si se cierra sin guardar, desaparece — y cualquier pagina del informe que "
+    "ya lo referencie quedara rota ('Hubo un problema con uno o mas campos'). "
+    "Guarda con Ctrl+S en Desktop, o usa mode='pbip' para escribir en el TMDL, "
+    "que si es duradero."
+)
+
+
+def _efimero() -> Dict[str, Any]:
+    """Campos que acompanan a TODA escritura en vivo."""
+    return {"persisted": False, "note": LIVE_NOTE,
+            "warnings": [_AVISO_EFIMERO]}
+
 
 def _find_table(mdl, table_name: str):
     wanted = table_name.casefold()
@@ -195,7 +221,7 @@ def create_measure(
         _save_changes(mdl, "create_measure", table=target.Name, measure=name)
         after = _snapshot(measure)
     return {"action": action, "table": target.Name, "before": before,
-            "after": after, "note": LIVE_NOTE}
+            "after": after, **_efimero()}
 
 
 def update_measure(
@@ -227,7 +253,7 @@ def update_measure(
         _save_changes(mdl, "update_measure", table=owner.Name, measure=name)
         after = _snapshot(measure)
     return {"action": "updated", "table": owner.Name, "before": before, "after": after,
-            "note": LIVE_NOTE}
+            **_efimero()}
 
 
 def set_column_hidden(session: Session, table: str, column: str,
@@ -250,7 +276,7 @@ def set_column_hidden(session: Session, table: str, column: str,
         col.IsHidden = bool(hidden)
         _save_changes(mdl, "set_column_hidden", table=t.Name, column=col.Name)
     return {"table": table, "column": column, "before_hidden": before,
-            "after_hidden": bool(hidden), "note": LIVE_NOTE}
+            "after_hidden": bool(hidden), **_efimero()}
 
 
 def _find_column(mdl, table_name: str, column_name: str, index: int):
@@ -329,7 +355,7 @@ def set_columns_hidden_bulk(session: Session, entries: List[Dict[str, str]],
         _save_changes(mdl, "set_columns_hidden_bulk", columns=len(entries))
 
     return {"changed": sum(1 for r in resultados if r["changed"]),
-            "results": resultados, "save_changes_calls": 1, "note": LIVE_NOTE}
+            "results": resultados, "save_changes_calls": 1, **_efimero()}
 
 
 def set_relationship_crossfilter(session: Session, from_table: str, to_table: str,
@@ -366,7 +392,7 @@ def set_relationship_crossfilter(session: Session, from_table: str, to_table: st
         _save_changes(mdl, "set_relationship_crossfilter",
                       from_table=from_table, to_table=to_table)
     return {"matched": matched, "direction": direction, "changes": changes,
-            "note": LIVE_NOTE}
+            **_efimero()}
 
 
 def delete_measure(session: Session, table: str, name: str) -> Dict[str, Any]:
@@ -379,4 +405,4 @@ def delete_measure(session: Session, table: str, name: str) -> Dict[str, Any]:
         before = _snapshot(measure)
         owner.Measures.Remove(measure)
         _save_changes(mdl, "delete_measure", table=owner.Name, measure=name)
-    return {"action": "deleted", "table": owner.Name, "before": before, "note": LIVE_NOTE}
+    return {"action": "deleted", "table": owner.Name, "before": before, **_efimero()}

--- a/src/horizun_pbi_mcp/services/coherencia.py
+++ b/src/horizun_pbi_mcp/services/coherencia.py
@@ -1,0 +1,166 @@
+"""¿El modelo VIVO y el proyecto EN DISCO son el mismo archivo?
+
+El servidor mantiene dos estados a la vez —`active_model` (lo que Power BI
+Desktop tiene en memoria) y `active_pbip` (la carpeta en disco)— y hasta ahora
+ninguna validacion cruzaba los dos. Pueden apuntar a archivos distintos, de
+proyectos distintos, de CLIENTES distintos, y todo responde con normalidad
+porque cada mitad es valida por separado.
+
+El caso real que lo motiva: `pbi_select_model` servia el modelo de un `.pbix`
+mientras `pbi_start_here` reportaba otro `.pbip` como proyecto activo.
+`pbi_report_capabilities` devolvia los visuales del segundo. Se estuvo a punto
+de escribir cuatro paginas dentro del informe equivocado, y solo se detecto
+porque el conteo de visuales no cuadraba. Sin esa casualidad, el trabajo de
+otro proyecto se corrompe en silencio.
+
+La senal es precisa y ya existia a medias: `ActiveModel` guarda el `pid` del
+Power BI Desktop que sirve el modelo, y `project_state` sabe correlacionar un
+`.pbip` con los archivos que un proceso tiene abiertos. Cruzarlos responde la
+pregunta exacta: **ese** Desktop, ¿tiene abierto **este** proyecto?
+
+Tres veredictos, y la diferencia entre el segundo y el tercero es la que evita
+que esto estorbe:
+
+- `same`        el proceso que sirve el modelo tiene abierto este proyecto.
+- `different`   tiene abierto OTRO archivo. Es el caso peligroso y se bloquea.
+- `unknown`     no se pudo comprobar (permisos, proceso que ya no esta). Se
+                AVISA, nunca se bloquea: negarse por no poder verificar
+                convertiria un permiso denegado en una sesion inservible.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from horizun_pbi_mcp.logging_config import get_logger
+from horizun_pbi_mcp.powerbi.errors import PowerBIMCPError
+
+log = get_logger("coherencia")
+
+SAME = "same"
+DIFFERENT = "different"
+UNKNOWN = "unknown"
+NOT_APPLICABLE = "not_applicable"
+
+
+class ProyectoYModeloDivergenError(PowerBIMCPError):
+    """El modelo vivo y el proyecto en disco son archivos distintos."""
+
+    code = "active_model_project_mismatch"
+
+
+def _archivos_del_proceso(pid: int) -> Optional[List[str]]:
+    """Rutas abiertas por ese PID, o None si no se puede saber."""
+    try:
+        import psutil
+    except ImportError:                                  # pragma: no cover
+        return None
+    try:
+        proc = psutil.Process(pid)
+        return [h.path for h in (proc.open_files() or [])]
+    except Exception:                                    # noqa: BLE001
+        # NoSuchProcess, AccessDenied, OSError: en todos, "no se sabe".
+        return None
+
+
+def _pistas_de_otro_archivo(rutas: List[str]) -> List[str]:
+    """Archivos de Power BI que ese proceso tiene abiertos."""
+    interesantes = []
+    for r in rutas:
+        bajo = r.casefold()
+        if bajo.endswith((".pbix", ".pbip")) or ".report" in bajo or \
+                ".semanticmodel" in bajo:
+            interesantes.append(r)
+    return interesantes
+
+
+def check(session) -> Dict[str, Any]:
+    """Veredicto de coherencia entre el modelo activo y el proyecto activo.
+
+    Nunca lanza: es un diagnostico. Quien quiera bloquear usa `assert_coherente`.
+    """
+    modelo = getattr(session, "active_model", None)
+    proyecto = getattr(session, "active_pbip", None)
+
+    if modelo is None or proyecto is None:
+        return {"state": NOT_APPLICABLE,
+                "reason": ("Solo hay uno de los dos estados activos: no puede "
+                           "haber divergencia."),
+                "has_live_model": modelo is not None,
+                "has_project": proyecto is not None}
+
+    detalle_modelo = {"port": getattr(modelo, "port", None),
+                      "pid": getattr(modelo, "pid", None),
+                      "catalog": getattr(modelo, "catalog", None),
+                      "workspace": getattr(modelo, "workspace", None)}
+    detalle_proyecto = {"pbip_path": proyecto.pbip_path,
+                        "name": proyecto.report_name}
+
+    pid = getattr(modelo, "pid", None)
+    if not pid:
+        return {"state": UNKNOWN,
+                "reason": ("El modelo activo no tiene PID asociado, asi que no "
+                           "se puede comprobar que sirva a este proyecto."),
+                "model": detalle_modelo, "project": detalle_proyecto}
+
+    rutas = _archivos_del_proceso(int(pid))
+    if rutas is None:
+        return {"state": UNKNOWN,
+                "reason": (f"No se pudieron leer los archivos abiertos del "
+                           f"proceso {pid} (permisos, o ya no existe). No se "
+                           "afirma coherencia ni divergencia."),
+                "model": detalle_modelo, "project": detalle_proyecto}
+
+    from horizun_pbi_mcp.services import project_state
+
+    raices = [Path(proyecto.project_dir)]
+    for d in (proyecto.report_dir, proyecto.semantic_model_dir):
+        if d:
+            raices.append(Path(d))
+
+    for ruta in rutas:
+        if project_state._references_project(ruta, raices, proyecto.pbip_path):
+            return {"state": SAME,
+                    "reason": (f"El proceso {pid} que sirve el modelo tiene "
+                               "abierto este mismo proyecto."),
+                    "evidence": ruta,
+                    "model": detalle_modelo, "project": detalle_proyecto}
+
+    otros = _pistas_de_otro_archivo(rutas)
+    if not otros:
+        return {"state": UNKNOWN,
+                "reason": (f"El proceso {pid} no muestra ningun archivo de "
+                           "Power BI abierto; no hay con que comparar."),
+                "model": detalle_modelo, "project": detalle_proyecto}
+
+    return {
+        "state": DIFFERENT,
+        "reason": (f"El modelo activo lo sirve el proceso {pid}, que tiene "
+                   f"abierto OTRO archivo, no '{Path(proyecto.pbip_path).name}'. "
+                   "El modelo en vivo y el proyecto en disco son cosas "
+                   "distintas: lo que consultes con DAX no describe el informe "
+                   "que vas a escribir."),
+        "evidence": sorted(set(otros))[:5],
+        "model": detalle_modelo, "project": detalle_proyecto,
+        "how_to_fix": ("Elige uno: `pbi_open_pbip_project` con el proyecto del "
+                       "modelo que estas consultando, o `pbi_select_model` con "
+                       "el puerto del Desktop que tiene abierto este proyecto "
+                       "(`pbi_list_desktop_models` los enumera)."),
+    }
+
+
+def assert_coherente(session, operacion: str) -> Optional[Dict[str, Any]]:
+    """Bloquea si esta CONFIRMADO que son archivos distintos.
+
+    Se niega igual que se niega escribir con Desktop abierto: el precedente ya
+    existe y funciona. Pero solo ante `different` — con `unknown` se deja pasar
+    y se avisa, porque no poder verificar no es lo mismo que estar mal, y
+    convertir un permiso denegado en un bloqueo dejaria el servidor inutil en
+    cualquier maquina con politicas estrictas.
+    """
+    veredicto = check(session)
+    if veredicto["state"] != DIFFERENT:
+        return veredicto
+    raise ProyectoYModeloDivergenError(
+        f"{operacion} se detuvo: {veredicto['reason']} {veredicto['how_to_fix']}",
+        details=veredicto)

--- a/src/horizun_pbi_mcp/services/guide.py
+++ b/src/horizun_pbi_mcp/services/guide.py
@@ -186,6 +186,28 @@ def situacion(session) -> Dict[str, Any]:
             "propuesta y el sistema de diseño lo leen."))
 
     # --- lo que BLOQUEA va primero: no tiene sentido sugerir algo imposible --
+    from horizun_pbi_mcp.services import coherencia
+
+    coh = coherencia.check(session)
+    proyecto["coherence"] = {"state": coh["state"], "reason": coh["reason"]}
+    if coh["state"] == coherencia.DIFFERENT:
+        # Antes que cualquier otra cosa: el modelo que se consulta NO describe
+        # el informe que se va a escribir, y todo lo demas se leeria como si si.
+        frases.append(
+            "AVISO GRAVE: el modelo en vivo y este proyecto son archivos "
+            "DISTINTOS. Lo que consultes con DAX no describe el informe que "
+            "vas a escribir, y las escrituras de informe estan bloqueadas.")
+        pasos.append(_paso(
+            "pbi_list_desktop_models",
+            "Resuelve la divergencia antes de nada: elige el Desktop que "
+            "tiene abierto ESTE proyecto, o abre el proyecto del modelo que "
+            "estas consultando."))
+    elif coh["state"] == coherencia.UNKNOWN:
+        frases.append(
+            "No se pudo comprobar que el modelo en vivo corresponda a este "
+            "proyecto (permisos). No se bloquea nada, pero conviene verificarlo "
+            "antes de escribir.")
+
     if estado.state == project_state.OPEN:
         frases.append(
             "Esta ABIERTO en Power BI Desktop, asi que el modelo (TMDL) no se "

--- a/src/horizun_pbi_mcp/services/pbir_edit.py
+++ b/src/horizun_pbi_mcp/services/pbir_edit.py
@@ -128,13 +128,29 @@ def assert_pbir_soportado(active: ActivePbip, operation: str) -> str:
 
 
 def assert_escritura_pbir(active: ActivePbip, operation: str) -> None:
-    """Puerta unica de toda escritura PBIR: formato soportado + Desktop cerrado.
+    """Puerta unica de toda escritura PBIR.
 
-    El orden importa: primero el formato, porque si no sabemos escribirlo da
-    igual que Desktop este cerrado.
+    Tres comprobaciones, en este orden:
+
+    1. **Formato soportado**: si no sabemos escribirlo, lo demas da igual.
+    2. **Desktop cerrado**: su Ctrl+S sobrescribiria lo que escribamos.
+    3. **El modelo vivo y este proyecto son el MISMO archivo**. Es la mas
+       nueva y nace de un incidente real: `pbi_select_model` servia el modelo
+       de un `.pbix` mientras el proyecto activo era otro `.pbip`, de otro
+       cliente, y se estuvo a punto de escribirle cuatro paginas al informe
+       equivocado. Solo se detecto porque el conteo de visuales no cuadraba.
+       Se niega igual que se niega con Desktop abierto —el precedente ya
+       existe y funciona—, pero SOLO ante una divergencia confirmada: si no se
+       puede verificar, se deja pasar. Negarse por no poder comprobar
+       convertiria un permiso denegado en una sesion inservible.
     """
     assert_pbir_soportado(active, operation)
     project_state.assert_writable(active, operation=operation)
+
+    from horizun_pbi_mcp.config import get_session
+    from horizun_pbi_mcp.services import coherencia
+
+    coherencia.assert_coherente(get_session(), operation)
 
 
 def report_capabilities(active: ActivePbip) -> Dict[str, Any]:

--- a/src/horizun_pbi_mcp/tools/ops_tools.py
+++ b/src/horizun_pbi_mcp/tools/ops_tools.py
@@ -141,6 +141,18 @@ def register(mcp) -> None:
                 f"{Path(pbip.pbip_path).name}" if pbip else "sin proyecto activo",
                 requerido=False)
 
+            # Con los dos estados activos hay una pregunta que ninguna otra
+            # comprobacion hacia: ¿son el MISMO archivo? Puede haber un modelo
+            # de un cliente y un proyecto de otro, y cada mitad valida sola.
+            from horizun_pbi_mcp.services import coherencia
+
+            coh = coherencia.check(session)
+            if coh["state"] != coherencia.NOT_APPLICABLE:
+                add("model_matches_project",
+                    coh["state"] != coherencia.DIFFERENT,
+                    coh["reason"],
+                    requerido=coh["state"] == coherencia.DIFFERENT)
+
             pendientes = []
             if pbip is not None:
                 try:
@@ -271,12 +283,26 @@ def register(mcp) -> None:
                              "desktop_state": estado_proyecto.to_dict(),
                              "writable": estado_proyecto.writable}
 
-            return {
+            # La pregunta que ninguna validacion cruzaba: ¿el modelo en vivo
+            # y el proyecto en disco son el MISMO archivo? Pueden ser de
+            # clientes distintos y todo responder con normalidad, porque cada
+            # mitad es valida por separado.
+            from horizun_pbi_mcp.services import coherencia
+
+            coh = coherencia.check(session)
+            salida = {
                 "active_model": info_modelo,
                 "active_pbip": info_pbip,
+                "coherence": coh,
                 "outputs_dir": str(get_settings().outputs_dir),
                 "live_plans": operations.registro().planes_vivos(),
             }
+            if coh["state"] == coherencia.DIFFERENT:
+                salida["warnings"] = [
+                    "El modelo en vivo y el proyecto activo son archivos "
+                    "DISTINTOS. Las escrituras de informe estan bloqueadas "
+                    "hasta resolverlo. " + coh["how_to_fix"]]
+            return salida
         return guard(_impl)
 
     @mcp.tool()

--- a/src/horizun_pbi_mcp/tools/spec_tools.py
+++ b/src/horizun_pbi_mcp/tools/spec_tools.py
@@ -24,7 +24,17 @@ def _active():
 
 
 def _compilar(spec: Dict[str, Any], seed: str = ""):
-    return page_spec.compile_spec(_active(), spec, _model_data(), seed=seed)
+    datos = _model_data()
+    compilado = page_spec.compile_spec(_active(), spec, datos, seed=seed)
+    # Si los campos se validaron contra el modelo EN VIVO en vez del TMDL, la
+    # respuesta tiene que decirlo: una medida no guardada pasa la comprobacion
+    # y desaparece al cerrar Desktop, dejando la pagina rota en disco.
+    from horizun_pbi_mcp.tools.visual_tools import drenar_avisos_de_fuente
+
+    avisos = drenar_avisos_de_fuente()
+    if avisos:
+        compilado.setdefault("warnings", []).extend(avisos)
+    return compilado
 
 
 def register(mcp) -> None:

--- a/src/horizun_pbi_mcp/tools/visual_tools.py
+++ b/src/horizun_pbi_mcp/tools/visual_tools.py
@@ -22,6 +22,25 @@ RELOAD_HINT = (
 )
 
 
+#: Aviso que se emite cuando los campos se validaron contra el modelo EN VIVO
+#: en vez del TMDL. Se acumula aqui y las tools lo vacian en su respuesta.
+_AVISO_FUENTE_VIVA = (
+    "Los campos se validaron contra el modelo EN VIVO (este proyecto no tiene "
+    "TMDL). Una medida creada con mode='live' y no guardada pasa esta "
+    "comprobacion y desaparece al cerrar Power BI Desktop: la pagina queda en "
+    "disco referenciando algo que ya no existe. Guarda con Ctrl+S antes de "
+    "cerrar."
+)
+_AVISOS_DE_FUENTE: List[str] = []
+
+
+def drenar_avisos_de_fuente() -> List[str]:
+    """Devuelve y limpia los avisos sobre la fuente del modelo."""
+    avisos = list(dict.fromkeys(_AVISOS_DE_FUENTE))
+    _AVISOS_DE_FUENTE.clear()
+    return avisos
+
+
 def _model_data() -> Optional[Dict[str, Any]]:
     """Modelo contra el que se resuelven los campos al escribir en el informe.
 
@@ -39,6 +58,18 @@ def _model_data() -> Optional[Dict[str, Any]]:
         if session.active_pbip and session.active_pbip.has_tmdl:
             return tmdl_reader.read_semantic_model(session.active_pbip)
         if session.active_model:
+            # RESPALDO, y conviene saber que se esta usando: aqui las
+            # referencias se validan contra un modelo EN MEMORIA. Una medida
+            # creada con mode='live' y no guardada existe para esta
+            # comprobacion y desaparece al cerrar Desktop, dejando la pagina
+            # -que si quedo en disco- con "Hubo un problema con uno o mas
+            # campos". Paso de verdad, con cinco medidas y cuatro tarjetas.
+            # No se puede impedir desde aqui, pero callarlo es peor.
+            log.warning(
+                "Sin TMDL: los campos se validan contra el modelo EN VIVO. Lo "
+                "que no este guardado en Desktop no sobrevivira, y las paginas "
+                "que lo referencien quedaran rotas.")
+            _AVISOS_DE_FUENTE.append(_AVISO_FUENTE_VIVA)
             return model_reader.read_model(session)
     except Exception as exc:  # noqa: BLE001
         # Si hay una fuente autoritativa pero esta rota, None significaria

--- a/tests/test_coherencia_modelo_proyecto.py
+++ b/tests/test_coherencia_modelo_proyecto.py
@@ -1,0 +1,185 @@
+"""Los dos estados del servidor pueden divergir, y nadie los cruzaba.
+
+El servidor mantiene `active_model` (lo que Desktop tiene en memoria) y
+`active_pbip` (la carpeta en disco). Pueden apuntar a archivos distintos, de
+clientes distintos, y todo responde con normalidad porque cada mitad es valida
+por separado.
+
+Caso real: `pbi_select_model` servia el modelo de un `.pbix` mientras el
+proyecto activo era otro `.pbip`. `pbi_report_capabilities` devolvia los
+visuales del segundo. Se estuvo a punto de escribir cuatro paginas en el
+informe equivocado y solo se detecto porque el conteo de visuales no cuadraba.
+
+Las dos reglas que se vigilan:
+
+1. **Se bloquea la escritura ante divergencia CONFIRMADA**, igual que se
+   bloquea con Desktop abierto —ese precedente ya existia y funciona—.
+2. **Nunca se bloquea por no poder comprobar.** `unknown` avisa y deja pasar:
+   convertir un permiso denegado en un bloqueo dejaria el servidor inutil en
+   cualquier maquina con politicas estrictas. Esa distincion es el corazon
+   del diseno y por eso tiene su propio test.
+"""
+from __future__ import annotations
+
+import pytest
+
+from horizun_pbi_mcp.services import coherencia
+
+
+class _Modelo:
+    def __init__(self, pid=4242):
+        self.pid = pid
+        self.port = 51000
+        self.catalog = "cat"
+        self.workspace = None
+
+
+class _Proyecto:
+    def __init__(self, tmp_path, nombre="Mio"):
+        self.project_dir = str(tmp_path / nombre)
+        self.pbip_path = str(tmp_path / nombre / f"{nombre}.pbip")
+        self.report_dir = str(tmp_path / nombre / f"{nombre}.Report")
+        self.semantic_model_dir = None
+        self.report_name = nombre
+
+
+class _Sesion:
+    def __init__(self, modelo=None, proyecto=None):
+        self.active_model = modelo
+        self.active_pbip = proyecto
+
+
+@pytest.fixture
+def proyecto(tmp_path):
+    p = _Proyecto(tmp_path)
+    (tmp_path / "Mio" / "Mio.Report").mkdir(parents=True)
+    (tmp_path / "Mio" / "Mio.pbip").write_text("{}", encoding="utf-8")
+    return p
+
+
+def _con_archivos(monkeypatch, rutas):
+    monkeypatch.setattr(coherencia, "_archivos_del_proceso", lambda _pid: rutas)
+
+
+# ------------------------------------------------------- no hay divergencia ---
+def test_sin_los_dos_estados_no_hay_nada_que_comparar(proyecto):
+    assert coherencia.check(_Sesion(proyecto=proyecto))["state"] == \
+        coherencia.NOT_APPLICABLE
+    assert coherencia.check(_Sesion(modelo=_Modelo()))["state"] == \
+        coherencia.NOT_APPLICABLE
+
+
+def test_el_mismo_archivo_se_reconoce(proyecto, monkeypatch):
+    _con_archivos(monkeypatch, [proyecto.pbip_path])
+    r = coherencia.check(_Sesion(_Modelo(), proyecto))
+    assert r["state"] == coherencia.SAME
+    assert r["evidence"] == proyecto.pbip_path
+
+
+def test_un_archivo_bajo_el_report_dir_tambien_cuenta(proyecto, monkeypatch):
+    _con_archivos(monkeypatch,
+                  [str(__import__("pathlib").Path(proyecto.report_dir)
+                       / "definition" / "report.json")])
+    assert coherencia.check(_Sesion(_Modelo(), proyecto))["state"] == \
+        coherencia.SAME
+
+
+# ------------------------------------------------------- el caso peligroso ---
+def test_otro_archivo_de_power_bi_es_divergencia(proyecto, monkeypatch):
+    """El incidente exacto: el modelo sirve un .pbix de otro proyecto."""
+    _con_archivos(monkeypatch, [r"C:\otra\ruta\Control_Acceso.pbix"])
+    r = coherencia.check(_Sesion(_Modelo(), proyecto))
+    assert r["state"] == coherencia.DIFFERENT
+    assert "Control_Acceso.pbix" in str(r["evidence"])
+    assert "how_to_fix" in r, "un bloqueo sin salida es un callejon"
+    assert "pbi_list_desktop_models" in r["how_to_fix"] or \
+        "pbi_select_model" in r["how_to_fix"]
+
+
+def test_la_escritura_se_niega_ante_divergencia_confirmada(proyecto, monkeypatch):
+    _con_archivos(monkeypatch, [r"C:\otra\Control_Acceso.pbix"])
+    with pytest.raises(coherencia.ProyectoYModeloDivergenError) as exc:
+        coherencia.assert_coherente(_Sesion(_Modelo(), proyecto),
+                                    "Escribir una pagina")
+    assert exc.value.code == "active_model_project_mismatch"
+    assert "Escribir una pagina" in str(exc.value)
+
+
+# ------------------------- no poder comprobar NO es lo mismo que estar mal ---
+def test_sin_permisos_se_avisa_pero_no_se_bloquea(proyecto, monkeypatch):
+    """La distincion que evita que esto estorbe.
+
+    Si `open_files` devuelve None (permisos denegados, proceso desaparecido),
+    no se sabe nada. Bloquear ahi convertiria una politica de seguridad
+    estricta en un servidor inservible.
+    """
+    _con_archivos(monkeypatch, None)
+    r = coherencia.check(_Sesion(_Modelo(), proyecto))
+    assert r["state"] == coherencia.UNKNOWN
+    # y sobre todo: NO lanza
+    assert coherencia.assert_coherente(_Sesion(_Modelo(), proyecto), "X")
+
+
+def test_un_proceso_sin_archivos_de_power_bi_es_desconocido(proyecto, monkeypatch):
+    """No hay con que comparar: no se afirma divergencia."""
+    _con_archivos(monkeypatch, [r"C:\Windows\System32\kernel32.dll"])
+    assert coherencia.check(_Sesion(_Modelo(), proyecto))["state"] == \
+        coherencia.UNKNOWN
+
+
+def test_un_modelo_sin_pid_no_se_puede_comprobar(proyecto):
+    r = coherencia.check(_Sesion(_Modelo(pid=None), proyecto))
+    assert r["state"] == coherencia.UNKNOWN
+
+
+# --------------------------------------------------- llega a los diagnosticos ---
+def test_la_guia_lo_pone_lo_primero(proyecto, monkeypatch, tmp_path):
+    """Un aviso grave al final de una lista larga no lo lee nadie."""
+    from horizun_pbi_mcp.services import guide, project_state
+
+    _con_archivos(monkeypatch, [r"C:\otra\Control_Acceso.pbix"])
+    monkeypatch.setattr(project_state, "detect",
+                        lambda _a, **_k: project_state.ProjectOpenState(
+                            project_state.CLOSED, "high", "cerrado"))
+    proyecto.has_tmdl = False
+    proyecto.has_pbir = False
+    s = guide.situacion(_Sesion(_Modelo(), proyecto))
+    assert "DISTINTOS" in s["situation"]
+    assert s["project"]["coherence"]["state"] == coherencia.DIFFERENT
+
+
+# ============================ CRITICO 2: lo efimero se anuncia ==============
+def test_una_escritura_en_vivo_grita_que_no_esta_persistida():
+    """Antes era una nota al pie; se perdieron 5 medidas y 4 tarjetas.
+
+    El aviso ya existia («usa Ctrl+S») pero viajaba como `note`, que se lee al
+    final o no se lee. Ahora sale `persisted: False` Y un warning, que ademas
+    hace que el envelope marque la respuesta como WARNING en vez de exito
+    limpio.
+    """
+    from horizun_pbi_mcp.powerbi import model_writer
+    from horizun_pbi_mcp.services import envelope
+
+    salida = envelope.success({"action": "created", **model_writer._efimero()},
+                              operation="pbi_create_measure",
+                              request_id="r", duration_ms=1)
+    assert salida["persisted"] is False
+    assert salida["status"] == envelope.WARNING, (
+        "un exito limpio se lee por encima; esto no puede pasar desapercibido")
+    assert any("NO PERSISTIDO" in a for a in salida["warnings"])
+    assert any("quedara rota" in a or "rota" in a for a in salida["warnings"]), (
+        "hay que decir la CONSECUENCIA, no solo que no se guardo")
+
+
+def test_el_aviso_de_fuente_viva_se_drena_una_sola_vez():
+    """Se acumula al validar y lo vacia quien responde: no debe repetirse."""
+    from horizun_pbi_mcp.tools import visual_tools
+
+    visual_tools._AVISOS_DE_FUENTE.clear()
+    visual_tools._AVISOS_DE_FUENTE.append(visual_tools._AVISO_FUENTE_VIVA)
+    visual_tools._AVISOS_DE_FUENTE.append(visual_tools._AVISO_FUENTE_VIVA)
+
+    primero = visual_tools.drenar_avisos_de_fuente()
+    assert len(primero) == 1, "duplicados colapsados"
+    assert "EN VIVO" in primero[0]
+    assert visual_tools.drenar_avisos_de_fuente() == [], "ya se habia drenado"


### PR DESCRIPTION
Both **critical** findings from the 5D-session feedback share one cause: the server holds `active_model` (Desktop's memory) and `active_pbip` (disk), and nothing ever cross-checked them. Each half is valid on its own, so everything answers normally while describing different things.

## 1. Active project ≠ active model

`pbi_select_model` served a `.pbix` while the active project was a different `.pbip` — **another client's**. Four pages nearly went into the wrong report; it was caught only because a visual count didn't add up.

The signal already half-existed: `ActiveModel` stores the `pid` of the Desktop serving the model, and `project_state` knows how to correlate a `.pbip` with a process's open files. Crossing them answers the exact question: does *that* Desktop have *this* project open?

Blocked at `assert_escritura_pbir` — the single gate every PBIR write passes through — exactly like the Desktop-open block the feedback itself cites as the precedent that works. Announced in `pbi_start_here` (first, before anything else), `pbi_health_check` and `pbi_session_info`.

**The distinction that keeps it from getting in the way:** it blocks on *confirmed* divergence, never on `unknown`. If open files can't be read (permissions, process gone) it warns and lets through — refusing because you couldn't verify would turn a strict security policy into an unusable server. That has its own test; it's the heart of the design.

## 2. Ephemeral live measures

Five measures created with `mode='live'`, Desktop closed without saving, and pages already referencing them broke with *"Hubo un problema con uno o más campos"* on four cards. The warning existed but rode as `note` — a footnote read last or not at all.

Every live write now returns `persisted: False` plus a warning stating the **consequence**, not just the fact. The envelope also marks the response `WARNING` instead of clean success, so a skim still shows something is pending.

## An honest note

Finding 2's second suggestion — validate the spec against the TMDL rather than the live model — **was already implemented, and already shipped in the v1.0.1 that was tested** (`_model_data` prefers TMDL; its docstring explains why). The real remaining hole is the *fallback*: without TMDL, validation runs against the live model, where an unsaved measure passes. That can't be prevented from there, but staying quiet about it could be fixed — the response now says so.

## Verification

11 tests; 5/5 mutation-verified, including the one asserting `unknown` does **not** block. Suite 1822 passed; contract unchanged; `doctor.py` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
