### PR TITLE
Camino de vuelta al cambiar de lienzo o de sistema de diseño

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **MCP** (Model Context Protocol) server for working with **local Power BI Desktop** and **`.pbip`** projects from Claude Code.
 
-**v1.2.0** — 127 tools, 1793 tests passed (3 skipped, with their condition documented). Covers two complementary layers:
+**v1.2.0** — 128 tools, 1793 tests passed (3 skipped, with their condition documented). Covers two complementary layers:
 
 | Layer | For what | How |
 |---|---|---|
@@ -22,7 +22,7 @@
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Current architecture, structural debt and invariants |
 | [`docs/CAPABILITY_MATRIX.md`](docs/CAPABILITY_MATRIX.md) | Coexistence with other Power BI MCPs, with verification levels |
 | [`AGENTS.md`](AGENTS.md) | Rules for modifying this repository without breaking the contract |
-| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 127 tools by block, with their risk class |
+| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 128 tools by block, with their risk class |
 | [`docs/DUAL_MODE.md`](docs/DUAL_MODE.md) | Why `mode="both"` is blocked (R15) |
 | [`docs/VALIDATION.md`](docs/VALIDATION.md) | The two PBIR validation layers and their limits |
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | What is checked before publishing |
@@ -92,7 +92,7 @@ claude plugin install horizun-pbi-mcp@horizun
 
 When the first session opens, the plugin runs the full setup automatically in
 the background. Check `pbi_install_status`; once it finishes, restart the
-client and the 127 `pbi_*` tools will be available. There are no downloads or
+client and the 128 `pbi_*` tools will be available. There are no downloads or
 additional scripts the user needs to run manually.
 
 > **Honest technical limit:** there's no dedicated executable, but you do need
@@ -190,7 +190,7 @@ Exits with code **0** if everything mandatory is fine. It distinguishes missing 
 
 ---
 
-## Available tools (127)
+## Available tools (128)
 
 > Full catalog by block: [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md).
 > Baseline inventory with risk class and preconditions: [`docs/TOOL_INVENTORY.md`](docs/TOOL_INVENTORY.md).
@@ -369,7 +369,7 @@ python -m pytest -m live                # against an open Power BI Desktop
 python -m pytest -m live_validator      # against Microsoft's official CLI
 ```
 
-Verify the MCP contract (the 127 tools are frozen):
+Verify the MCP contract (the 128 tools are frozen):
 
 ```bash
 python -m tests.contract_utils

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 What remains open, why it matters and how to check it. Ordered by what
 hurts the most.
 
-Updated on 2026-08-04 for **v1.2.0** (127 tools). Two things closed since
+Updated on 2026-08-04 for **v1.2.0** (128 tools). Two things closed since
 1.0.1: the fourteen-item field report from the first real end-to-end session,
 and **the four phases of the product vision** — intent brief, content-level
 data diagnostics, external sources, and the ecosystem port as a data
@@ -217,7 +217,32 @@ the token. Nothing to do; the item is closed.
 
 ---
 
-## 9. What we learned and must not lose
+## 9. Left over from the 5D session (findings 5 to 9)
+
+**Status:** open, all of them MEDIUM or LOW. The two CRITICAL ones (active
+project ≠ active model, ephemeral live measures) and the two HIGH ones
+(orphans on canvas change, no way back after changing design system) are
+closed — the latter two by `pbi_reflow_pages` plus the warning that `merge`
+now issues, with the count and both ways out, before the damage.
+
+What's left, in order:
+
+- **`pbi_compose_page` has a single shape.** Header, KPI row, hero + supports,
+  detail table. It's deliberate — coherence between pages comes from no page
+  being able to invent its own order — but a cover page and a monitor page
+  aren't the same page. Archetypes (`portada`, `detalle`, `monitor`) without
+  reopening free-form composition.
+- **Format-property validation isn't uniform.** An invalid property makes
+  `tableEx` fail entirely, while cards and charts ignore it silently. Same
+  input, three behaviours: the one that's right is failing, and saying which
+  property.
+- **Open/close cycles.** Every PBIR edit needs Desktop closed and every model
+  edit needs it open and saved; a long session is a lot of manual cycles.
+- **The navigator ignores `visibility`.** Hidden pages appear anyway.
+
+---
+
+## 10. What we learned and must not lose
 
 Three rules that were expensive to learn. They're in the code as comments,
 but it's worth having them together:

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -19,7 +19,7 @@ Every statement carries its **verification level**. They are not mixed.
 
 | Server | Version | Status | Highest level reached |
 |---|---|---|---|
-| **Horizun PBI MCP** (this repo) | 1.2.0 | Present, starts | **Tested** — stdio handshake, 127 tools, 1793 tests, live DAX, PBIR fixture and Desktop capture by PID |
+| **Horizun PBI MCP** (this repo) | 1.2.0 | Present, starts | **Tested** — stdio handshake, 128 tools, 1793 tests, live DAX, PBIR fixture and Desktop capture by PID |
 | **powerbi-report-mcp** | 0.9.6 | Present and built at `..\PowerBI MCP\powerbi-report-mcp\dist\index.js` | **Observed** — 57 tool names extracted from the bundle and the README. **Not run** |
 | **@microsoft/powerbi-modeling-mcp** | 0.5.0-beta.11 | Downloaded to a temp folder, extracted and read. **Not run** | **Declared** — README + CHANGELOG + `index.js`. Execution **halted** due to a stop condition (§2.1) |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,14 +17,14 @@ claude plugin install horizun-pbi-mcp@horizun
 
 Setup starts automatically on the first session. While it progresses
 you'll see `pbi_install_runtime` and `pbi_install_status`; after restarting
-the client the 127 tools will appear. Nothing needs to be downloaded or run
+the client the 128 tools will appear. Nothing needs to be downloaded or run
 separately. The runtime and verified downloads stay in the plugin's local
 data, outside the repository and your projects.
 
 Python 3.10+ is still a requirement: it's the local process that talks to
 Power BI Desktop. Node 20 is only needed for the optional PBIR validator.
 
-Reproducible guide from scratch. At the end, an MCP client should see 127 `pbi_*` tools.
+Reproducible guide from scratch. At the end, an MCP client should see 128 `pbi_*` tools.
 
 ---
 

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,4 +1,4 @@
-# Tool catalog — 127
+# Tool catalog — 128
 
 Generated from the contract frozen in `tests/golden/tools_v1.json`.
 The **34 baseline** tools keep their name, parameters, types, defaults and response shape since version 0.1.0.
@@ -25,7 +25,7 @@ tools registered.
 | H — composition, theme and bookmarks | 7 |
 | I — pre-delivery verification | 3 |
 | J — data loading | 2 |
-| L — design and entry point | 4 |
+| L — design and entry point | 5 |
 | M — work cycle | 1 |
 | N — refactoring | 1 |
 | O — session exit | 1 |
@@ -33,7 +33,7 @@ tools registered.
 | Q — data diagnostics | 1 |
 | R — external sources | 1 |
 | S — ecosystem port | 2 |
-| **Total** | **127** |
+| **Total** | **128** |
 
 ---
 
@@ -189,6 +189,7 @@ Close two gaps of the same kind: having the pieces isn't the same as knowing how
 | `pbi_list_design_systems` | Available systems: each one decides theme, canvas, grid and text scale all at once |
 | `pbi_apply_design_system` | Applies the system and returns the grid, to place things by hand on the same guides |
 | `pbi_compose_page` | Composes an entire page on the grid from intent |
+| `pbi_reflow_pages` | The way back after changing system: rescales already-written pages to the new canvas and recomputes the text colour baked in at composition time |
 
 ## Risk classes
 

--- a/skills/horizun-pbi-setup/SKILL.md
+++ b/skills/horizun-pbi-setup/SKILL.md
@@ -17,7 +17,7 @@ y descarga las DLL y esquemas fijados, verificando sus hashes.
 3. Consulta `pbi_install_status` hasta que indique `ready` o `failed`. No inicies
    procesos adicionales mientras esté `installing`.
 4. Si termina en `ready`, pide reiniciar Codex o Claude. Al volver, comprueba que
-   `tools/list` expone las 127 tools `pbi_*`, no solo las dos de instalación.
+   `tools/list` expone las 128 tools `pbi_*`, no solo las dos de instalación.
 5. Si falla, informa el paso y el mensaje devueltos por el status. No borres el
    runtime ni ocultes el error; una nueva llamada permite reintentar.
 

--- a/src/horizun_pbi_mcp/branding.py
+++ b/src/horizun_pbi_mcp/branding.py
@@ -3,7 +3,7 @@
 El nombre vive aqui y no repartido por el codigo: renombrar un producto no
 deberia obligar a buscar cadenas sueltas en veinte archivos.
 
-COMPATIBILIDAD: las 127 tools conservan el prefijo `pbi_`. Renombrarlas romperia
+COMPATIBILIDAD: las 128 tools conservan el prefijo `pbi_`. Renombrarlas romperia
 a cualquier cliente ya configurado, y el nombre comercial no es motivo
 suficiente para eso.
 """

--- a/src/horizun_pbi_mcp/services/design.py
+++ b/src/horizun_pbi_mcp/services/design.py
@@ -435,9 +435,14 @@ def aplicar(active: Any, system: str) -> Dict[str, Any]:
               "color": s["color"], **resultado}
     if desajustadas:
         salida["pages_with_other_canvas"] = desajustadas
+        # Las comillas anidadas dentro del f-string son de Python 3.12 (PEP
+        # 701) y aqui se soporta 3.10: la lista se arma fuera.
+        lienzos = sorted({"{:.0f}x{:.0f}".format(d["canvas"]["width"],
+                                                 d["canvas"]["height"])
+                          for d in desajustadas})
         salida.setdefault("warnings", []).append(
             f"{len(desajustadas)} pagina(s) siguen con OTRO lienzo "
-            f"({', '.join(sorted({f'{d["canvas"]["width"]:.0f}x{d["canvas"]["height"]:.0f}' for d in desajustadas}))}) "
+            f"({', '.join(lienzos)}) "
             f"y con los colores del tema anterior: sus titulos pueden quedar "
             f"ilegibles y sus visuales fuera de limites. Aplicar el sistema NO "
             f"las reescribe. Usa pbi_reflow_pages(system='{system}') para "

--- a/src/horizun_pbi_mcp/services/design.py
+++ b/src/horizun_pbi_mcp/services/design.py
@@ -415,8 +415,31 @@ def aplicar(active: Any, system: str) -> Dict[str, Any]:
     haga sobre las mismas guias.
     """
     s = tokens(system)
+
+    # Que pasa con lo que YA existe. Aplicar un sistema cambia el tema del
+    # informe entero, pero NO reescribe las paginas ya compuestas: se quedan
+    # con el lienzo anterior y con los colores que se cocieron al componerlas.
+    # Callarlo es lo que dejo titulos blancos sobre fondo blanco y visuales
+    # fuera de limites que solo aparecen al abrir.
+    from horizun_pbi_mcp.services import reflow
+
+    try:
+        desajustadas = reflow.paginas_con_otro_lienzo(active, s["canvas"])
+    except Exception:                                    # noqa: BLE001
+        desajustadas = []
+
     resultado = theme_mod.apply_theme(active, theme_mod.build_theme(s["theme"]))
     log.info("Sistema de diseño '%s' aplicado (tema %s).", system, s["theme"])
-    return {"system": system, "title": s["titulo"], "canvas": s["canvas"],
-            "grid": s["grid"], "typography": s["tipografia"],
-            "color": s["color"], **resultado}
+    salida = {"system": system, "title": s["titulo"], "canvas": s["canvas"],
+              "grid": s["grid"], "typography": s["tipografia"],
+              "color": s["color"], **resultado}
+    if desajustadas:
+        salida["pages_with_other_canvas"] = desajustadas
+        salida.setdefault("warnings", []).append(
+            f"{len(desajustadas)} pagina(s) siguen con OTRO lienzo "
+            f"({', '.join(sorted({f'{d["canvas"]["width"]:.0f}x{d["canvas"]["height"]:.0f}' for d in desajustadas}))}) "
+            f"y con los colores del tema anterior: sus titulos pueden quedar "
+            f"ilegibles y sus visuales fuera de limites. Aplicar el sistema NO "
+            f"las reescribe. Usa pbi_reflow_pages(system='{system}') para "
+            f"reescalarlas y recolorearlas.")
+    return salida

--- a/src/horizun_pbi_mcp/services/guide.py
+++ b/src/horizun_pbi_mcp/services/guide.py
@@ -1,4 +1,4 @@
-"""Por donde se empieza. Un punto de entrada para 127 tools.
+"""Por donde se empieza. Un punto de entrada para 128 tools.
 
 El problema que cierra
 ----------------------
@@ -9,7 +9,7 @@ ninguna lista alfabetica—. El catalogo estaba completo y el camino no existia.
 
 Aqui no se documenta nada nuevo: se MIRA el estado real y se responde a «¿y
 ahora que?» con tres o cuatro pasos concretos, cada uno con el nombre exacto de
-la tool y el motivo. Una lista de 127 opciones no es una respuesta a esa
+la tool y el motivo. Una lista de 128 opciones no es una respuesta a esa
 pregunta; tres si.
 
 La regla que lo mantiene util

--- a/src/horizun_pbi_mcp/services/page_spec.py
+++ b/src/horizun_pbi_mcp/services/page_spec.py
@@ -615,8 +615,13 @@ def apply_spec(active: ActivePbip, compilado: Dict[str, Any], *,
     plan = page_update.planificar(active, compilado, page=page,
                                   sync_mode=sync_mode)
     if plan["change"] == page_update.NO_CHANGE:
+        # Los avisos viajan tambien aqui: una pagina que ya coincide con el
+        # spec puede seguir arrastrando visuales fuera del lienzo, y callarlo
+        # porque "no hay nada que escribir" es justo como se descubren tarde.
         return {"change": page_update.NO_CHANGE, "page_id": plan["page_id"],
                 "applied": 0, "summary": page_update.resumen(plan),
+                "warnings": list(plan.get("warnings") or []),
+                "out_of_bounds_kept": list(plan.get("out_of_bounds_kept") or []),
                 "visuals_created": []}
 
     pbir_edit_mod = __import__("horizun_pbi_mcp.services.pbir_edit", fromlist=["x"])
@@ -645,6 +650,8 @@ def apply_spec(active: ActivePbip, compilado: Dict[str, Any], *,
             "added": plan["added"], "updated": plan["updated"],
             "kept": plan["kept"], "removed": plan.get("removed", []),
             "not_removed": plan.get("not_removed", []),
+            "out_of_bounds_kept": list(plan.get("out_of_bounds_kept") or []),
+            "warnings": list(plan.get("warnings") or []),
             "sync_mode": plan["sync_mode"],
             "summary": page_update.resumen(plan),
             "visuals_created": [{"id": v} for v in plan["added"]],

--- a/src/horizun_pbi_mcp/services/page_update.py
+++ b/src/horizun_pbi_mcp/services/page_update.py
@@ -29,6 +29,16 @@ un visual no debe regenerar su id.
 
 El defecto por defecto es el conservador: un spec parcial no puede vaciar una
 pagina por omision.
+
+Lo conservador tiene un precio, y hay que decirlo
+------------------------------------------------
+Si el lienzo del spec no es el de la pagina —se recompuso con otro sistema de
+diseno— los visuales que `merge` conserva se quedan con las coordenadas del
+lienzo VIEJO. Los que no caben en el nuevo no desaparecen: quedan fuera de
+limites, invisibles al abrir el informe pero presentes en el render y en la
+publicacion, y solo se descubren con `pbi_detect_layout_issues`. Paso de
+verdad al pasar de 1920x1080 a 1280x720. Ahora se avisa ANTES, con la cuenta
+hecha y con las dos salidas: `sync_mode='replace'` o `pbi_reflow_pages`.
 """
 from __future__ import annotations
 
@@ -135,6 +145,44 @@ def planificar(active: ActivePbip, compilado: Dict[str, Any], *,
     return _planificar_update(active, compilado, page_id, sync_mode)
 
 
+def _avisar_de_los_que_quedan_fuera(sobrantes: List[Dict[str, Any]],
+                                    pagina_actual: Dict[str, Any],
+                                    canvas_nuevo: Dict[str, Any]
+                                    ) -> Dict[str, Any]:
+    """Los que `merge` conserva y ya no caben en el lienzo del spec.
+
+    Solo cuenta como fuera de limites lo que se sale del lienzo NUEVO: si el
+    lienzo no cambia, un visual que ya estaba mal colocado se avisa igual, que
+    para el que lee es el mismo problema.
+    """
+    ancho = float(canvas_nuevo.get("width") or 0)
+    alto = float(canvas_nuevo.get("height") or 0)
+    if not sobrantes or not ancho or not alto:
+        return {"ids": [], "warnings": []}
+
+    fuera = []
+    for v in sobrantes:
+        pos = v.get("position") or {}
+        x, y = float(pos.get("x") or 0), float(pos.get("y") or 0)
+        w, h = float(pos.get("width") or 0), float(pos.get("height") or 0)
+        if x + w > ancho or y + h > alto:
+            fuera.append(v["id"])
+    if not fuera:
+        return {"ids": [], "warnings": []}
+
+    viejo = (float(pagina_actual.get("width") or 0),
+             float(pagina_actual.get("height") or 0))
+    cambio = viejo != (ancho, alto) and all(viejo)
+    porque = (f"El lienzo pasa de {viejo[0]:.0f}x{viejo[1]:.0f} a "
+              f"{ancho:.0f}x{alto:.0f} y " if cambio else "")
+    return {"ids": fuera, "warnings": [
+        f"{porque}{len(fuera)} visual(es) de la composicion anterior quedan "
+        f"FUERA del lienzo y sync_mode='merge' los conserva: {fuera}. No se "
+        "ven al abrir el informe, pero si viajan al render y a la "
+        "publicacion. Usa sync_mode='replace' para eliminarlos, o "
+        "pbi_reflow_pages para reescalar la pagina entera al lienzo nuevo."]}
+
+
 def _planificar_update(active: ActivePbip, compilado: Dict[str, Any],
                        page_id: str, sync_mode: str) -> Dict[str, Any]:
     pdir = pbir_reader.pages_dir(active)
@@ -191,6 +239,10 @@ def _planificar_update(active: ActivePbip, compilado: Dict[str, Any],
     if sync_mode == REPLACE:
         borrados = [Path(v["file"]) for v in sobrantes]
 
+    avisos = _avisar_de_los_que_quedan_fuera(
+        sobrantes if sync_mode == MERGE else [], actual_pagina,
+        compilado["canvas"])
+
     # page.json: solo lo que el spec declara.
     nueva_pagina = dict(actual_pagina)
     nueva_pagina["displayName"] = compilado["page_name"]
@@ -218,6 +270,8 @@ def _planificar_update(active: ActivePbip, compilado: Dict[str, Any],
         "kept": kept, "added": added, "updated": updated,
         "removed": [v["id"] for v in (sobrantes if sync_mode == REPLACE else [])],
         "not_removed": [v["id"] for v in (sobrantes if sync_mode == MERGE else [])],
+        "out_of_bounds_kept": avisos["ids"],
+        "warnings": avisos["warnings"],
         "sync_mode": sync_mode,
     }
 

--- a/src/horizun_pbi_mcp/services/reflow.py
+++ b/src/horizun_pbi_mcp/services/reflow.py
@@ -1,0 +1,229 @@
+"""Cambiar de sistema de diseno sin recomponerlo todo a mano.
+
+Dos hallazgos ALTO de una sesion real, que resultan ser el mismo:
+
+- Se compuso con `sala` (1920x1080), se cambio a `informe` (1280x720) y se
+  recompuso con `merge`. Los visuales de la composicion anterior se
+  CONSERVARON fuera del lienzo: basura invisible que si viaja al render y a la
+  publicacion, y que hay que descubrir con `pbi_detect_layout_issues`.
+- La documentacion avisa «eligelo ANTES de la primera pagina», pero la gente
+  cambia de opinion —en esa sesion se paso de oscuro a claro a mitad—, y
+  cuando pasa la herramienta no ayudaba: a recomponer cada pagina a mano.
+
+Y un detalle que no estaba dicho en ninguna parte: el color del texto de los
+elementos decorativos SI sale del tema, pero se cuece AL COMPONER y queda
+literal en el `visual.json`. Cambiar de sistema despues no reescribe lo ya
+escrito, asi que los titulos compuestos en oscuro (#FFFFFF) quedan blancos
+sobre blanco al pasar a claro. Invisibles, y sin que falle nada.
+
+Lo que hace este modulo es lo unico honesto que se puede hacer con una pagina
+ya escrita: **reescalarla** al lienzo nuevo y **recalcular** los colores que se
+cocieron con el tema viejo. No es recomponer -no se sabe que intencion tenia
+cada visual- pero deja la pagina utilizable en vez de rota.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from horizun_pbi_mcp.logging_config import get_logger
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+
+log = get_logger("reflow")
+
+#: Tipos cuyo color de texto se cocio del tema al componer.
+DECORATIVOS_CON_COLOR = ("textbox", "shape")
+
+
+def _canvas_de_pagina(pagina: Dict[str, Any]) -> Tuple[float, float]:
+    return (float(pagina.get("width") or 0), float(pagina.get("height") or 0))
+
+
+def paginas_con_otro_lienzo(active, canvas_destino: Dict[str, Any]
+                            ) -> List[Dict[str, Any]]:
+    """Paginas cuyo lienzo NO es el del sistema que se va a aplicar."""
+    from horizun_pbi_mcp.pbip import pbir_reader
+
+    ancho = float(canvas_destino.get("width") or 0)
+    alto = float(canvas_destino.get("height") or 0)
+    distintas = []
+    for p in pbir_reader.list_pages(active, strict=False):
+        pw, ph = _canvas_de_pagina(p)
+        if pw and ph and (pw != ancho or ph != alto):
+            distintas.append({"page": p["name"],
+                              "display_name": p.get("display_name"),
+                              "canvas": {"width": pw, "height": ph}})
+    return distintas
+
+
+def _reescalar(pos: Dict[str, Any], fx: float, fy: float,
+               canvas: Dict[str, float]) -> Dict[str, float]:
+    """Posicion proporcional al lienzo nuevo, acotada a sus limites."""
+    ancho = max(1.0, round(float(pos.get("width") or 0) * fx))
+    alto = max(1.0, round(float(pos.get("height") or 0) * fy))
+    # El tamano se acota ANTES que el origen: un visual mas ancho que el
+    # lienzo nuevo no puede caber, y encogerlo es preferible a dejarlo fuera.
+    ancho = min(ancho, canvas["width"])
+    alto = min(alto, canvas["height"])
+    x = min(max(0.0, round(float(pos.get("x") or 0) * fx)), canvas["width"] - ancho)
+    y = min(max(0.0, round(float(pos.get("y") or 0) * fy)), canvas["height"] - alto)
+    nueva = {"x": float(x), "y": float(y),
+             "width": float(ancho), "height": float(alto)}
+    if pos.get("z") is not None:
+        nueva["z"] = pos["z"]
+    if pos.get("tabOrder") is not None:
+        nueva["tabOrder"] = pos["tabOrder"]
+    return nueva
+
+
+def _color_literal(valor: Any) -> Optional[str]:
+    """Extrae '#RRGGBB' de la forma anidada que usa PBIR, si la tiene."""
+    try:
+        crudo = valor["solid"]["color"]["expr"]["Literal"]["Value"]
+    except (KeyError, TypeError):
+        return None
+    return str(crudo).strip("'") or None
+
+
+def planificar(active, system: str,
+               paginas: Optional[List[str]] = None) -> Dict[str, Any]:
+    """Que cambiaria el reflujo, sin escribir nada."""
+    from horizun_pbi_mcp.pbip import pbir_reader
+    from horizun_pbi_mcp.services import design
+
+    if system not in design.SISTEMAS:
+        raise ValidationError(
+            f"Sistema '{system}' no existe. Disponibles: "
+            f"{sorted(design.SISTEMAS)}.")
+    t = design.tokens(system)
+    destino = {"width": float(t["canvas"]["width"]),
+               "height": float(t["canvas"]["height"])}
+    colores = design.tinta(system, design.paleta_del_informe(active))
+
+    objetivo = {str(p).casefold() for p in paginas} if paginas else None
+    plan: List[Dict[str, Any]] = []
+    for p in pbir_reader.list_pages(active, strict=False):
+        if objetivo and p["name"].casefold() not in objetivo and \
+                str(p.get("display_name") or "").casefold() not in objetivo:
+            continue
+        pw, ph = _canvas_de_pagina(p)
+        if not pw or not ph:
+            continue
+        fx = destino["width"] / pw
+        fy = destino["height"] / ph
+
+        visuales = []
+        for v in pbir_reader.list_visuals(active, p["name"], strict=False):
+            pos = v.get("position") or {}
+            nueva = _reescalar(pos, fx, fy, destino)
+            fuera = (float(pos.get("x") or 0) + float(pos.get("width") or 0)
+                     > destino["width"]
+                     or float(pos.get("y") or 0) + float(pos.get("height") or 0)
+                     > destino["height"])
+            entrada = {"visual_id": v["id"], "type": v.get("type"),
+                       "was_out_of_bounds": bool(fuera),
+                       "from": {k: pos.get(k) for k in ("x", "y", "width", "height")},
+                       "to": {k: nueva[k] for k in ("x", "y", "width", "height")}}
+            # El color cocido del tema viejo: si no es el del sistema nuevo,
+            # se recalcula. Es lo que deja los titulos blancos sobre blanco.
+            if v.get("type") in DECORATIVOS_CON_COLOR:
+                entrada["recolor"] = colores.get("strong")
+            visuales.append(entrada)
+
+        if visuales or (pw, ph) != (destino["width"], destino["height"]):
+            plan.append({
+                "page": p["name"], "display_name": p.get("display_name"),
+                "canvas_from": {"width": pw, "height": ph},
+                "canvas_to": dict(destino),
+                "scale": {"x": round(fx, 4), "y": round(fy, 4)},
+                "visuals": visuales,
+                "out_of_bounds_before": sum(
+                    1 for x in visuales if x["was_out_of_bounds"]),
+            })
+
+    return {"system": system, "canvas": destino, "pages": plan,
+            "page_count": len(plan),
+            "visual_count": sum(len(p["visuals"]) for p in plan),
+            "out_of_bounds_total": sum(p["out_of_bounds_before"] for p in plan)}
+
+
+def _recolorear(data: Dict[str, Any], color: str) -> bool:
+    """Reescribe el color de texto de un decorativo. True si cambio algo.
+
+    Solo toca lo que el compositor escribio: el `color` del textbox y el
+    `text_color` de una forma. No se inventa formato donde no lo habia.
+    """
+    from horizun_pbi_mcp.pbip.visual_factory import _lit
+
+    vis = data.get("visual") or {}
+    objetos = vis.get("objects")
+    if not isinstance(objetos, dict):
+        return False
+    cambio = False
+    for grupo, propiedad in (("general", "fontColor"),
+                             ("text", "color"),
+                             ("shape", "textColor")):
+        for bloque in objetos.get(grupo) or []:
+            props = bloque.get("properties") if isinstance(bloque, dict) else None
+            if isinstance(props, dict) and propiedad in props:
+                props[propiedad] = _lit(color)
+                cambio = True
+    # El textbox escribe el color dentro de su `paragraphs`, no en objects.
+    for bloque in objetos.get("general") or []:
+        parrafos = (bloque.get("properties") or {}).get("paragraphs")
+        for parrafo in (parrafos or []) if isinstance(parrafos, list) else []:
+            for run in (parrafo.get("textRuns") or []):
+                estilo = run.get("textStyle")
+                if isinstance(estilo, dict) and "color" in estilo:
+                    estilo["color"] = color
+                    cambio = True
+    return cambio
+
+
+def aplicar(active, system: str, paginas: Optional[List[str]] = None,
+            dry_run: bool = True) -> Dict[str, Any]:
+    """Reescala las paginas al lienzo del sistema y recalcula sus colores."""
+    from horizun_pbi_mcp.pbip import pbir_writer
+    from horizun_pbi_mcp.services import pbir_edit
+    from horizun_pbi_mcp.services import txn as txn_service
+
+    plan = planificar(active, system, paginas)
+    if dry_run:
+        return {**plan, "dry_run": True, "applied": False}
+    if not plan["pages"]:
+        return {**plan, "applied": False,
+                "reason": "No hay paginas que reflujar."}
+
+    # Se compila TODO antes de escribir nada: una transaccion para el lote
+    # entero, no una por pagina. Si falla la tercera, las dos primeras no
+    # pueden quedar reflujadas y el resto no.
+    planificados: List[Dict[str, Any]] = []
+    recoloreados = 0
+    for pagina in plan["pages"]:
+        updates = [{"visual_id": v["visual_id"], **v["to"]}
+                   for v in pagina["visuals"]]
+        if not updates:
+            continue
+        for p in pbir_writer.plan_visuals_bulk(active, pagina["page"], updates):
+            entrada = next(v for v in pagina["visuals"]
+                           if v["visual_id"] == p["id"])
+            if entrada.get("recolor") and _recolorear(p["data"],
+                                                      entrada["recolor"]):
+                recoloreados += 1
+            planificados.append(p)
+
+    pbir_edit.assert_escritura_pbir(active, "Reflujar las paginas")
+    cm = txn_service.project_transaction(
+        active, [p["path"] for p in planificados], tool="pbi_reflow_pages")
+    with cm as t:
+        for p in planificados:
+            t.write_json(p["path"], p["data"])
+
+    log.info("Reflujo aplicado: %d visual(es) en %d pagina(s), %d recoloreado(s).",
+             len(planificados), len(plan["pages"]), recoloreados)
+    return {**plan, "applied": True, "dry_run": False,
+            "visuals_moved": len(planificados),
+            "visuals_recolored": recoloreados,
+            "transaction": cm.result,
+            "note": ("El reflujo reescala y recolorea; NO recompone. Si una "
+                     "pagina necesita otra estructura, recomponla con "
+                     "pbi_compose_page.")}

--- a/src/horizun_pbi_mcp/tools/design_tools.py
+++ b/src/horizun_pbi_mcp/tools/design_tools.py
@@ -25,7 +25,7 @@ def register(mcp) -> None:
     def pbi_start_here(request_id: str = "") -> Dict[str, Any]:
         """Por donde empezar. Mira el estado real y dice los siguientes pasos.
 
-        Ciento veintisiete tools con buen nombre siguen siendo ciento veintisiete tools.
+        Ciento veintiocho tools con buen nombre siguen siendo ciento veintiocho tools.
         Esta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada
         uno con el nombre exacto de la tool y **por que** toca ahora: si hay
         proyecto activo, si tiene modelo o solo informe, si esta vacio, y si
@@ -238,3 +238,37 @@ def register(mcp) -> None:
                     "recommended_design_system":
                         brief_service.recommended_system(datos)}
         return guard(_impl)
+
+    @mcp.tool()
+    def pbi_reflow_pages(system: str, pages: Optional[List[str]] = None,
+                         dry_run: bool = True,
+                         request_id: str = "") -> Dict[str, Any]:
+        """Reescala las paginas ya escritas al lienzo de otro sistema.
+
+        El camino de vuelta que faltaba. Aplicar un sistema cambia el tema del
+        informe, pero NO reescribe lo ya compuesto: las paginas se quedan con
+        el lienzo anterior —visuales fuera de limites, basura invisible que si
+        viaja al render— y con los colores que se cocieron al componerlas: un
+        titulo compuesto en tema oscuro queda BLANCO SOBRE BLANCO al pasar a
+        claro, sin que falle nada.
+
+        Esto hace las dos cosas: reescala cada visual proporcionalmente al
+        lienzo nuevo (acotandolo si no cabe) y recalcula el color de texto de
+        los elementos decorativos con el tema del sistema destino.
+
+        **No recompone**: no se puede saber que intencion tenia cada visual, y
+        adivinarla seria peor. Si una pagina necesita otra estructura,
+        recomponla con `pbi_compose_page`. Esto la deja utilizable, no optima.
+
+        `pages`: subconjunto opcional (id o nombre visible); por defecto todas.
+        `dry_run=true` (por defecto) devuelve el plan visual por visual, con
+        cuales estaban ya fuera de limites, sin escribir nada.
+
+        Escribe en el informe (PBIR): requiere el proyecto CERRADO en Desktop.
+        """
+        from horizun_pbi_mcp.services import reflow
+
+        def _impl():
+            return reflow.aplicar(get_session().require_active_pbip(),
+                                  system, pages, dry_run=dry_run)
+        return guard_mutation(_impl)

--- a/src/horizun_pbi_mcp/tools/risk.py
+++ b/src/horizun_pbi_mcp/tools/risk.py
@@ -145,7 +145,7 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_open_in_desktop": SIDE_EFFECT_EXTERNAL,
     "pbi_validate_desktop_render": SIDE_EFFECT_EXTERNAL,
 
-    # -- write_reversible (47) --
+    # -- write_reversible (48) --
     "pbi_add_custom_visual": WRITE_REVERSIBLE,
     "pbi_add_image_resource": WRITE_REVERSIBLE,
     "pbi_add_table_from_file": WRITE_REVERSIBLE,
@@ -154,6 +154,7 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_define_port_contract": WRITE_REVERSIBLE,
     "pbi_align_visuals": WRITE_REVERSIBLE,
     "pbi_apply_design_system": WRITE_REVERSIBLE,
+    "pbi_reflow_pages": WRITE_REVERSIBLE,
     # El brief es un artefacto del proyecto, con journal como todo.
     "pbi_define_brief": WRITE_REVERSIBLE,
     "pbi_apply_page_spec": WRITE_REVERSIBLE,

--- a/src/horizun_pbi_mcp/tools/spec_tools.py
+++ b/src/horizun_pbi_mcp/tools/spec_tools.py
@@ -249,7 +249,13 @@ def register(mcp) -> None:
             if resultado.get("change") != page_update.NO_CHANGE:
                 resultado["validation"] = page_spec.validate_generated_page(
                     active, resultado["page_id"], _model_data())
-            resultado["warnings"] = compilado["warnings"]
+            # Se SUMAN, no se pisan: los del compilado hablan del spec y los
+            # del resultado de lo que quedo escrito —los visuales fuera del
+            # lienzo que merge conserva—. Asignar aqui los del compilado
+            # borraba los segundos justo antes de devolverlos.
+            resultado["warnings"] = (list(compilado["warnings"])
+                                     + [a for a in (resultado.get("warnings") or [])
+                                        if a not in compilado["warnings"]])
             return resultado
         return guard_mutation(_impl)
 

--- a/tests/golden/tools_v1.json
+++ b/tests/golden/tools_v1.json
@@ -1,6 +1,6 @@
 {
   "contract_version": 1,
-  "tool_count": 127,
+  "tool_count": 128,
   "tools": [
     {
       "name": "pbi_add_custom_visual",
@@ -3796,6 +3796,49 @@
       }
     },
     {
+      "name": "pbi_reflow_pages",
+      "description": "Reescala las paginas ya escritas al lienzo de otro sistema.\n\nEl camino de vuelta que faltaba. Aplicar un sistema cambia el tema del\ninforme, pero NO reescribe lo ya compuesto: las paginas se quedan con\nel lienzo anterior —visuales fuera de limites, basura invisible que si\nviaja al render— y con los colores que se cocieron al componerlas: un\ntitulo compuesto en tema oscuro queda BLANCO SOBRE BLANCO al pasar a\nclaro, sin que falle nada.\n\nEsto hace las dos cosas: reescala cada visual proporcionalmente al\nlienzo nuevo (acotandolo si no cabe) y recalcula el color de texto de\nlos elementos decorativos con el tema del sistema destino.\n\n**No recompone**: no se puede saber que intencion tenia cada visual, y\nadivinarla seria peor. Si una pagina necesita otra estructura,\nrecomponla con `pbi_compose_page`. Esto la deja utilizable, no optima.\n\n`pages`: subconjunto opcional (id o nombre visible); por defecto todas.\n`dry_run=true` (por defecto) devuelve el plan visual por visual, con\ncuales estaban ya fuera de limites, sin escribir nada.\n\nEscribe en el informe (PBIR): requiere el proyecto CERRADO en Desktop.",
+      "params": {
+        "dry_run": {
+          "required": false,
+          "type": "boolean",
+          "default": true
+        },
+        "pages": {
+          "required": false,
+          "type": "array[string]|null",
+          "default": null
+        },
+        "request_id": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "system": {
+          "required": true,
+          "type": "string"
+        }
+      },
+      "required": [
+        "system"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      }
+    },
+    {
       "name": "pbi_refresh_model",
       "description": "Refresca el modelo LOCAL abierto en Power BI Desktop (no el Service).\n\n`type`: full | calculate | clear_values (tambien automatic | data_only).\n`tables`: lista opcional de tablas a refrescar; si se omite, todo el modelo.\nLos errores de credenciales/origen se reportan.\n\nDevuelve estado, duracion y **`rows_by_table`**: cuantas filas quedaron\nen cada tabla refrescada. Un refresh puede terminar en 'ok' y haber\ncargado CERO filas -credenciales que devuelven vacio, un filtro de\nfecha que no alcanza nada, un origen que cambio de esquema-, asi que\nlas tablas vacias salen ademas en `warnings`. Si no se pudo contar, se\ndice; no se inventa el numero.\n\nEn un proyecto **.pbip los datos NO se guardan**: viven en la sesion de\nDesktop y al reabrir hay que refrescar otra vez. Lo que persiste al\nguardar es la definicion (TMDL + PBIR).",
       "params": {
@@ -4521,7 +4564,7 @@
     },
     {
       "name": "pbi_start_here",
-      "description": "Por donde empezar. Mira el estado real y dice los siguientes pasos.\n\nCiento veintisiete tools con buen nombre siguen siendo ciento veintisiete tools.\nEsta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada\nuno con el nombre exacto de la tool y **por que** toca ahora: si hay\nproyecto activo, si tiene modelo o solo informe, si esta vacio, y si\nPower BI Desktop lo tiene abierto —que impide escribir el TMDL—.\n\nDevuelve tambien `common_tasks`: tareas frecuentes y la secuencia de\ntools que las resuelve.\n\nNo escribe nada. Empieza por aqui cuando no sepas que sigue.",
+      "description": "Por donde empezar. Mira el estado real y dice los siguientes pasos.\n\nCiento veintiocho tools con buen nombre siguen siendo ciento veintiocho tools.\nEsta responde «¿y ahora que?» con tres o cuatro pasos concretos, cada\nuno con el nombre exacto de la tool y **por que** toca ahora: si hay\nproyecto activo, si tiene modelo o solo informe, si esta vacio, y si\nPower BI Desktop lo tiene abierto —que impide escribir el TMDL—.\n\nDevuelve tambien `common_tasks`: tareas frecuentes y la secuencia de\ntools que las resuelve.\n\nNo escribe nada. Empieza por aqui cuando no sepas que sigue.",
       "params": {
         "request_id": {
           "required": false,

--- a/tests/test_reflujo_al_cambiar_lienzo.py
+++ b/tests/test_reflujo_al_cambiar_lienzo.py
@@ -1,0 +1,336 @@
+"""Cambiar de sistema de diseno dejaba las paginas ya escritas atras.
+
+Dos hallazgos ALTO de una sesion real que son el mismo defecto visto por dos
+lados: **el estado cambio y lo ya escrito se quedo como estaba, en silencio.**
+
+1. Se compuso en `sala` (1920x1080), se cambio a `informe` (1280x720) y se
+   recompuso con `merge`. Los visuales de la composicion anterior se
+   conservaron FUERA del lienzo: no se ven al abrir, pero viajan al render y a
+   la publicacion, y solo aparecen si a alguien se le ocurre correr
+   `pbi_detect_layout_issues`.
+2. No habia camino de vuelta: cambiar de sistema obligaba a recomponer cada
+   pagina a mano.
+
+Y el detalle que no estaba dicho en ninguna parte: el color del texto SI sale
+del tema, pero se cuece AL COMPONER y queda literal en el `visual.json`. Un
+titulo compuesto en oscuro queda blanco sobre blanco al pasar a claro. Nada
+falla; simplemente no se lee.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from horizun_pbi_mcp.services import page_update, reflow
+
+
+# ============================================================ hallazgo 3 =====
+class TestMergeAvisaDeLosQueQuedanFuera:
+    """Antes del dano, con la cuenta hecha y con las dos salidas."""
+
+    @staticmethod
+    def _sobrante(vid, x, y, w=400, h=300):
+        return {"id": vid, "position": {"x": x, "y": y, "width": w, "height": h}}
+
+    def test_los_de_fuera_del_lienzo_nuevo_se_cuentan_y_se_nombran(self):
+        r = page_update._avisar_de_los_que_quedan_fuera(
+            [self._sobrante("v1", 1500, 100),      # se sale por la derecha
+             self._sobrante("v2", 100, 900),       # se sale por abajo
+             self._sobrante("v3", 100, 100)],      # cabe
+            {"width": 1920, "height": 1080},
+            {"width": 1280, "height": 720})
+
+        assert r["ids"] == ["v1", "v2"], "v3 cabe y no debe acusarse"
+        aviso = r["warnings"][0]
+        assert "1920x1080" in aviso and "1280x720" in aviso, (
+            "hay que decir de que lienzo a cual, o el aviso no explica nada")
+        assert "sync_mode='replace'" in aviso and "pbi_reflow_pages" in aviso, (
+            "un aviso sin salida es un callejon: van las DOS salidas")
+        assert "render" in aviso or "publicacion" in aviso, (
+            "hay que decir la CONSECUENCIA: son invisibles pero se publican")
+
+    def test_si_todo_cabe_no_se_inventa_un_aviso(self):
+        r = page_update._avisar_de_los_que_quedan_fuera(
+            [self._sobrante("v1", 10, 10)],
+            {"width": 1280, "height": 720}, {"width": 1280, "height": 720})
+        assert r == {"ids": [], "warnings": []}
+
+    def test_con_replace_no_hay_nada_que_avisar(self):
+        """`replace` los borra: avisar de lo que se va a eliminar es ruido."""
+        assert page_update._avisar_de_los_que_quedan_fuera(
+            [], {"width": 1920, "height": 1080},
+            {"width": 1280, "height": 720}) == {"ids": [], "warnings": []}
+
+    def test_sin_cambio_de_lienzo_se_avisa_igual_pero_sin_culparlo(self):
+        r = page_update._avisar_de_los_que_quedan_fuera(
+            [self._sobrante("v1", 1200, 10)],
+            {"width": 1280, "height": 720}, {"width": 1280, "height": 720})
+        assert r["ids"] == ["v1"], "estar fuera es un problema aunque nada cambie"
+        assert "pasa de" not in r["warnings"][0], (
+            "no se puede culpar a un cambio de lienzo que no hubo")
+
+
+# ------------------------------------------- el caso entero, sobre disco -----
+@pytest.fixture
+def proyecto_compuesto_en_sala(session, tmp_path, isolated_settings):
+    """Una pagina compuesta en 1920x1080, tal como quedo en la sesion real."""
+    import json
+
+    from horizun_pbi_mcp.pbip import pbir_reader, project_locator, tmdl_reader
+    from horizun_pbi_mcp.services import operations, page_spec
+    from tests.fixtures import synthetic
+
+    pbip = synthetic.materialize(tmp_path)
+    project_locator.open_project(session, str(pbip))
+    active = session.require_active_pbip()
+    operations.registro().limpiar()
+    md = tmdl_reader.read_semantic_model(active)
+
+    spec_sala = {"schema_version": "1.0",
+                 "page": {"name": "Control", "width": 1920, "height": 1080},
+                 "layout": {"preset": "executive", "gap": 16},
+                 "visuals": [{"type": "card", "title": "Avance",
+                              "fields": {"values": ["[TotalAmount]"]}}],
+                 "filters": [], "interactions": []}
+    page_spec.apply_spec(active, page_spec.compile_spec(active, spec_sala, md))
+
+    # Se empuja el visual a la derecha del lienzo grande: ahi cabe, y en
+    # 1280x720 ya no. Es exactamente lo que hace una composicion en sala.
+    pagina = next(p for p in pbir_reader.list_pages(active)
+                  if p.get("display_name") == "Control")
+    visual = pbir_reader.list_visuals(active, pagina["name"])[0]
+    ruta = Path(visual["file"])
+    datos = json.loads(ruta.read_text(encoding="utf-8"))
+    datos["position"] = {"x": 1500, "y": 800, "width": 380, "height": 240,
+                         "z": 0, "tabOrder": 0}
+    ruta.write_text(json.dumps(datos), encoding="utf-8")
+    return session, active, md
+
+
+def test_el_aviso_llega_hasta_la_respuesta_de_la_tool(proyecto_compuesto_en_sala,
+                                                      monkeypatch):
+    """El defecto recurrente de esta casa: el servidor lo sabe y no lo dice.
+
+    Se recompone la misma pagina en `informe` (1280x720) con otro visual, asi
+    que el de la composicion en sala sobra. Con `merge` se conserva —y se
+    queda fuera del lienzo—. El aviso tiene que salir por la tool, no
+    quedarse en el planificador: `pbi_apply_page_spec` hacia
+    `resultado["warnings"] = compilado["warnings"]`, una ASIGNACION que
+    borraba los avisos de la escritura justo antes de devolverlos.
+    """
+    import asyncio
+
+    import horizun_pbi_mcp.config as cfg
+    from horizun_pbi_mcp.server import build_server
+
+    sesion, _active, _md = proyecto_compuesto_en_sala
+    monkeypatch.setattr(cfg, "_session", sesion)
+
+    spec_informe = {"schema_version": "1.0",
+                    "page": {"name": "Control", "width": 1280, "height": 720},
+                    "layout": {"preset": "executive", "gap": 16},
+                    "visuals": [{"type": "card", "title": "Costo",
+                                 "fields": {"values": ["[TotalAmount]"]}}],
+                    "filters": [], "interactions": []}
+
+    salida = asyncio.run(build_server().call_tool(
+        "pbi_apply_page_spec", {"spec": spec_informe, "sync_mode": "merge"}))
+    cuerpo = salida[1] if isinstance(salida, tuple) else salida
+    if isinstance(cuerpo, dict) and "result" in cuerpo:
+        cuerpo = cuerpo["result"]
+
+    avisos = " ".join(cuerpo.get("warnings") or [])
+    assert "FUERA del lienzo" in avisos, (
+        f"el aviso no llego a la respuesta de la tool: {cuerpo.get('warnings')}")
+    assert "1920x1080" in avisos and "1280x720" in avisos
+    assert "sync_mode='replace'" in avisos and "pbi_reflow_pages" in avisos
+    assert cuerpo.get("out_of_bounds_kept"), "y con los ids, para poder actuar"
+
+
+def test_el_planificador_hace_la_cuenta_y_no_solo_la_funcion_suelta(
+        proyecto_compuesto_en_sala):
+    """Que la funcion sepa contar no sirve si nadie la llama.
+
+    Este test recorre `page_update.planificar` de verdad: si se quita la
+    llamada dentro de `_planificar_update`, la funcion sigue pasando sus
+    propios tests y este es el que acusa.
+    """
+    from horizun_pbi_mcp.services import page_spec
+
+    _s, active, md = proyecto_compuesto_en_sala
+    spec_informe = {"schema_version": "1.0",
+                    "page": {"name": "Control", "width": 1280, "height": 720},
+                    "layout": {"preset": "executive", "gap": 16},
+                    "visuals": [{"type": "card", "title": "Costo",
+                                 "fields": {"values": ["[TotalAmount]"]}}],
+                    "filters": [], "interactions": []}
+    plan = page_update.planificar(
+        active, page_spec.compile_spec(active, spec_informe, md),
+        sync_mode=page_update.MERGE)
+
+    assert plan["out_of_bounds_kept"], (
+        "el visual de la composicion en sala queda fuera y nadie lo dijo")
+    assert plan["out_of_bounds_kept"] == plan["not_removed"]
+    assert any("FUERA del lienzo" in a for a in plan["warnings"])
+
+
+def test_con_replace_el_aviso_desaparece_porque_el_problema_tambien(
+        proyecto_compuesto_en_sala):
+    from horizun_pbi_mcp.services import page_spec
+
+    _s, active, md = proyecto_compuesto_en_sala
+    spec_informe = {"schema_version": "1.0",
+                    "page": {"name": "Control", "width": 1280, "height": 720},
+                    "layout": {"preset": "executive", "gap": 16},
+                    "visuals": [{"type": "card", "title": "Costo",
+                                 "fields": {"values": ["[TotalAmount]"]}}],
+                    "filters": [], "interactions": []}
+    plan = page_update.planificar(
+        active, page_spec.compile_spec(active, spec_informe, md),
+        sync_mode=page_update.REPLACE)
+
+    assert plan["removed"], "replace si los borra"
+    assert plan["warnings"] == [], "no hay nada de que avisar si se eliminan"
+
+
+# ============================================================ hallazgo 4 =====
+class TestReflujo:
+    """El camino de vuelta: reescalar y recolorear lo ya escrito."""
+
+    def test_reescalar_es_proporcional(self):
+        nueva = reflow._reescalar({"x": 960, "y": 540, "width": 480, "height": 270},
+                                  1280 / 1920, 720 / 1080,
+                                  {"width": 1280.0, "height": 720.0})
+        assert nueva == {"x": 640.0, "y": 360.0, "width": 320.0, "height": 180.0}
+
+    def test_nada_puede_quedar_fuera_del_lienzo_nuevo(self):
+        """El punto entero del reflujo: acotar, no arrastrar el problema."""
+        nueva = reflow._reescalar({"x": 1900, "y": 1000, "width": 800, "height": 600},
+                                  1.0, 1.0, {"width": 1280.0, "height": 720.0})
+        assert nueva["x"] + nueva["width"] <= 1280.0
+        assert nueva["y"] + nueva["height"] <= 720.0
+
+    def test_un_visual_mas_grande_que_el_lienzo_se_encoge_no_se_descarta(self):
+        nueva = reflow._reescalar({"x": 0, "y": 0, "width": 3000, "height": 2000},
+                                  1.0, 1.0, {"width": 1280.0, "height": 720.0})
+        assert nueva["width"] == 1280.0 and nueva["height"] == 720.0
+
+    def test_el_z_y_el_tab_order_sobreviven(self):
+        """Reordenar la pila al reescalar cambiaria que tapa a que."""
+        nueva = reflow._reescalar({"x": 0, "y": 0, "width": 10, "height": 10,
+                                   "z": 7000, "tabOrder": 3},
+                                  1.0, 1.0, {"width": 1280.0, "height": 720.0})
+        assert nueva["z"] == 7000 and nueva["tabOrder"] == 3
+
+    def test_nada_desaparece_por_redondeo(self):
+        """Un visual fino no puede quedar en 0 de ancho al encoger."""
+        nueva = reflow._reescalar({"x": 0, "y": 0, "width": 2, "height": 2},
+                                  0.05, 0.05, {"width": 1280.0, "height": 720.0})
+        assert nueva["width"] >= 1.0 and nueva["height"] >= 1.0
+
+
+class TestRecolorear:
+    """Lo que deja los titulos blancos sobre blanco."""
+
+    def test_el_color_del_textbox_vive_en_los_textruns(self):
+        data = {"visual": {"objects": {"general": [{"properties": {"paragraphs": [
+            {"textRuns": [{"value": "Titulo",
+                           "textStyle": {"color": "#FFFFFF",
+                                         "fontSize": "28pt"}}]}]}}]}}}
+
+        assert reflow._recolorear(data, "#1A1A1A") is True
+        run = data["visual"]["objects"]["general"][0]["properties"][
+            "paragraphs"][0]["textRuns"][0]
+        assert run["textStyle"]["color"] == "#1A1A1A"
+        assert run["textStyle"]["fontSize"] == "28pt", (
+            "recolorear no puede llevarse por delante el resto del estilo")
+
+    def test_no_se_inventa_formato_donde_no_lo_habia(self):
+        data = {"visual": {"objects": {"general": [{"properties": {}}]}}}
+        assert reflow._recolorear(data, "#1A1A1A") is False
+        assert data["visual"]["objects"]["general"][0]["properties"] == {}
+
+    def test_un_visual_sin_objects_no_revienta(self):
+        assert reflow._recolorear({"visual": {}}, "#1A1A1A") is False
+        assert reflow._recolorear({}, "#1A1A1A") is False
+
+
+def test_solo_se_recolorean_los_decorativos():
+    """Un grafico toma su color del tema al renderizar; tocarlo seria pisar
+    una decision del usuario. El texto compuesto no: ese esta cocido."""
+    assert set(reflow.DECORATIVOS_CON_COLOR) == {"textbox", "shape"}
+
+
+def test_aplicar_un_sistema_que_no_existe_falla_antes_de_tocar_nada():
+    from horizun_pbi_mcp.powerbi.errors import ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        reflow.planificar(object(), "no_existe")
+    assert "no_existe" in str(exc.value)
+
+
+def test_el_plan_no_escribe_nada(monkeypatch, tmp_path):
+    """`dry_run` por defecto: el reflujo mueve TODA la pagina, y eso se mira
+    antes de hacerlo."""
+    import inspect
+
+    fuente = inspect.getsource(reflow.aplicar)
+    assert "if dry_run:" in fuente
+    assert fuente.index("if dry_run:") < fuente.index("assert_escritura_pbir"), (
+        "el corte por dry_run tiene que ir ANTES de la puerta de escritura")
+
+    firma = inspect.signature(reflow.aplicar)
+    assert firma.parameters["dry_run"].default is True, (
+        "el defecto seguro es no escribir")
+
+
+def test_se_escribe_en_una_sola_transaccion():
+    """Si falla la tercera pagina, las dos primeras no pueden quedar
+    reflujadas y el resto no: media pagina en cada lienzo es peor que nada."""
+    import inspect
+
+    fuente = inspect.getsource(reflow.aplicar)
+    assert fuente.count("project_transaction") == 1
+    assert fuente.index("for pagina in plan") < fuente.index("project_transaction"), (
+        "hay que compilar TODAS las paginas antes de abrir la transaccion")
+
+
+def test_aplicar_un_sistema_avisa_de_las_paginas_que_deja_atras(
+        proyecto_compuesto_en_sala):
+    """El aviso que convierte un defecto silencioso en uno que se ve.
+
+    Aplicar un sistema cambia el TEMA del informe y nada mas: las paginas ya
+    escritas se quedan con el lienzo viejo. Antes eso no se decia y el
+    desajuste se descubria abriendo el informe.
+    """
+    from horizun_pbi_mcp.services import design
+
+    _s, active, _md = proyecto_compuesto_en_sala      # la pagina esta en 1920x1080
+    salida = design.aplicar(active, "informe")        # 1280x720
+
+    desajustadas = salida.get("pages_with_other_canvas") or []
+    assert desajustadas, (
+        "la pagina sigue en 1920x1080 y aplicar 'informe' no lo dijo")
+    assert any(p.get("canvas") == {"width": 1920.0, "height": 1080.0}
+               for p in desajustadas), "hay que decir en QUE lienzo se quedaron"
+    assert any("pbi_reflow_pages" in a for a in (salida.get("warnings") or [])), (
+        "hay que decir con QUE se arregla, no solo que esta mal")
+
+
+def test_aplicar_un_sistema_no_avisa_cuando_no_hay_nada_desajustado(
+        session, tmp_path, isolated_settings):
+    """El aviso tiene que significar algo: si el lienzo ya coincide, callar."""
+    from horizun_pbi_mcp.pbip import project_locator
+    from horizun_pbi_mcp.services import design
+    from tests.fixtures import synthetic
+
+    # El proyecto sintetico trae sus paginas en 1280x720, que es el lienzo de
+    # `informe`: aplicarlo no deja ninguna atras.
+    project_locator.open_project(session, str(synthetic.materialize(tmp_path)))
+    salida = design.aplicar(session.require_active_pbip(), "informe")
+
+    assert not (salida.get("pages_with_other_canvas") or []), (
+        "avisar de lo que ya esta bien entrena a ignorar los avisos")
+    assert not any("pbi_reflow_pages" in a
+                   for a in (salida.get("warnings") or []))

--- a/tests/test_sintaxis_python_minima.py
+++ b/tests/test_sintaxis_python_minima.py
@@ -1,0 +1,106 @@
+"""Sintaxis que el Python minimo declarado no entiende.
+
+`pyproject.toml` dice `requires-python = ">=3.10"`, pero la suite corre con el
+interprete que haya en la maquina. Escribiendo en 3.14 se cuela sin ruido
+sintaxis de 3.12: **comillas del mismo tipo anidadas dentro de un f-string**
+(PEP 701). En 3.10 eso no es un fallo en tiempo de ejecucion sino un
+`SyntaxError` **al importar**, asi que no rompe un test: rompe la recoleccion
+entera y el servidor no arranca.
+
+Paso de verdad, y solo lo vio CI en la matriz 3.10:
+
+    f"({', '.join(sorted({f'{d["canvas"]["width"]:.0f}' for d in x}))})"
+
+`ast.parse(..., feature_version=(3, 10))` NO sirve para esto —lo acepta, el
+tokenizador no esta versionado—, asi que hay que mirar los tokens. Con
+`FSTRING_START`/`FSTRING_END` (3.12+) se sabe exactamente donde empieza y
+acaba cada f-string y con que comilla, y cualquier STRING de dentro que use
+esa misma comilla es sintaxis que 3.10 no compila.
+
+Cubre esa trampa, que es la que hemos pisado. No es un backport del parser.
+"""
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+from pathlib import Path
+
+import pytest
+
+RAIZ = Path(__file__).resolve().parents[1]
+FUENTES = sorted((RAIZ / "src").rglob("*.py")) + sorted((RAIZ / "scripts").rglob("*.py"))
+
+
+def minimo_declarado() -> tuple:
+    texto = (RAIZ / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'requires-python\s*=\s*"[><=~^ ]*(\d+)\.(\d+)', texto)
+    assert m, "pyproject.toml no declara requires-python"
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def comillas_anidadas(fuente: str):
+    """Posiciones donde un f-string reusa por dentro una comilla que lo cierra.
+
+    La regla de antes de 3.12 es literal: el texto de un f-string no puede
+    contener su propio delimitador. Y vale para CUALQUIERA de los f-strings
+    que envuelven, no solo el mas interno —el caso que se colo tenia el
+    `"canvas"` dentro de un `f'...'` que a su vez estaba dentro de un
+    `f"..."`—. Un `f\"\"\"` solo choca con tres comillas seguidas, no con una.
+    """
+    tokens = tokenize.generate_tokens(io.StringIO(fuente).readline)
+    pila: list = []
+    hallazgos = []
+    for tok in tokens:
+        if tok.type == getattr(tokenize, "FSTRING_START", -1):
+            pila.append(tok.string.lstrip("fFrRbB"))       # el delimitador
+        elif tok.type == getattr(tokenize, "FSTRING_END", -1):
+            if pila:
+                pila.pop()
+        elif pila and tok.type in (tokenize.STRING,
+                                   getattr(tokenize, "FSTRING_MIDDLE", -1)):
+            texto = tok.string
+            if tok.type != tokenize.STRING:
+                # En la parte LITERAL, una comilla escapada siempre fue legal
+                # —`f"... ROW(\"n\", ...)"` es DAX de toda la vida—. Lo que
+                # 3.10 no admite es la comilla desnuda.
+                texto = texto.replace('\\"', "").replace("\\'", "")
+            if any(delim in texto for delim in pila):
+                hallazgos.append((tok.start[0], tok.string))
+    return hallazgos
+
+
+@pytest.mark.skipif(not hasattr(tokenize, "FSTRING_START"),
+                    reason="el interprete no distingue los tokens de f-string "
+                           "(<3.12); ahi el propio parser ya rechaza PEP 701")
+@pytest.mark.parametrize("ruta", FUENTES, ids=lambda p: p.name)
+def test_ninguna_fuente_usa_comillas_anidadas_en_f_strings(ruta):
+    minimo = minimo_declarado()
+    if minimo >= (3, 12):
+        pytest.skip(f"el minimo declarado ya es {minimo}: PEP 701 es legal")
+
+    hallazgos = comillas_anidadas(ruta.read_text(encoding="utf-8"))
+    assert not hallazgos, (
+        f"{ruta.relative_to(RAIZ)} usa comillas anidadas dentro de un f-string "
+        f"(PEP 701, Python 3.12+) y el minimo declarado es "
+        f"{minimo[0]}.{minimo[1]}. En 3.10 esto es un SyntaxError AL IMPORTAR: "
+        f"el servidor no arranca. Saca la expresion a una variable antes. "
+        f"Lineas: {[l for l, _ in hallazgos]}")
+
+
+def test_el_detector_encuentra_el_caso_que_se_nos_colo():
+    """El detector tiene que acusar la linea real que rompio CI."""
+    c = '"'
+    malo = ("x = f" + c + "({', '.join(sorted({f'{d[" + c + "canvas" + c
+            + "][" + c + "width" + c + "]:.0f}' for d in y}))})" + c + "\n")
+
+    hallazgos = comillas_anidadas(malo)
+    assert hallazgos, "el detector no vio el caso que rompio la matriz 3.10"
+
+
+def test_el_detector_no_acusa_lo_que_si_es_legal():
+    """Comillas del OTRO tipo por dentro son validas desde siempre."""
+    assert comillas_anidadas("""x = f"{d['canvas']['width']:.0f}"\n""") == []
+    assert comillas_anidadas('''x = f'{d["canvas"]}'\n''') == []
+    assert comillas_anidadas('x = "una cadena normal"\n') == []
+    assert comillas_anidadas('x = f"{a}{b}" + "otra"\n') == []

--- a/tests/test_sintaxis_python_minima.py
+++ b/tests/test_sintaxis_python_minima.py
@@ -70,9 +70,17 @@ def comillas_anidadas(fuente: str):
     return hallazgos
 
 
-@pytest.mark.skipif(not hasattr(tokenize, "FSTRING_START"),
-                    reason="el interprete no distingue los tokens de f-string "
-                           "(<3.12); ahi el propio parser ya rechaza PEP 701")
+#: El detector necesita los tokens de f-string, que son de 3.12. Corriendo en
+#: 3.10 u 11 no hace falta: ahi el propio parser rechaza PEP 701 y el fallo
+#: sale solo. El guard existe justamente para el caso contrario —escribir en
+#: un interprete nuevo y publicar para uno viejo—, y ahi si esta disponible.
+SIN_TOKENS_DE_FSTRING = pytest.mark.skipif(
+    not hasattr(tokenize, "FSTRING_START"),
+    reason="el interprete no distingue los tokens de f-string (<3.12); ahi el "
+           "propio parser ya rechaza PEP 701 al importar")
+
+
+@SIN_TOKENS_DE_FSTRING
 @pytest.mark.parametrize("ruta", FUENTES, ids=lambda p: p.name)
 def test_ninguna_fuente_usa_comillas_anidadas_en_f_strings(ruta):
     minimo = minimo_declarado()
@@ -88,6 +96,7 @@ def test_ninguna_fuente_usa_comillas_anidadas_en_f_strings(ruta):
         f"Lineas: {[l for l, _ in hallazgos]}")
 
 
+@SIN_TOKENS_DE_FSTRING
 def test_el_detector_encuentra_el_caso_que_se_nos_colo():
     """El detector tiene que acusar la linea real que rompio CI."""
     c = '"'
@@ -98,6 +107,7 @@ def test_el_detector_encuentra_el_caso_que_se_nos_colo():
     assert hallazgos, "el detector no vio el caso que rompio la matriz 3.10"
 
 
+@SIN_TOKENS_DE_FSTRING
 def test_el_detector_no_acusa_lo_que_si_es_legal():
     """Comillas del OTRO tipo por dentro son validas desde siempre."""
     assert comillas_anidadas("""x = f"{d['canvas']['width']:.0f}"\n""") == []

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -161,6 +161,7 @@ DISENO_TOOLS = [
     "pbi_list_design_systems",
     "pbi_apply_design_system",
     "pbi_compose_page",
+    "pbi_reflow_pages",
 ]
 
 #: Filtrar un visual EXISTENTE sin escribir `filterConfig` a mano.


### PR DESCRIPTION
Los dos hallazgos **ALTO** de la sesión 5D son el mismo defecto visto por dos lados, y el mismo que los dos críticos ya cerrados: **el estado cambió y lo ya escrito se quedó como estaba, en silencio.**

Se compuso en `sala` (1920×1080), se cambió a `informe` (1280×720) y se recompuso con `merge`. Los visuales de la composición anterior se conservaron **fuera del lienzo**: no se ven al abrir el informe, pero viajan al render y a la publicación, y solo aparecen si a alguien se le ocurre correr `pbi_detect_layout_issues`. Y no había vuelta atrás: cambiar de sistema obligaba a recomponer cada página a mano.

Un detalle que no estaba dicho en ninguna parte: el color del texto **sí** sale del tema, pero se cuece **al componer** y queda literal en el `visual.json`. Un título compuesto en oscuro queda blanco sobre blanco al pasar a claro. Nada falla; simplemente no se lee.

## Qué trae

- **`pbi_reflow_pages`** (128 tools). Reescala cada visual proporcionalmente al lienzo nuevo —acotándolo si no cabe— y recalcula el color de los decorativos con el tema destino. Una sola transacción para todo el lote: media página en cada lienzo es peor que nada. `dry_run=True` por defecto. **No recompone**, y lo dice: adivinar la intención de cada visual sería peor.
- **`merge` avisa antes del daño**, con la cuenta hecha, los ids y las **dos** salidas: `sync_mode='replace'` o `pbi_reflow_pages`.
- **`pbi_apply_design_system`** dice cuántas páginas deja con otro lienzo.

De paso, el defecto recurrente de esta casa: `pbi_apply_page_spec` hacía `resultado["warnings"] = compilado["warnings"]`, una **asignación** que borraba los avisos de la escritura justo antes de devolverlos. El servidor lo sabía y no lo decía.

## Verificación

Por mutación, las cuatro. Quitar la llamada al aviso dentro del planificador, volver a pisar los `warnings` en la tool, quitar el acotado del reescalado y quitar el aviso de `apply_design_system`: cada una la acusa un test que la nombra.

La primera versión del test de `apply_design_system` hacía grep del nombre de la función y **no acusaba nada**; se reescribió contra el comportamiento.

**1841 tests en verde, 3 saltados.** `doctor.py`: instalación operativa, contrato de 128 tools cuadrado con el golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)