### PR TITLE
Reserva atómica del request_id y JSON corrupto que no se pisa

### DIFF
--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -452,8 +452,11 @@ def check_session_freshness(rep: Report, instances: List[Dict[str, Any]]) -> Non
         data = json.loads(session_file.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         rep.add("session", "Sesion persistida", WARN,
-                f"session.json ilegible: {exc}", required=False,
-                hint=f"Puedes borrarlo sin riesgo: {session_file}")
+                f"session.json CORRUPTO: {exc}. El servidor lo conserva sin "
+                "tocar y arranca con la sesion vacia; no persistira nada "
+                "mientras siga asi.", required=False,
+                hint="Miralo y borralo tu si no te dice nada. No se "
+                     f"sobreescribe solo, a proposito: {session_file}")
         return
 
     problems = []

--- a/src/horizun_pbi_mcp/config.py
+++ b/src/horizun_pbi_mcp/config.py
@@ -41,6 +41,10 @@ except Exception:  # pragma: no cover
     def load_dotenv(*_a, **_k):  # type: ignore
         return False
 
+from horizun_pbi_mcp.logging_config import get_logger
+
+log = get_logger("config")
+
 #: src/horizun_pbi_mcp/config.py -> la raiz del clon es el abuelo de src/.
 #: Solo es "la raiz del proyecto" cuando de verdad se ejecuta desde un clon;
 #: `running_from_checkout()` es quien lo decide, no esta constante.
@@ -247,6 +251,9 @@ class Session:
         self._verified_identity: Optional[tuple[Any, ...]] = None
         self._verified_at_monotonic: Optional[float] = None
         self._session_file = settings.outputs_dir / "session.json"
+        # Lo pone `_load_persisted`; se declara aqui para que `_persist`
+        # nunca pueda mirarlo antes de que exista.
+        self._session_corrupta: Optional[str] = None
         self._load_persisted()
 
     # -- modelo activo --
@@ -391,7 +398,40 @@ class Session:
             return self._active_pbip
 
     # -- persistencia best-effort --
+    @property
+    def persisted_state(self) -> Dict[str, Any]:
+        """Que le paso al `session.json` al arrancar.
+
+        `ok` cuando se leyo (o no existia); `corrupt` cuando existe y no es
+        JSON valido. En ese caso el archivo NO se toca —ni se reescribe, ni se
+        renombra, ni se borra— y la sesion arranca en blanco. Es el unico
+        estado que hay que contar hacia fuera: todo lo demas sigue igual, pero
+        el modelo y el proyecto activos ya no sobreviven a un reinicio y nadie
+        se enteraria.
+        """
+        estado: Dict[str, Any] = {"path": str(self._session_file),
+                                  "state": "corrupt" if self._session_corrupta
+                                  else "ok"}
+        if self._session_corrupta:
+            estado["reason"] = self._session_corrupta
+            estado["consequence"] = (
+                "La sesion arranco vacia y no se persistira nada mientras el "
+                "archivo siga asi: el modelo y el proyecto activos se perderan "
+                "al reiniciar.")
+            estado["recovery"] = (
+                "Miralo y borralo tu si no te dice nada. No se sobreescribe "
+                "solo, a proposito: nadie sabe que habia dentro.")
+        return estado
+
     def _persist(self) -> None:
+        if self._session_corrupta:
+            # Invariante: no se pisa un JSON que no parsea. Perder la sesion
+            # persistida es reversible; destruir el archivo que explica que
+            # paso, no.
+            log.warning(
+                "No se persiste la sesion: %s esta corrupto (%s). Se deja "
+                "intacto.", self._session_file, self._session_corrupta)
+            return
         data = {
             "active_model": self._active_model.to_dict() if self._active_model else None,
             "active_pbip": self._active_pbip.to_dict() if self._active_pbip else None,
@@ -408,17 +448,33 @@ class Session:
             pass
 
     def _load_persisted(self) -> None:
+        self._session_corrupta: Optional[str] = None
+        if not self._session_file.exists():
+            return
         try:
-            if self._session_file.exists():
-                data = json.loads(self._session_file.read_text(encoding="utf-8"))
-                am = data.get("active_model")
-                ap = data.get("active_pbip")
-                if am:
-                    self._active_model = ActiveModel(**am)
-                if ap:
-                    self._active_pbip = ActivePbip(**ap)
-        except (OSError, ValueError, TypeError):
-            pass
+            crudo = self._session_file.read_text(encoding="utf-8")
+        except OSError:
+            return
+        try:
+            data = json.loads(crudo)
+        except ValueError as exc:
+            # Antes se ignoraba en silencio y el primer `_persist()` lo pisaba.
+            self._session_corrupta = f"{type(exc).__name__}: {exc}"
+            log.error("session.json corrupto, se conserva sin tocar: %s (%s)",
+                      self._session_file, exc)
+            return
+        try:
+            am = data.get("active_model") if isinstance(data, dict) else None
+            ap = data.get("active_pbip") if isinstance(data, dict) else None
+            if am:
+                self._active_model = ActiveModel(**am)
+            if ap:
+                self._active_pbip = ActivePbip(**ap)
+        except (TypeError, AttributeError) as exc:
+            # JSON valido pero con otra forma: no es corrupcion del archivo, y
+            # reescribirlo con la forma buena es justo lo que toca.
+            log.warning("session.json no tiene la forma esperada (%s): se "
+                        "ignora su contenido.", exc)
 
 
 # --- singletons de proceso ---

--- a/src/horizun_pbi_mcp/services/idempotency.py
+++ b/src/horizun_pbi_mcp/services/idempotency.py
@@ -36,15 +36,49 @@ Persistencia
 Un archivo JSON por `request_id` bajo `<backups>/_idempotency/`, escrito con
 `durable_write` (tmp + fsync + replace). Un proceso interrumpido a mitad deja el
 registro anterior intacto, nunca un archivo a medias.
+
+La reserva tiene que ser ATOMICA
+--------------------------------
+`comenzar()` hacia leer -> decidir -> escribir sin nada que lo hiciera
+indivisible. Dos llamadas simultaneas con el mismo `request_id` leian las dos
+que no habia registro, las dos escribian `in_flight` y las dos ejecutaban la
+mutacion: exactamente lo que esta pieza existe para impedir. La ventana es
+pequena pero real, y un cliente que reintenta por timeout es justo quien la
+abre.
+
+Dos cerrojos, porque son dos problemas distintos:
+
+- **Entre procesos**: un cerrojo de archivo (`fcntl.flock` / `msvcrt.locking`)
+  sobre `<request_id>.lock`, tomado durante la decision entera. Se eligio el
+  cerrojo del sistema y no un archivo centinela porque **el sistema lo suelta
+  solo cuando el proceso muere**; un centinela lo dejaria puesto para siempre.
+- **Entre hilos**: un `threading.Lock` por `request_id`. En el mismo proceso el
+  cerrojo de archivo no siempre distingue dos descriptores, y el servidor
+  atiende en hilos.
+
+Y el alta se hace ademas con `O_CREAT | O_EXCL`, que es atomico de por si: si
+el cerrojo de archivo no llegara a aplicarse —hay sistemas de archivos en red
+que lo ignoran—, dos altas simultaneas siguen sin poder ganar las dos.
+
+El JSON corrupto no se pisa
+---------------------------
+`leer()` devolvia `None` ante un registro ilegible, asi que la llamada
+siguiente lo tomaba por inexistente y lo SOBREESCRIBIA: se habilitaba una
+mutacion que quiza ya se habia hecho, y encima se destruia la unica evidencia
+de lo ocurrido. Ahora falla cerrado (`idempotency_record_corrupt`) y el
+archivo se queda como esta, byte a byte. Nadie lo renombra ni lo borra: eso lo
+decide una persona mirandolo.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Optional
 
 from horizun_pbi_mcp.logging_config import get_logger
 from horizun_pbi_mcp.powerbi.errors import PowerBIMCPError
@@ -59,6 +93,11 @@ STALE_IN_FLIGHT_SECONDS = 300
 #: Espera maxima ante un in_flight vivo, antes de devolver request_in_progress.
 WAIT_SECONDS = 2.0
 _WAIT_STEP = 0.05
+#: Espera maxima por el cerrojo de un `request_id`. La seccion critica es una
+#: lectura y una escritura de unos pocos kilobytes: agotarlo no significa
+#: "hay cola", significa que alguien lo tiene tomado y no lo suelta.
+LOCK_TIMEOUT_SECONDS = 30.0
+_LOCK_STEP = 0.01
 
 IN_FLIGHT = "in_flight"
 SUCCEEDED = "succeeded"
@@ -76,6 +115,110 @@ class RequestInProgressError(PowerBIMCPError):
     """Ese request_id se esta ejecutando ahora mismo en otra llamada."""
 
     code = "request_in_progress"
+
+
+class RegistroCorruptoError(PowerBIMCPError):
+    """El registro de esa peticion existe pero no es JSON valido.
+
+    Se falla cerrado a proposito. Un registro ilegible es la unica prueba de
+    que esa peticion paso por aqui: tratarlo como inexistente habilitaria una
+    mutacion que quiza ya ocurrio, y sobreescribirlo borraria la evidencia.
+    """
+
+    code = "idempotency_record_corrupt"
+
+
+# ------------------------------------------------------- exclusion mutua ---
+#: Un cerrojo por `request_id` dentro del proceso. Se guardan indefinidamente
+#: porque un Lock son unas decenas de bytes y el numero de request_id vivos en
+#: una sesion es pequeno; purgarlos abriria una carrera al purgar.
+_CERROJOS: Dict[str, threading.Lock] = {}
+_CERROJOS_LOCK = threading.Lock()
+
+
+def _cerrojo_de_hilo(clave: str) -> threading.Lock:
+    with _CERROJOS_LOCK:
+        return _CERROJOS.setdefault(clave, threading.Lock())
+
+
+if os.name == "nt":                                       # pragma: no cover
+    import msvcrt
+
+    def _intentar_tomar(fd: int) -> bool:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+
+    def _soltar(fd: int) -> None:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+else:                                                     # pragma: no cover
+    import fcntl
+
+    def _intentar_tomar(fd: int) -> bool:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+    def _soltar(fd: int) -> None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+
+@contextlib.contextmanager
+def _cerrojo_de_archivo(ruta: Path, request_id: str) -> Iterator[None]:
+    """Cerrojo del sistema sobre `ruta`, con espera acotada.
+
+    Se reintenta sin bloquear en vez de usar la espera del sistema: en Windows
+    `LK_LOCK` bloquea diez segundos fijos y no hay forma de acotarlo, y colgar
+    un hilo del servidor sin limite no es una opcion.
+    """
+    ruta.parent.mkdir(parents=True, exist_ok=True)
+    banderas = os.O_CREAT | os.O_RDWR | getattr(os, "O_BINARY", 0)
+    fd = os.open(ruta, banderas, 0o600)
+    try:
+        limite = time.time() + LOCK_TIMEOUT_SECONDS
+        while True:
+            os.lseek(fd, 0, os.SEEK_SET)
+            if _intentar_tomar(fd):
+                break
+            if time.time() >= limite:
+                raise RequestInProgressError(
+                    f"El request_id '{request_id}' lleva mas de "
+                    f"{LOCK_TIMEOUT_SECONDS:.0f}s tomado por otra llamada y no "
+                    "se ha podido reservar. Espera a que termine antes de "
+                    "reintentar.",
+                    details={"request_id": request_id,
+                             "lock_timeout_seconds": LOCK_TIMEOUT_SECONDS})
+            time.sleep(_LOCK_STEP)
+        try:
+            yield
+        finally:
+            _soltar(fd)
+    finally:
+        os.close(fd)
+
+
+@contextlib.contextmanager
+def _exclusion(store: "Store", request_id: str) -> Iterator[None]:
+    """Exclusion por `request_id`: primero entre hilos, luego entre procesos.
+
+    El orden es siempre el mismo en todo el modulo; invertirlo en algun sitio
+    seria un abrazo mortal entre dos procesos multihilo.
+    """
+    ruta = store._archivo_cerrojo(request_id)
+    with _cerrojo_de_hilo(str(ruta)):
+        with _cerrojo_de_archivo(ruta, request_id):
+            yield
 
 
 @dataclass
@@ -127,28 +270,92 @@ class Store:
         seguro = safe_paths.safe_identifier(request_id, kind="request_id")
         return self.root / f"{seguro}.json"
 
+    def _archivo_cerrojo(self, request_id: str) -> Path:
+        from horizun_pbi_mcp.services import paths as safe_paths
+
+        seguro = safe_paths.safe_identifier(request_id, kind="request_id")
+        # Archivo aparte: tomar el cerrojo no puede crear ni tocar el registro,
+        # que es lo que decide si la peticion existe. Y `purgar` mira *.json.
+        return self.root / f"{seguro}.lock"
+
+    def _corrupto(self, f: Path, request_id: str) -> RegistroCorruptoError:
+        return RegistroCorruptoError(
+            f"El registro de idempotencia de '{request_id}' existe pero no es "
+            "JSON valido. No se ejecuta la operacion ni se sobreescribe el "
+            "archivo: es la unica prueba de que esa peticion paso por aqui y "
+            "no se sabe si llego a aplicarse. Revisalo y decide tu si "
+            f"borrarlo: {f}",
+            details={"request_id": request_id, "path": str(f),
+                     "recovery": "Inspecciona el archivo. Si el cambio NO se "
+                                 "aplico, borralo a mano y reintenta. Si se "
+                                 "aplico, borralo y NO reintentes."})
+
     def leer(self, request_id: str) -> Optional[Registro]:
         f = self._archivo(request_id)
         if not f.exists():
             return None
         try:
-            datos = json.loads(f.read_text(encoding="utf-8"))
-        except (ValueError, OSError):
-            log.warning("Registro de idempotencia ilegible, se ignora: %s", f)
+            crudo = f.read_text(encoding="utf-8")
+        except OSError:
+            log.warning("Registro de idempotencia ilegible: %s", f)
             return None
+        try:
+            datos = json.loads(crudo)
+        except ValueError as exc:
+            # Antes esto devolvia None y la llamada siguiente lo pisaba.
+            log.error("Registro de idempotencia corrupto: %s (%s)", f, exc)
+            raise self._corrupto(f, request_id) from exc
         reg = Registro.from_dict(datos)
         if time.time() - reg.created_at > TTL_SECONDS:
             return None
         return reg
 
+    def _no_pisar_corrupto(self, request_id: str) -> None:
+        """Invariante: nunca se sobreescribe un JSON que no parsea."""
+        f = self._archivo(request_id)
+        if not f.exists():
+            return
+        try:
+            json.loads(f.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            raise self._corrupto(f, request_id) from exc
+        except OSError:
+            return          # ilegible por permisos: no es corrupcion probada
+
     def escribir(self, reg: Registro) -> None:
         from horizun_pbi_mcp.services.txn import durable_write
 
+        self._no_pisar_corrupto(reg.request_id)
         reg.updated_at = time.time()
         self.root.mkdir(parents=True, exist_ok=True)
         durable_write(self._archivo(reg.request_id),
                       json.dumps(reg.to_dict(), ensure_ascii=False,
                                  indent=2).encode("utf-8"))
+
+    def reservar(self, reg: Registro) -> bool:
+        """Crea el registro SOLO si no existia. `True` si la reserva es nuestra.
+
+        `O_CREAT | O_EXCL` es atomico en el sistema de archivos: de dos altas
+        simultaneas, exactamente una lo consigue. Es la garantia de ultimo
+        recurso, por debajo del cerrojo, para el unico caso que importa de
+        verdad —dos llamadas que no ven registro— y el unico que sobrevive a un
+        sistema de archivos que ignore los cerrojos.
+        """
+        self.root.mkdir(parents=True, exist_ok=True)
+        reg.updated_at = time.time()
+        datos = json.dumps(reg.to_dict(), ensure_ascii=False,
+                           indent=2).encode("utf-8")
+        try:
+            fd = os.open(self._archivo(reg.request_id),
+                         os.O_CREAT | os.O_EXCL | os.O_WRONLY
+                         | getattr(os, "O_BINARY", 0), 0o600)
+        except FileExistsError:
+            return False
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(datos)
+            fh.flush()
+            os.fsync(fh.fileno())
+        return True
 
     def borrar(self, request_id: str) -> None:
         try:
@@ -180,20 +387,62 @@ def store_por_defecto() -> Store:
 
 
 # ------------------------------------------------------------------ protocolo ---
+#: Veredictos de `_decidir`. No son parte del contrato publico.
+_EJECUTAR = "ejecutar"
+_REPRODUCIR = "reproducir"
+_EN_VUELO = "en_vuelo"
+
+
 def comenzar(store: Store, request_id: str, operation: str,
              payload: Any) -> Optional[Dict[str, Any]]:
     """Abre (o resuelve) una peticion.
 
     Devuelve el resultado guardado si es un reintento ya resuelto; `None` si hay
     que ejecutar la mutacion. Lanza si hay conflicto o si sigue en vuelo.
+
+    La decision se toma entera bajo el cerrojo del `request_id` —leer y
+    reservar tienen que ser indivisibles o dos llamadas ejecutan la misma
+    mutacion—, pero la ESPERA se hace fuera: quien esta ejecutando tiene que
+    poder escribir su resultado, y si el que espera retuviera el cerrojo no
+    podria. Por eso es un bucle y no una llamada anidada.
     """
     fp = plan_contract.fingerprint_de(payload)
+    limite = time.time() + WAIT_SECONDS
+    while True:
+        with _exclusion(store, request_id):
+            veredicto, valor = _decidir(store, request_id, operation, fp)
+        if veredicto == _EJECUTAR:
+            return None
+        if veredicto == _REPRODUCIR:
+            return valor
+        if time.time() >= limite:
+            raise RequestInProgressError(
+                f"El request_id '{request_id}' se esta ejecutando ahora mismo. "
+                "Espera a que termine antes de reintentar.",
+                details={"request_id": request_id, "operation": valor.operation,
+                         "age_seconds": round(valor.edad, 1)})
+        time.sleep(_WAIT_STEP)
+
+
+def _decidir(store: Store, request_id: str, operation: str, fp: str):
+    """Que hacer con esta peticion. Se llama SIEMPRE con el cerrojo tomado."""
     reg = store.leer(request_id)
 
     if reg is None:
-        store.escribir(Registro(request_id=request_id, operation=operation,
-                                payload_fingerprint=fp, state=IN_FLIGHT))
-        return None
+        nuevo = Registro(request_id=request_id, operation=operation,
+                         payload_fingerprint=fp, state=IN_FLIGHT)
+        if store.reservar(nuevo):
+            return _EJECUTAR, None
+        # Alguien gano el alta entre la lectura y esta linea, aun teniendo el
+        # cerrojo: solo puede pasar si el cerrojo no se aplico. Se vuelve a
+        # decidir con lo que hay ahora, que es lo unico honesto.
+        log.warning("La reserva de %s la gano otra llamada: se reevalua.",
+                    request_id)
+        reg = store.leer(request_id)
+        if reg is None:                                   # pragma: no cover
+            return _EN_VUELO, Registro(request_id=request_id,
+                                       operation=operation,
+                                       payload_fingerprint=fp, state=IN_FLIGHT)
 
     if reg.payload_fingerprint != fp:
         raise IdempotencyConflictError(
@@ -206,49 +455,20 @@ def comenzar(store: Store, request_id: str, operation: str,
     if reg.state == SUCCEEDED and reg.result is not None:
         salida = dict(reg.result)
         salida["idempotent_replay"] = True
-        return salida
+        return _REPRODUCIR, salida
 
     if reg.state == IN_FLIGHT:
-        reg = _esperar_o_reclamar(store, reg, fp)
-        if reg is None:
-            return None                       # se reclamo: hay que ejecutar
-        if reg.state == SUCCEEDED and reg.result is not None:
-            salida = dict(reg.result)
-            salida["idempotent_replay"] = True
-            return salida
-        raise RequestInProgressError(
-            f"El request_id '{request_id}' se esta ejecutando ahora mismo. "
-            "Espera a que termine antes de reintentar.",
-            details={"request_id": request_id, "operation": reg.operation,
-                     "age_seconds": round(reg.edad, 1)})
+        if reg.edad <= STALE_IN_FLIGHT_SECONDS:
+            return _EN_VUELO, reg
+        # Lleva parado demasiado: el proceso que lo abrio murio. Se reclama.
+        # No se afirma que la mutacion no ocurriera, solo que nadie la vigila.
+        log.warning("Peticion %s abandonada en vuelo hace %.0fs: se reclama.",
+                    request_id, reg.edad)
 
-    # failed / compensated: se puede reintentar, se reabre.
+    # in_flight abandonado, failed o compensated: se reabre y se ejecuta.
     store.escribir(Registro(request_id=request_id, operation=operation,
                             payload_fingerprint=fp, state=IN_FLIGHT))
-    return None
-
-
-def _esperar_o_reclamar(store: Store, reg: Registro,
-                        fp: str) -> Optional[Registro]:
-    """Espera acotada a que un in_flight se resuelva.
-
-    Si lleva parado mas de `STALE_IN_FLIGHT_SECONDS`, el proceso que lo abrio
-    murio: se reclama la entrada. No se afirma que la mutacion no ocurriera.
-    """
-    if reg.edad > STALE_IN_FLIGHT_SECONDS:
-        log.warning("Peticion %s abandonada en vuelo hace %.0fs: se reclama.",
-                    reg.request_id, reg.edad)
-        store.escribir(Registro(request_id=reg.request_id, operation=reg.operation,
-                                payload_fingerprint=fp, state=IN_FLIGHT))
-        return None
-
-    limite = time.time() + WAIT_SECONDS
-    while time.time() < limite:
-        time.sleep(_WAIT_STEP)
-        actual = store.leer(reg.request_id)
-        if actual is None or actual.state != IN_FLIGHT:
-            return actual
-    return reg
+    return _EJECUTAR, None
 
 
 def terminar_ok(store: Store, request_id: str, operation: str, payload: Any,

--- a/src/horizun_pbi_mcp/tools/ops_tools.py
+++ b/src/horizun_pbi_mcp/tools/ops_tools.py
@@ -295,6 +295,7 @@ def register(mcp) -> None:
                 "active_pbip": info_pbip,
                 "coherence": coh,
                 "outputs_dir": str(get_settings().outputs_dir),
+                "persisted_session": session.persisted_state,
                 "live_plans": operations.registro().planes_vivos(),
             }
             if coh["state"] == coherencia.DIFFERENT:
@@ -302,6 +303,13 @@ def register(mcp) -> None:
                     "El modelo en vivo y el proyecto activo son archivos "
                     "DISTINTOS. Las escrituras de informe estan bloqueadas "
                     "hasta resolverlo. " + coh["how_to_fix"]]
+            # Un session.json corrupto no rompe nada AHORA, y por eso hay que
+            # decirlo: se nota al reiniciar, cuando ya nadie lo relaciona.
+            if salida["persisted_session"]["state"] == "corrupt":
+                salida.setdefault("warnings", []).append(
+                    f"{salida['persisted_session']['path']} esta corrupto. "
+                    + salida["persisted_session"]["consequence"] + " "
+                    + salida["persisted_session"]["recovery"])
             return salida
         return guard(_impl)
 

--- a/tests/test_idempotency_concurrencia.py
+++ b/tests/test_idempotency_concurrencia.py
@@ -1,0 +1,317 @@
+"""La reserva de un `request_id` tiene que ser indivisible.
+
+`comenzar()` hacia leer -> decidir -> escribir sin nada que lo hiciera atomico.
+Dos llamadas simultaneas con el mismo `request_id` leian las dos que no habia
+registro, las dos escribian `in_flight` y las dos ejecutaban la mutacion: justo
+lo que esta pieza existe para impedir. Un cliente que reintenta por timeout es
+quien abre esa ventana, asi que no es teorica.
+
+Todas las pruebas de aqui son DETERMINISTAS: la carrera no se busca repitiendo
+a ver si sale, se PROVOCA parando a un hilo dentro de la ventana exacta. Una
+prueba de concurrencia que depende del planificador no prueba nada, y ademas
+falla sola de vez en cuando.
+
+Y el corolario del segundo defecto: un registro corrupto no se pisa. Se
+comprueba byte a byte, que es la unica forma de afirmarlo.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from horizun_pbi_mcp.services import idempotency
+from horizun_pbi_mcp.services.idempotency import Store
+
+PAYLOAD = {"operation": "pbi_rename_page", "arguments": {"page": "A", "new_name": "B"}}
+
+#: Margen para la cita entre hilos. Generoso a proposito: agotarlo solo puede
+#: significar que la coordinacion se rompio, nunca que la maquina iba lenta.
+TIMEOUT = 30.0
+
+
+@pytest.fixture
+def store(tmp_path):
+    return Store(tmp_path / "_idem")
+
+
+# ==================================================== la carrera, entre hilos ==
+#: Cuanto se mantiene ABIERTA la ventana entre leer y reservar. No es un
+#: margen por si la maquina va lenta —de esos ya nos hemos quemado—: con el
+#: arreglo el resultado no depende de este numero, porque el segundo hilo se
+#: queda parado en el cerrojo pase lo que pase. Solo sirve para que la version
+#: ANTERIOR falle siempre y no una de cada diez veces.
+VENTANA = 0.3
+
+
+def test_dos_hilos_a_la_vez_solo_uno_ejecuta(store):
+    """El defecto exacto, provocado a mano.
+
+    No se puede citar a los dos hilos DENTRO de la seccion critica: si la
+    exclusion funciona, el segundo no llega nunca y la cita se rompe sola. Lo
+    que se hace es mantener abierta la ventana del primero —se le para entre
+    leer el registro y reservarlo— y comprobar que el segundo no puede
+    colarse por ella.
+
+    Con la version anterior los dos leian ausencia de registro y los dos
+    devolvian `None`, que es permiso para mutar. Ahora uno reserva y el otro
+    se lo encuentra en vuelo.
+    """
+    veredictos = []
+    fallos = []
+    ventana_abierta = threading.Event()
+    real_leer = store.leer
+
+    def leer_con_ventana(request_id):
+        reg = real_leer(request_id)
+        if not ventana_abierta.is_set():
+            ventana_abierta.set()      # el primero ya leyo y aun no reservo
+            time.sleep(VENTANA)        # ...y se queda ahi, con la ventana abierta
+        return reg
+
+    def llamar():
+        try:
+            veredictos.append(idempotency.comenzar(store, "r1", "op", PAYLOAD))
+        except idempotency.RequestInProgressError:
+            veredictos.append("en_vuelo")
+        except Exception as exc:                      # pragma: no cover
+            fallos.append(repr(exc))
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(idempotency, "WAIT_SECONDS", 0.2)
+        mp.setattr(store, "leer", leer_con_ventana)
+        primero = threading.Thread(target=llamar, name="primero")
+        primero.start()
+        assert ventana_abierta.wait(TIMEOUT), "el primero no llego a leer"
+        segundo = threading.Thread(target=llamar, name="segundo")
+        segundo.start()
+        for h in (primero, segundo):
+            h.join(TIMEOUT)
+
+    assert not fallos, f"un hilo reviento: {fallos}"
+    assert not primero.is_alive() and not segundo.is_alive(), "algun hilo colgado"
+
+    permisos = [v for v in veredictos if v is None]
+    assert len(permisos) == 1, (
+        f"exactamente UNO puede recibir permiso para mutar; veredictos: "
+        f"{veredictos}")
+    assert veredictos.count("en_vuelo") == 1, (
+        "el segundo tiene que verlo en vuelo, no ejecutar tambien")
+    assert idempotency.estado(store, "r1")["state"] == idempotency.IN_FLIGHT
+
+
+def test_la_barrera_es_el_cerrojo_y_no_la_suerte(store):
+    """Que el segundo ESPERE de verdad, no que llegue tarde por casualidad.
+
+    Se comprueba que mientras un hilo tiene el cerrojo tomado, otro no puede
+    entrar en la seccion critica. Sin esto, la prueba de arriba pasaria
+    tambien con un `time.sleep` bien puesto.
+    """
+    dentro = threading.Event()
+    puede_salir = threading.Event()
+    entro_el_segundo = threading.Event()
+
+    def primero():
+        with idempotency._exclusion(store, "r1"):
+            dentro.set()
+            puede_salir.wait(TIMEOUT)
+
+    def segundo():
+        dentro.wait(TIMEOUT)
+        with idempotency._exclusion(store, "r1"):
+            entro_el_segundo.set()
+
+    h1 = threading.Thread(target=primero)
+    h2 = threading.Thread(target=segundo)
+    h1.start()
+    h2.start()
+    try:
+        assert dentro.wait(TIMEOUT), "el primero no llego a tomar el cerrojo"
+        assert not entro_el_segundo.wait(0.3), (
+            "el segundo entro en la seccion critica con el cerrojo tomado")
+    finally:
+        puede_salir.set()
+        h1.join(TIMEOUT)
+        h2.join(TIMEOUT)
+
+    assert entro_el_segundo.is_set(), (
+        "al soltarlo, el segundo tiene que poder entrar: un cerrojo que no se "
+        "suelta es peor que no tenerlo")
+
+
+def test_el_alta_es_atomica_aunque_el_cerrojo_no_se_aplique(store):
+    """La garantia de ultimo recurso.
+
+    Hay sistemas de archivos en red que ignoran los cerrojos. Ahi el alta
+    sigue sin poder ganarla dos, porque `O_CREAT|O_EXCL` es atomico en el
+    propio sistema de archivos. Se simula anulando el cerrojo.
+    """
+    import contextlib
+
+    @contextlib.contextmanager
+    def sin_cerrojo(_store, _rid):
+        yield
+
+    ganadores = []
+    barrera = threading.Barrier(2, timeout=TIMEOUT)
+
+    def intentar():
+        reg = idempotency.Registro(request_id="r1", operation="op",
+                                   payload_fingerprint="fp",
+                                   state=idempotency.IN_FLIGHT)
+        barrera.wait()
+        ganadores.append(store.reservar(reg))
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(idempotency, "_exclusion", sin_cerrojo)
+        hilos = [threading.Thread(target=intentar) for _ in range(2)]
+        for h in hilos:
+            h.start()
+        for h in hilos:
+            h.join(TIMEOUT)
+
+    assert ganadores.count(True) == 1, (
+        f"solo uno puede crear el registro; resultados: {ganadores}")
+    assert ganadores.count(False) == 1
+
+
+def test_reservar_no_toca_un_registro_que_ya_existe(store):
+    reg = idempotency.Registro(request_id="r1", operation="op",
+                               payload_fingerprint="fp",
+                               state=idempotency.IN_FLIGHT)
+    assert store.reservar(reg) is True
+    antes = (store.root / "r1.json").read_bytes()
+
+    reg2 = idempotency.Registro(request_id="r1", operation="OTRA",
+                                payload_fingerprint="otra",
+                                state=idempotency.SUCCEEDED)
+    assert store.reservar(reg2) is False
+    assert (store.root / "r1.json").read_bytes() == antes, (
+        "una reserva perdida no puede haber escrito nada")
+
+
+# =================================================== la carrera, entre procesos ==
+_HIJO = r"""
+import json, os, sys, time
+sys.path.insert(0, sys.argv[1])
+from horizun_pbi_mcp.services import idempotency
+from horizun_pbi_mcp.services.idempotency import Store
+
+store = Store(sys.argv[2])
+arranque = float(sys.argv[3])
+# Los dos procesos entran a la vez: se citan por RELOJ DE PARED, que es lo
+# unico compartido sin montar un canal entre ellos.
+time.sleep(max(0.0, arranque - time.time()))
+try:
+    r = idempotency.comenzar(store, "rp", "op", {"a": 1})
+    print(json.dumps({"veredicto": "ejecuta" if r is None else "reproduce"}))
+except idempotency.RequestInProgressError:
+    print(json.dumps({"veredicto": "en_vuelo"}))
+except Exception as exc:
+    print(json.dumps({"veredicto": "error", "detalle": repr(exc)}))
+"""
+
+
+def test_dos_procesos_a_la_vez_solo_uno_ejecuta(store, tmp_path):
+    """El cerrojo tiene que valer TAMBIEN entre procesos.
+
+    Un `threading.Lock` no cruza el limite del proceso, y dos clientes MCP
+    sobre el mismo directorio de trabajo son dos procesos. Se lanzan dos de
+    verdad, citados por reloj de pared.
+    """
+    guion = tmp_path / "hijo.py"
+    guion.write_text(_HIJO, encoding="utf-8")
+    src = str((__import__("pathlib").Path(__file__).resolve().parents[1] / "src"))
+
+    arranque = time.time() + 1.5
+    procesos = [
+        subprocess.Popen([sys.executable, str(guion), src, str(store.root),
+                          str(arranque)],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         text=True)
+        for _ in range(2)]
+    salidas = []
+    for p in procesos:
+        out, err = p.communicate(timeout=120)
+        assert p.returncode == 0, f"el hijo fallo: {err}"
+        salidas.append(json.loads(out.strip().splitlines()[-1]))
+
+    veredictos = [s["veredicto"] for s in salidas]
+    assert "error" not in veredictos, salidas
+    assert veredictos.count("ejecuta") == 1, (
+        f"exactamente un PROCESO puede mutar; veredictos: {veredictos}")
+
+
+# ================================================ el JSON corrupto no se pisa ==
+CORRUPTO = b'{"request_id": "r1", "state": "succ'
+
+
+def test_un_registro_corrupto_falla_cerrado_y_no_habilita_la_mutacion(store):
+    store.root.mkdir(parents=True, exist_ok=True)
+    f = store.root / "r1.json"
+    f.write_bytes(CORRUPTO)
+
+    with pytest.raises(idempotency.RegistroCorruptoError) as exc:
+        idempotency.comenzar(store, "r1", "op", PAYLOAD)
+
+    assert exc.value.code == "idempotency_record_corrupt"
+    assert "recovery" in exc.value.details, (
+        "fallar cerrado sin decir como salir es un callejon")
+    assert f.read_bytes() == CORRUPTO, "el archivo tiene que quedar INTACTO"
+
+
+def test_un_registro_corrupto_no_se_sobreescribe_ni_al_terminar(store):
+    """Ni siquiera guardando un resultado: la evidencia manda.
+
+    Antes `leer` devolvia None ante un JSON roto, la llamada siguiente lo daba
+    por inexistente y lo pisaba. Se perdia la unica prueba de que esa peticion
+    habia pasado por aqui, justo cuando hacia falta para saber si el cambio se
+    aplico.
+    """
+    store.root.mkdir(parents=True, exist_ok=True)
+    f = store.root / "r1.json"
+    f.write_bytes(CORRUPTO)
+
+    with pytest.raises(idempotency.RegistroCorruptoError):
+        idempotency.terminar_ok(store, "r1", "op", PAYLOAD, {"ok": True})
+    assert f.read_bytes() == CORRUPTO
+
+    with pytest.raises(idempotency.RegistroCorruptoError):
+        idempotency.terminar_error(store, "r1", "op", PAYLOAD, {"ok": False},
+                                   safe_to_retry=True)
+    assert f.read_bytes() == CORRUPTO
+
+
+def test_nadie_renombra_ni_borra_el_registro_corrupto(store):
+    store.root.mkdir(parents=True, exist_ok=True)
+    (store.root / "r1.json").write_bytes(CORRUPTO)
+
+    with pytest.raises(idempotency.RegistroCorruptoError):
+        idempotency.comenzar(store, "r1", "op", PAYLOAD)
+    store.purgar()
+
+    assert [p.name for p in store.root.glob("*.json")] == ["r1.json"], (
+        "no se crea un .bak, no se mueve y no se borra: lo decide una persona")
+    assert (store.root / "r1.json").read_bytes() == CORRUPTO
+
+
+def test_un_registro_sano_si_se_sobreescribe(store):
+    """El guard no puede convertirse en un candado sobre lo normal."""
+    idempotency.comenzar(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_ok(store, "r1", "op", PAYLOAD, {"ok": True, "v": 1})
+    assert idempotency.estado(store, "r1")["result"] == {"ok": True, "v": 1}
+
+
+def test_el_cerrojo_no_se_confunde_con_el_registro(store):
+    """El archivo de cerrojo no puede hacer creer que la peticion existe."""
+    with idempotency._exclusion(store, "r1"):
+        pass
+    assert store.leer("r1") is None, (
+        "tomar el cerrojo no da de alta la peticion")
+    assert (store.root / "r1.lock").exists()
+    assert store.purgar() == 0, "purgar mira *.json: el cerrojo no es un registro"

--- a/tests/test_session_json_corrupto.py
+++ b/tests/test_session_json_corrupto.py
@@ -1,0 +1,161 @@
+"""Un `session.json` que no parsea no se sobreescribe. Nunca.
+
+`_load_persisted()` se tragaba el `ValueError` en silencio y arrancaba con la
+sesion vacia; el primer `_persist()` —que ocurre en cuanto alguien selecciona
+un modelo o abre un proyecto— lo pisaba con el estado nuevo. El archivo que
+explicaba que habia pasado desaparecia sin que nadie llegara a verlo, y encima
+sin dejar rastro de que hubiera estado roto.
+
+Que se garantiza aqui:
+
+- el archivo queda **byte a byte** como estaba, en el arranque y despues de
+  operar;
+- nadie lo renombra, lo mueve ni lo borra: eso lo decide una persona que lo
+  mire;
+- el estado se cuenta hacia fuera —`persisted_state` y `pbi_session_info`—,
+  porque un `session.json` corrupto no rompe nada AHORA: se nota al reiniciar,
+  cuando ya nadie lo relaciona con esto.
+
+Lo que NO cuenta como corrupto: un JSON valido con otra forma. Ahi el archivo
+se entiende, simplemente no dice lo que esperabamos, y reescribirlo con la
+forma buena es exactamente lo que toca.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from horizun_pbi_mcp.config import ActiveModel, ActivePbip, Session
+from tests.conftest import make_settings
+
+ROTO = b'{"active_model": {"port": 51000, "cata'
+
+
+@pytest.fixture
+def settings_con_session_rota(tmp_path):
+    s = make_settings(tmp_path)
+    s.ensure_dirs()
+    (s.outputs_dir / "session.json").write_bytes(ROTO)
+    return s
+
+
+def archivo(s):
+    return s.outputs_dir / "session.json"
+
+
+# ------------------------------------------------------------- el invariante --
+def test_arrancar_con_el_json_roto_no_lo_toca(settings_con_session_rota):
+    s = settings_con_session_rota
+    Session(s)
+    assert archivo(s).read_bytes() == ROTO
+
+
+def test_operar_despues_tampoco_lo_pisa(settings_con_session_rota, tmp_path):
+    """El momento exacto del defecto: `_persist()` tras el arranque fallido."""
+    s = settings_con_session_rota
+    sesion = Session(s)
+
+    sesion.set_active_pbip(ActivePbip(
+        pbip_path=str(tmp_path / "X.pbip"), project_dir=str(tmp_path),
+        report_dir=str(tmp_path / "X.Report"), semantic_model_dir=None,
+        report_name="X"))
+
+    assert archivo(s).read_bytes() == ROTO, (
+        "seleccionar un proyecto persiste la sesion, y ahi se perdia el "
+        "archivo que explicaba el problema")
+
+
+def test_la_sesion_arranca_vacia_pero_sigue_funcionando(settings_con_session_rota):
+    """Fallar cerrado no es morirse: el servidor tiene que atender igual."""
+    sesion = Session(settings_con_session_rota)
+    assert sesion.active_model is None
+    assert sesion.active_pbip is None
+
+
+def test_nadie_renombra_ni_borra_ni_deja_un_bak(settings_con_session_rota, tmp_path):
+    s = settings_con_session_rota
+    sesion = Session(s)
+    sesion.set_active_model(ActiveModel(host="localhost", port=51000,
+                                   connection_string="Data Source=localhost:51000",
+                                   catalog="c"))
+
+    assert sorted(p.name for p in s.outputs_dir.iterdir()) == ["session.json"], (
+        "no se crea copia, no se mueve y no se borra")
+    assert archivo(s).read_bytes() == ROTO
+
+
+# ----------------------------------------------------------------- se cuenta --
+def test_el_estado_es_accionable(settings_con_session_rota):
+    estado = Session(settings_con_session_rota).persisted_state
+
+    assert estado["state"] == "corrupt"
+    assert estado["path"].endswith("session.json")
+    assert "reason" in estado, "hay que decir POR QUE no parsea"
+    assert "reiniciar" in estado["consequence"], (
+        "hay que decir la CONSECUENCIA: se nota al reiniciar, no ahora")
+    assert "borralo" in estado["recovery"], (
+        "y quien tiene que hacer que, porque el servidor no lo va a hacer solo")
+
+
+def test_pbi_session_info_lo_saca_como_aviso(settings_con_session_rota,
+                                             monkeypatch):
+    """No basta con guardarlo: tiene que llegar a quien mira."""
+    import asyncio
+
+    import horizun_pbi_mcp.config as cfg
+    from horizun_pbi_mcp.server import build_server
+
+    sesion = Session(settings_con_session_rota)
+    monkeypatch.setattr(cfg, "_session", sesion)
+    monkeypatch.setattr(cfg, "_settings", settings_con_session_rota)
+
+    salida = asyncio.run(build_server().call_tool("pbi_session_info", {}))
+    cuerpo = salida[1] if isinstance(salida, tuple) else salida
+    if isinstance(cuerpo, dict) and "result" in cuerpo and "ok" not in cuerpo:
+        cuerpo = cuerpo["result"]
+
+    assert cuerpo["persisted_session"]["state"] == "corrupt"
+    assert any("corrupto" in a for a in (cuerpo.get("warnings") or [])), (
+        f"el aviso no llego a la respuesta: {cuerpo.get('warnings')}")
+
+
+# ------------------------------------------- y lo normal sigue siendo normal --
+def test_una_sesion_sana_si_se_persiste(tmp_path):
+    """El guard no puede convertirse en un candado sobre el caso bueno."""
+    s = make_settings(tmp_path)
+    s.ensure_dirs()
+    sesion = Session(s)
+    sesion.set_active_model(ActiveModel(host="localhost", port=51000,
+                                   connection_string="Data Source=localhost:51000",
+                                   catalog="c"))
+
+    datos = json.loads(archivo(s).read_text(encoding="utf-8"))
+    assert datos["active_model"]["port"] == 51000
+    assert Session(s).persisted_state["state"] == "ok"
+
+
+def test_un_json_valido_con_otra_forma_no_es_corrupcion(tmp_path):
+    """Se entiende el archivo; solo no dice lo que esperabamos."""
+    s = make_settings(tmp_path)
+    s.ensure_dirs()
+    archivo(s).write_text('{"active_model": "esto deberia ser un objeto"}',
+                          encoding="utf-8")
+
+    sesion = Session(s)
+    assert sesion.persisted_state["state"] == "ok"
+    assert sesion.active_model is None
+
+    sesion.set_active_model(ActiveModel(host="localhost", port=52000,
+                            connection_string="Data Source=localhost:52000",
+                            catalog="c"))
+    assert json.loads(archivo(s).read_text(
+        encoding="utf-8"))["active_model"]["port"] == 52000, (
+        "un archivo legible con otra forma SI se reescribe: no hay evidencia "
+        "que preservar")
+
+
+def test_sin_archivo_no_hay_nada_que_conservar(tmp_path):
+    s = make_settings(tmp_path)
+    s.ensure_dirs()
+    assert Session(s).persisted_state["state"] == "ok"


### PR DESCRIPTION
Dos defectos con la misma forma: **el servidor decidía sobre un estado que podía cambiar entre que lo leía y que actuaba.**

## 1. Carrera en la idempotencia

`comenzar()` hacía leer → decidir → escribir sin nada que lo hiciera indivisible. Dos llamadas simultáneas con el mismo `request_id` leían las dos que no había registro, las dos escribían `in_flight` y las dos ejecutaban la mutación: exactamente lo que esta pieza existe para impedir. La ventana es pequeña, y quien la abre es justo el caso previsto — un cliente que reintenta por timeout.

**Dos cerrojos, porque son dos problemas distintos:**

- **Entre procesos**: cerrojo del sistema (`fcntl.flock` / `msvcrt.locking`) sobre `<request_id>.lock`. Se eligió el del sistema y no un archivo centinela porque **el sistema lo suelta cuando el proceso muere**; un centinela se quedaría puesto para siempre. Se reintenta sin bloquear con límite propio: `LK_LOCK` en Windows bloquea diez segundos fijos y colgar un hilo del servidor sin tope no es una opción.
- **Entre hilos**: `threading.Lock` por `request_id`. El servidor atiende en hilos y un cerrojo de archivo no siempre distingue dos descriptores del mismo proceso.

El alta va **además** con `O_CREAT|O_EXCL`, atómico de por sí: es la garantía de último recurso para el único caso que importa de verdad —dos llamadas que no ven registro— y la única que sobrevive a un sistema de archivos en red que ignore los cerrojos.

`comenzar` pasa a ser un bucle: la decisión entera bajo el cerrojo, **la espera fuera**. Si el que espera retuviera el cerrojo, el que ejecuta no podría escribir su resultado y la espera no serviría de nada.

## 2. El JSON corrupto se sobreescribía

`Store.leer()` devolvía `None` ante un registro ilegible, así que la llamada siguiente lo tomaba por inexistente y lo pisaba: se habilitaba una mutación que quizá ya se había hecho, y se destruía la única prueba de lo ocurrido. Ahora falla cerrado (`idempotency_record_corrupt`) y `escribir()` se niega a pisar un archivo que no parsea. `_common.py` ya trataba bien esa excepción, así que el contrato no se toca.

`Session._load_persisted()` se tragaba el `ValueError` en silencio y el primer `_persist()` —al seleccionar modelo o abrir proyecto— lo pisaba. Ahora la sesión se marca corrupta, no se persiste nada mientras siga así, y el estado sale por `pbi_session_info` con la consecuencia (**se nota al reiniciar, no ahora**) y con quién tiene que arreglarlo. Nadie renombra, mueve ni borra el archivo: eso lo decide una persona que lo mire.

Un JSON **válido con otra forma** no cuenta como corrupto: ahí el archivo se entiende y reescribirlo es lo que toca.

## Verificación

Las pruebas nuevas se contrastaron contra la implementación **anterior**:

| | falla sin el arreglo |
|---|---|
| `test_dos_hilos_a_la_vez_solo_uno_ejecuta` | ✔ |
| `test_la_barrera_es_el_cerrojo_y_no_la_suerte` | ✔ |
| `test_el_alta_es_atomica_aunque_el_cerrojo_no_se_aplique` | ✔ |
| `test_reservar_no_toca_un_registro_que_ya_existe` | ✔ |
| `test_dos_procesos_a_la_vez_solo_uno_ejecuta` | ✔ |
| `test_el_cerrojo_no_se_confunde_con_el_registro` | ✔ |
| `test_operar_despues_tampoco_lo_pisa` | ✔ |
| `test_nadie_renombra_ni_borra_ni_deja_un_bak` | ✔ |

La carrera no se busca repitiendo a ver si sale: se **provoca** parando al primer hilo entre leer y reservar, con la ventana abierta. Los dos procesos son dos `subprocess` de verdad, citados por reloj de pared. Y lo del archivo intacto se comprueba **byte a byte**, que es la única forma de afirmarlo.

**Contrato intacto**: 128 tools, `El contrato MCP no cambio.` — 1976 tests en verde, 3 saltados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)