### PR TITLE
El reclaim por antigüedad era una carrera con la mutación viva

### DIFF
--- a/src/horizun_pbi_mcp/services/idempotency.py
+++ b/src/horizun_pbi_mcp/services/idempotency.py
@@ -433,10 +433,12 @@ class Store:
             # Antes esto devolvia None y la llamada siguiente lo pisaba.
             log.error("Registro de idempotencia corrupto: %s (%s)", f, exc)
             raise self._corrupto(f, request_id) from exc
-        reg = Registro.from_dict(datos)
-        if time.time() - reg.created_at > TTL_SECONDS:
-            return None
-        return reg
+        # El TTL ya NO se aplica aqui. Ocultar un registro por viejo convertia
+        # "caducado" en "no existe": un in_flight o un fallo inseguro de mas
+        # de 24h volvia a autorizarse —el reclaim inseguro, por la puerta del
+        # calendario—. Quien caduca es `purgar()`, y solo lo terminal
+        # inequivocamente seguro.
+        return Registro.from_dict(datos)
 
     def _no_pisar_corrupto(self, request_id: str) -> None:
         """Invariante: nunca se sobreescribe un JSON que no parsea."""
@@ -503,17 +505,42 @@ class Store:
             pass
 
     def purgar(self) -> int:
-        """Elimina registros caducados. Devuelve cuantos."""
+        """Elimina SOLO lo terminal inequivocamente seguro y caducado.
+
+        Purgar era la otra puerta del reclaim: borraba por edad cualquier
+        registro —incluido un `in_flight` o un fallo inseguro— y el siguiente
+        `comenzar()` con ese request_id volvia a autorizarse. **La duda no
+        prescribe**: lo incierto se queda hasta que una persona lo resuelva.
+
+        Se puede ir: `succeeded`, `compensated` y `failed` con
+        `safe_to_retry=True`, pasado el TTL. Se queda: todo `in_flight`, los
+        fallos inseguros o sin veredicto, y lo corrupto o ilegible, que es
+        evidencia.
+
+        Cada borrado se decide bajo la exclusion de SU request_id, releyendo
+        el registro con el cerrojo tomado: entre ver el archivo y borrarlo,
+        otra llamada pudo reabrir la peticion, y borrar eso seria matar un
+        intento vivo por una lectura vieja.
+        """
         if not self.root.exists():
             return 0
         n = 0
         for f in self.root.glob("*.json"):
             try:
-                datos = json.loads(f.read_text(encoding="utf-8"))
-                if time.time() - datos.get("created_at", 0) > TTL_SECONDS:
+                with _exclusion(self, f.stem):
+                    reg = self.leer(f.stem)
+                    if reg is None or \
+                            time.time() - reg.created_at <= TTL_SECONDS:
+                        continue
+                    if reg.state == IN_FLIGHT:
+                        continue              # incierto: no prescribe
+                    if reg.state == FAILED and reg.safe_to_retry is not True:
+                        continue              # inseguro o sin veredicto
                     f.unlink(missing_ok=True)
                     n += 1
-            except (ValueError, OSError):
+            except PowerBIMCPError:
+                continue                      # corrupto/ilegible: evidencia
+            except OSError:                                 # pragma: no cover
                 continue
         return n
 
@@ -626,11 +653,56 @@ def _decidir(store: Store, request_id: str, operation: str, fp: str):
             return _EN_VUELO, reg
         raise _desconocido(reg)
 
-    # failed / compensated: acabaron, y acabaron mal. Reintentar es la via
-    # prevista, asi que se reabre con un intento NUEVO.
-    nuevo = _nuevo_intento(request_id, operation, fp)
-    store.escribir(nuevo)
-    return _EJECUTAR, nuevo.attempt_id
+    if reg.state == COMPENSATED or (reg.state == FAILED
+                                    and reg.safe_to_retry is True):
+        # Reintentar es seguro DECLARADO: compensated deshizo el cambio
+        # entero, y el failed lo afirmo quien lo cerro. Solo con esa
+        # afirmacion se reabre. Antes se reabria CUALQUIER failed sin mirar
+        # el veredicto, y un `bulk_partially_applied` cerrado con
+        # safe_to_retry=False se ejecutaba dos veces con el mismo request_id:
+        # guardar el veredicto y no consultarlo es no tenerlo.
+        nuevo = _nuevo_intento(request_id, operation, fp)
+        store.escribir(nuevo)
+        return _EJECUTAR, nuevo.attempt_id
+
+    if reg.state == FAILED and reg.safe_to_retry is False \
+            and isinstance(reg.error, dict):
+        # Fallo declarado NO seguro: se reproduce lo que paso, sin ejecutar.
+        # La raiz lleva el veredicto aunque el error guardado no lo trajera.
+        salida = dict(reg.error)
+        salida["idempotent_replay"] = True
+        salida["safe_to_retry"] = False
+        return _REPRODUCIR, salida
+
+    # failed sin veredicto (registro de una version anterior o cierre
+    # incompleto), inseguro sin error que reproducir, o un estado que este
+    # codigo no conoce: no hay base para autorizar nada.
+    raise _fallo_sin_permiso(reg)
+
+
+def _fallo_sin_permiso(reg: Registro) -> ResultadoDesconocidoError:
+    """Un fallo sin veredicto de reintento no autoriza nada.
+
+    `safe_to_retry=None` lo dejan los registros de versiones anteriores y los
+    cierres que no llegaron a declararlo. Tratarlo como "si se puede" seria
+    decidir por quien no dijo nada, que es como volvio la carrera la ultima
+    vez.
+    """
+    motivo = ("sin veredicto de reintento" if reg.safe_to_retry is None
+              else "declarado NO seguro de reintentar y sin resultado "
+                   "guardado que reproducir")
+    return ResultadoDesconocidoError(
+        f"El request_id '{reg.request_id}' termino en '{reg.state}' {motivo}. "
+        "No se autoriza otra ejecucion con ese mismo request_id.",
+        details={"request_id": reg.request_id, "operation": reg.operation,
+                 "state": reg.state,
+                 "stored_safe_to_retry": reg.safe_to_retry,
+                 "safe_to_retry": False,
+                 "recovery": (
+                     "Comprueba en el proyecto si el cambio se aplico. Si NO "
+                     "se aplico y quieres reintentar, usa un request_id nuevo "
+                     "o borra el registro a mano. Si se aplico, no "
+                     "reintentes.")})
 
 
 def _desconocido(reg: Registro) -> ResultadoDesconocidoError:
@@ -737,10 +809,19 @@ def descartar_en_vuelo(store: Store, request_id: str, *,
     """Recuperacion EXPLICITA de una peticion con resultado desconocido.
 
     El servidor no hace esto solo, y ese es el punto: quien lo llama esta
-    afirmando que ha mirado el proyecto y que el cambio no se aplico. Queda
-    como `failed` con `safe_to_retry=False`, para que el registro siga
-    contando lo que paso, y el siguiente intento con ese `request_id` se
-    autoriza con identidad nueva.
+    afirmando que ha mirado el proyecto y que el cambio NO se aplico.
+
+    Esa afirmacion es exactamente lo que hace seguro reintentar, asi que el
+    registro queda como `failed` con `safe_to_retry=True`. Guardar `False` y
+    reabrir igualmente —como se hacia— era incoherente por los dos lados a la
+    vez: el registro decia una cosa y la autorizacion hacia la contraria.
+    Ahora que el veredicto GOBIERNA la autorizacion, tiene que decir la
+    verdad de lo que se acaba de comprobar.
+
+    No es una compensacion: `compensated` significa que el servidor deshizo
+    el cambio y puede demostrarlo. Aqui no se deshizo nada; alguien miro y
+    dijo que nunca llego a haberlo. Por eso el estado es `failed` con el
+    motivo dentro, y no `compensated`.
     """
     with _exclusion(store, request_id):
         actual = store.leer(request_id)
@@ -751,8 +832,9 @@ def descartar_en_vuelo(store: Store, request_id: str, *,
             return {"request_id": request_id, "discarded": False,
                     "reason": f"No esta en vuelo, esta en '{actual.state}'."}
         actual.state = FAILED
-        actual.safe_to_retry = False
-        actual.error = {"error": "in_flight_discarded", "message": motivo}
+        actual.safe_to_retry = True
+        actual.error = {"error": "in_flight_discarded", "message": motivo,
+                        "reviewed_by_human": True}
         # Identidad nueva: el intento viejo, si despierta, ya no es el dueno y
         # no podra pisar lo que escriba el siguiente.
         actual.attempt_id = uuid.uuid4().hex

--- a/src/horizun_pbi_mcp/services/idempotency.py
+++ b/src/horizun_pbi_mcp/services/idempotency.py
@@ -26,10 +26,34 @@ Reglas:
 - ``failed`` -> se devuelve el error con `safe_to_retry` explicito;
 - ``compensated`` -> se puede reintentar.
 
-Un `in_flight` de un proceso que murio no puede bloquear para siempre: pasado
-`STALE_IN_FLIGHT_SECONDS` se considera abandonado y se permite reintentar,
-marcandolo como `failed` con `safe_to_retry=False` —porque nadie sabe si la
-escritura llego a ocurrir, y decir lo contrario seria mentir—.
+Lo que NO se hace: reclamar un `in_flight` por viejo
+----------------------------------------------------
+Antes, pasado `STALE_IN_FLIGHT_SECONDS`, un `in_flight` se daba por abandonado
+y se AUTORIZABA otra ejecucion. Eso era una carrera con la mutacion todavia
+corriendo:
+
+1. `comenzar()` autoriza y arranca la mutacion A;
+2. A tarda mas del umbral —`pbi_open_and_refresh` sobre un modelo grande lo
+   pasa sin despeinarse— y sigue perfectamente viva;
+3. una segunda llamada ve el registro "antiguo", lo reclama y arranca B;
+4. A termina y su `terminar_ok()` pisa el registro de B.
+
+Dos mutaciones con el mismo `request_id`, que es exactamente lo que esta pieza
+existe para impedir. **Antiguo no prueba muerto**, y aunque el proceso hubiera
+muerto, nadie sabe si la escritura llego a aplicarse.
+
+Ahora se falla cerrado: `request_outcome_unknown` con `safe_to_retry=False`.
+El error dice si el proceso dueno sigue vivo —diagnostico, no permiso— y como
+salir. Reabrir esa peticion es una decision de quien mira el proyecto y
+comprueba si el cambio esta o no: `descartar_en_vuelo()`.
+
+Identidad de intento
+--------------------
+Cada autorizacion acuna un `attempt_id` irrepetible y anota el proceso dueno.
+Cerrar es un compare-and-set bajo la misma exclusion que la reserva: si el
+registro ya pertenece a otro intento, el resultado NO se escribe
+(`idempotency_attempt_superseded`). Un intento antiguo que despierta tarde no
+puede completar ni borrar el rastro de uno nuevo.
 
 Persistencia
 ------------
@@ -76,6 +100,7 @@ import json
 import os
 import threading
 import time
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
@@ -115,6 +140,37 @@ class RequestInProgressError(PowerBIMCPError):
     """Ese request_id se esta ejecutando ahora mismo en otra llamada."""
 
     code = "request_in_progress"
+
+
+class ResultadoDesconocidoError(PowerBIMCPError):
+    """Hubo un intento anterior y no se sabe como acabo.
+
+    Es el estado que antes se resolvia solo, y mal: un `in_flight` viejo se
+    daba por muerto y se AUTORIZABA otra ejecucion. "Antiguo" no prueba nada.
+    Un `pbi_open_and_refresh` puede tardar mas que el umbral y estar
+    perfectamente vivo; y aunque el proceso hubiera muerto, nadie sabe si la
+    escritura llego a aplicarse. Autorizar ahi es duplicar la mutacion.
+
+    Se falla cerrado y la salida es de quien mira, no del servidor.
+    """
+
+    code = "request_outcome_unknown"
+
+
+class IntentoCaducadoError(PowerBIMCPError):
+    """Se intento cerrar una peticion que ya pertenece a otro intento.
+
+    Un intento antiguo no puede completar ni pisar el registro de uno nuevo:
+    su resultado describe una ejecucion que ya nadie esta esperando.
+    """
+
+    code = "idempotency_attempt_superseded"
+
+
+class RegistroIlegibleError(PowerBIMCPError):
+    """El registro existe y no se pudo leer. No es lo mismo que no existir."""
+
+    code = "idempotency_record_unreadable"
 
 
 class RegistroCorruptoError(PowerBIMCPError):
@@ -221,6 +277,36 @@ def _exclusion(store: "Store", request_id: str) -> Iterator[None]:
             yield
 
 
+def _proceso_vivo(pid: Optional[int], arranque: Optional[float]) -> Optional[bool]:
+    """Si el proceso que abrio la peticion sigue existiendo.
+
+    `None` cuando no se puede saber —no se guardo el dueno, o no hay permisos
+    para preguntarlo—. Se compara TAMBIEN el instante de arranque: los pid se
+    reciclan, y confundir un proceso nuevo con el que murio seria peor que no
+    mirar nada.
+
+    Esto NO autoriza nada por si solo. Que el dueno haya muerto no prueba que
+    la mutacion no se aplicara: solo dice que ya no hay nadie vigilandola.
+    """
+    if not pid:
+        return None
+    try:
+        import psutil
+    except Exception:                                      # noqa: BLE001
+        return None
+    try:
+        p = psutil.Process(pid)
+        if arranque and abs(p.create_time() - arranque) > 1.0:
+            return False                      # ese pid es de OTRO proceso
+        return p.is_running()
+    except psutil.NoSuchProcess:
+        # No existe es NO EXISTE, no "no se sabe": son dos diagnosticos
+        # distintos y mezclarlos deja al que lee sin la unica pista util.
+        return False
+    except Exception:                                      # noqa: BLE001
+        return None                            # sin permisos, por ejemplo
+
+
 @dataclass
 class Registro:
     request_id: str
@@ -232,13 +318,22 @@ class Registro:
     result: Optional[Dict[str, Any]] = None
     error: Optional[Dict[str, Any]] = None
     safe_to_retry: Optional[bool] = None
+    #: Identidad del INTENTO, no de la peticion. Se acuna una vez, al
+    #: autorizar, y no se reutiliza jamas: es lo que permite comprobar al
+    #: cerrar que quien escribe el resultado sigue siendo el dueno.
+    attempt_id: Optional[str] = None
+    #: Quien lo abrio. Sirve para saber si sigue vivo, no para autorizar.
+    owner_pid: Optional[int] = None
+    owner_started: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {"request_id": self.request_id, "operation": self.operation,
                 "payload_fingerprint": self.payload_fingerprint,
                 "state": self.state, "created_at": self.created_at,
                 "updated_at": self.updated_at, "result": self.result,
-                "error": self.error, "safe_to_retry": self.safe_to_retry}
+                "error": self.error, "safe_to_retry": self.safe_to_retry,
+                "attempt_id": self.attempt_id, "owner_pid": self.owner_pid,
+                "owner_started": self.owner_started}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "Registro":
@@ -249,11 +344,36 @@ class Registro:
             created_at=d.get("created_at", time.time()),
             updated_at=d.get("updated_at", time.time()),
             result=d.get("result"), error=d.get("error"),
-            safe_to_retry=d.get("safe_to_retry"))
+            safe_to_retry=d.get("safe_to_retry"),
+            # Los tres son opcionales a proposito: un registro escrito por una
+            # version anterior no los trae y tiene que seguir leyendose.
+            attempt_id=d.get("attempt_id"), owner_pid=d.get("owner_pid"),
+            owner_started=d.get("owner_started"))
 
     @property
     def edad(self) -> float:
         return time.time() - self.updated_at
+
+    @property
+    def dueno_vivo(self) -> Optional[bool]:
+        return _proceso_vivo(self.owner_pid, self.owner_started)
+
+
+def _mi_arranque() -> Optional[float]:
+    try:
+        import psutil
+
+        return psutil.Process(os.getpid()).create_time()
+    except Exception:                                      # noqa: BLE001
+        return None
+
+
+def _nuevo_intento(request_id: str, operation: str, fp: str) -> Registro:
+    """Un intento nuevo, con identidad propia y dueno declarado."""
+    return Registro(request_id=request_id, operation=operation,
+                    payload_fingerprint=fp, state=IN_FLIGHT,
+                    attempt_id=uuid.uuid4().hex,
+                    owner_pid=os.getpid(), owner_started=_mi_arranque())
 
 
 class Store:
@@ -296,9 +416,17 @@ class Store:
             return None
         try:
             crudo = f.read_text(encoding="utf-8")
-        except OSError:
-            log.warning("Registro de idempotencia ilegible: %s", f)
-            return None
+        except OSError as exc:
+            # Antes esto devolvia None, y "no se pudo leer" se convertia en
+            # "no existe": permiso para volver a mutar por un fallo de disco.
+            log.error("Registro de idempotencia ilegible: %s (%s)", f, exc)
+            raise RegistroIlegibleError(
+                f"El registro de idempotencia de '{request_id}' existe pero no "
+                f"se pudo leer ({exc}). No se ejecuta la operacion: no poder "
+                "comprobar si ya se hizo no es lo mismo que saber que no se "
+                "hizo. Revisa permisos y el estado del disco.",
+                details={"request_id": request_id, "path": str(f),
+                         "os_error": str(exc)}) from exc
         try:
             datos = json.loads(crudo)
         except ValueError as exc:
@@ -319,8 +447,14 @@ class Store:
             json.loads(f.read_text(encoding="utf-8"))
         except ValueError as exc:
             raise self._corrupto(f, request_id) from exc
-        except OSError:
-            return          # ilegible por permisos: no es corrupcion probada
+        except OSError as exc:
+            # No es corrupcion probada, pero tampoco permiso para pisarlo: si
+            # no se puede leer lo que hay, no se puede saber que se destruye.
+            raise RegistroIlegibleError(
+                f"No se pudo leer el registro de '{request_id}' antes de "
+                f"reescribirlo ({exc}). No se sobreescribe a ciegas.",
+                details={"request_id": request_id, "path": str(f),
+                         "os_error": str(exc)}) from exc
 
     def escribir(self, reg: Registro) -> None:
         from horizun_pbi_mcp.services.txn import durable_write
@@ -340,21 +474,26 @@ class Store:
         recurso, por debajo del cerrojo, para el unico caso que importa de
         verdad —dos llamadas que no ven registro— y el unico que sobrevive a un
         sistema de archivos que ignore los cerrojos.
+
+        Son dos pasos y tienen que serlo: el `O_EXCL` **reclama el hueco** y el
+        `durable_write` **pone el contenido** con tmp + fsync + replace. Antes
+        se escribia directo sobre el descriptor y un corte a mitad dejaba un
+        registro parcial. Ahora un corte entre los dos pasos deja el archivo
+        vacio, que no es JSON valido y por tanto bloquea —que es lo correcto:
+        si se murio reservando, nadie sabe si la mutacion llego a empezar—.
         """
+        from horizun_pbi_mcp.services.txn import durable_write
+
         self.root.mkdir(parents=True, exist_ok=True)
-        reg.updated_at = time.time()
-        datos = json.dumps(reg.to_dict(), ensure_ascii=False,
-                           indent=2).encode("utf-8")
+        destino = self._archivo(reg.request_id)
         try:
-            fd = os.open(self._archivo(reg.request_id),
-                         os.O_CREAT | os.O_EXCL | os.O_WRONLY
-                         | getattr(os, "O_BINARY", 0), 0o600)
+            os.close(os.open(destino, os.O_CREAT | os.O_EXCL | os.O_WRONLY
+                             | getattr(os, "O_BINARY", 0), 0o600))
         except FileExistsError:
             return False
-        with os.fdopen(fd, "wb") as fh:
-            fh.write(datos)
-            fh.flush()
-            os.fsync(fh.fileno())
+        reg.updated_at = time.time()
+        durable_write(destino, json.dumps(reg.to_dict(), ensure_ascii=False,
+                                          indent=2).encode("utf-8"))
         return True
 
     def borrar(self, request_id: str) -> None:
@@ -393,12 +532,27 @@ _REPRODUCIR = "reproducir"
 _EN_VUELO = "en_vuelo"
 
 
-def comenzar(store: Store, request_id: str, operation: str,
-             payload: Any) -> Optional[Dict[str, Any]]:
-    """Abre (o resuelve) una peticion.
+@dataclass
+class Intento:
+    """Lo que sale de abrir una peticion.
 
-    Devuelve el resultado guardado si es un reintento ya resuelto; `None` si hay
-    que ejecutar la mutacion. Lanza si hay conflicto o si sigue en vuelo.
+    `attempt_id` no es `None` exactamente cuando hay que ejecutar, y hay que
+    devolverlo al cerrar: es lo que demuestra que quien escribe el resultado
+    sigue siendo el dueno de la reserva.
+    """
+
+    request_id: str
+    attempt_id: Optional[str] = None
+    replay: Optional[Dict[str, Any]] = None
+
+    @property
+    def hay_que_ejecutar(self) -> bool:
+        return self.attempt_id is not None
+
+
+def comenzar_intento(store: Store, request_id: str, operation: str,
+                     payload: Any) -> Intento:
+    """Abre (o resuelve) una peticion, devolviendo la identidad del intento.
 
     La decision se toma entera bajo el cerrojo del `request_id` —leer y
     reservar tienen que ser indivisibles o dos llamadas ejecutan la misma
@@ -412,9 +566,9 @@ def comenzar(store: Store, request_id: str, operation: str,
         with _exclusion(store, request_id):
             veredicto, valor = _decidir(store, request_id, operation, fp)
         if veredicto == _EJECUTAR:
-            return None
+            return Intento(request_id=request_id, attempt_id=valor)
         if veredicto == _REPRODUCIR:
-            return valor
+            return Intento(request_id=request_id, replay=valor)
         if time.time() >= limite:
             raise RequestInProgressError(
                 f"El request_id '{request_id}' se esta ejecutando ahora mismo. "
@@ -424,15 +578,25 @@ def comenzar(store: Store, request_id: str, operation: str,
         time.sleep(_WAIT_STEP)
 
 
+def comenzar(store: Store, request_id: str, operation: str,
+             payload: Any) -> Optional[Dict[str, Any]]:
+    """Igual que `comenzar_intento`, con la forma de siempre.
+
+    Devuelve el resultado guardado si es un reintento ya resuelto, o `None` si
+    hay que ejecutar la mutacion. Quien pueda, use `comenzar_intento`: sin el
+    `attempt_id` no se puede comprobar al cerrar quien es el dueno.
+    """
+    return comenzar_intento(store, request_id, operation, payload).replay
+
+
 def _decidir(store: Store, request_id: str, operation: str, fp: str):
     """Que hacer con esta peticion. Se llama SIEMPRE con el cerrojo tomado."""
     reg = store.leer(request_id)
 
     if reg is None:
-        nuevo = Registro(request_id=request_id, operation=operation,
-                         payload_fingerprint=fp, state=IN_FLIGHT)
+        nuevo = _nuevo_intento(request_id, operation, fp)
         if store.reservar(nuevo):
-            return _EJECUTAR, None
+            return _EJECUTAR, nuevo.attempt_id
         # Alguien gano el alta entre la lectura y esta linea, aun teniendo el
         # cerrojo: solo puede pasar si el cerrojo no se aplico. Se vuelve a
         # decidir con lo que hay ahora, que es lo unico honesto.
@@ -460,38 +624,143 @@ def _decidir(store: Store, request_id: str, operation: str, fp: str):
     if reg.state == IN_FLIGHT:
         if reg.edad <= STALE_IN_FLIGHT_SECONDS:
             return _EN_VUELO, reg
-        # Lleva parado demasiado: el proceso que lo abrio murio. Se reclama.
-        # No se afirma que la mutacion no ocurriera, solo que nadie la vigila.
-        log.warning("Peticion %s abandonada en vuelo hace %.0fs: se reclama.",
-                    request_id, reg.edad)
+        raise _desconocido(reg)
 
-    # in_flight abandonado, failed o compensated: se reabre y se ejecuta.
-    store.escribir(Registro(request_id=request_id, operation=operation,
-                            payload_fingerprint=fp, state=IN_FLIGHT))
-    return _EJECUTAR, None
+    # failed / compensated: acabaron, y acabaron mal. Reintentar es la via
+    # prevista, asi que se reabre con un intento NUEVO.
+    nuevo = _nuevo_intento(request_id, operation, fp)
+    store.escribir(nuevo)
+    return _EJECUTAR, nuevo.attempt_id
+
+
+def _desconocido(reg: Registro) -> ResultadoDesconocidoError:
+    """El intento anterior lleva demasiado y no se sabe como acabo.
+
+    Antes esto se "reclamaba": se daba el registro por abandonado y se
+    autorizaba otra ejecucion. Es la carrera que quedaba. Una operacion
+    legitima puede pasar del umbral —abrir y refrescar un modelo grande lo
+    hace— y seguir viva; y aunque el dueno hubiera muerto, nadie sabe si la
+    escritura llego a aplicarse. Autorizar ahi duplica la mutacion.
+
+    Se mira si el proceso dueno sigue existiendo, no para decidir sino para
+    que quien lea el error sepa cual de los dos casos tiene delante.
+    """
+    vivo = reg.dueno_vivo
+    if vivo is True:
+        diagnostico = (f"El proceso que la abrio (pid {reg.owner_pid}) SIGUE "
+                       "VIVO: lo mas probable es que la operacion aun este "
+                       "trabajando. Espera a que acabe.")
+    elif vivo is False:
+        diagnostico = (f"El proceso que la abrio (pid {reg.owner_pid}) YA NO "
+                       "EXISTE, pero eso no dice si el cambio llego a "
+                       "aplicarse: pudo morir antes, durante o despues.")
+    else:
+        diagnostico = ("No se ha podido comprobar si el proceso que la abrio "
+                       "sigue vivo.")
+    return ResultadoDesconocidoError(
+        f"El request_id '{reg.request_id}' quedo en vuelo hace "
+        f"{reg.edad:.0f}s y no se sabe como acabo. {diagnostico} No se "
+        "autoriza otra ejecucion: seria la segunda mutacion con el mismo "
+        "request_id, que es justo lo que esto existe para impedir.",
+        details={
+            "request_id": reg.request_id, "operation": reg.operation,
+            "age_seconds": round(reg.edad, 1), "owner_pid": reg.owner_pid,
+            "owner_alive": vivo, "safe_to_retry": False,
+            "recovery": (
+                "1) Comprueba en el proyecto si el cambio se aplico. "
+                "2) Si NO se aplico, descarta el intento con "
+                "idempotency.descartar_en_vuelo(...) o borra el registro a "
+                "mano, y reintenta. 3) Si SI se aplico, no reintentes: usa un "
+                "request_id nuevo para el siguiente cambio."),
+        })
+
+
+def _cerrar(store: Store, reg: Registro, attempt_id: Optional[str]) -> None:
+    """Escribe el estado final SOLO si el intento sigue siendo el dueno.
+
+    El compare-and-set va bajo la misma exclusion que la reserva: sin eso, un
+    intento antiguo que despierta tarde pisa el registro de uno nuevo y borra
+    su rastro.
+
+    Compatibilidad: si el registro guardado no tiene `attempt_id` —lo escribio
+    una version anterior— o si quien cierra no lo trae, no hay con que
+    comparar y se escribe. La comprobacion aplica cuando los dos existen, que
+    es el caso de todo lo que se ejecuta a partir de ahora.
+    """
+    with _exclusion(store, reg.request_id):
+        actual = store.leer(reg.request_id)
+        if (actual is not None and attempt_id is not None
+                and actual.attempt_id is not None
+                and actual.attempt_id != attempt_id):
+            raise IntentoCaducadoError(
+                f"El intento {attempt_id} de '{reg.request_id}' ya no es el "
+                f"dueno de la reserva (ahora lo es {actual.attempt_id}, en "
+                f"estado '{actual.state}'). No se escribe su resultado: "
+                "describe una ejecucion que ya nadie esta esperando, y pisarlo "
+                "borraria el rastro del intento en curso.",
+                details={"request_id": reg.request_id,
+                         "attempt_id": attempt_id,
+                         "current_attempt_id": actual.attempt_id,
+                         "current_state": actual.state})
+        reg.attempt_id = attempt_id or (actual.attempt_id if actual else None)
+        store.escribir(reg)
 
 
 def terminar_ok(store: Store, request_id: str, operation: str, payload: Any,
-                resultado: Dict[str, Any]) -> None:
-    store.escribir(Registro(
+                resultado: Dict[str, Any], *,
+                attempt_id: Optional[str] = None) -> None:
+    _cerrar(store, Registro(
         request_id=request_id, operation=operation,
         payload_fingerprint=plan_contract.fingerprint_de(payload),
-        state=SUCCEEDED, result=resultado, safe_to_retry=None))
+        state=SUCCEEDED, result=resultado, safe_to_retry=None), attempt_id)
 
 
 def terminar_error(store: Store, request_id: str, operation: str, payload: Any,
                    error: Dict[str, Any], *, safe_to_retry: bool,
-                   compensado: bool = False) -> None:
+                   compensado: bool = False,
+                   attempt_id: Optional[str] = None) -> None:
     """Cierra una peticion fallida diciendo si reintentar es seguro.
 
     `compensado=True` significa que el cambio se deshizo por completo: el estado
     es el de antes y reintentar no duplica nada.
     """
-    store.escribir(Registro(
+    _cerrar(store, Registro(
         request_id=request_id, operation=operation,
         payload_fingerprint=plan_contract.fingerprint_de(payload),
         state=COMPENSATED if compensado else FAILED,
-        error=error, safe_to_retry=True if compensado else safe_to_retry))
+        error=error, safe_to_retry=True if compensado else safe_to_retry),
+        attempt_id)
+
+
+def descartar_en_vuelo(store: Store, request_id: str, *,
+                       motivo: str = "descartado a mano") -> Dict[str, Any]:
+    """Recuperacion EXPLICITA de una peticion con resultado desconocido.
+
+    El servidor no hace esto solo, y ese es el punto: quien lo llama esta
+    afirmando que ha mirado el proyecto y que el cambio no se aplico. Queda
+    como `failed` con `safe_to_retry=False`, para que el registro siga
+    contando lo que paso, y el siguiente intento con ese `request_id` se
+    autoriza con identidad nueva.
+    """
+    with _exclusion(store, request_id):
+        actual = store.leer(request_id)
+        if actual is None:
+            return {"request_id": request_id, "discarded": False,
+                    "reason": "No hay ningun registro para ese request_id."}
+        if actual.state != IN_FLIGHT:
+            return {"request_id": request_id, "discarded": False,
+                    "reason": f"No esta en vuelo, esta en '{actual.state}'."}
+        actual.state = FAILED
+        actual.safe_to_retry = False
+        actual.error = {"error": "in_flight_discarded", "message": motivo}
+        # Identidad nueva: el intento viejo, si despierta, ya no es el dueno y
+        # no podra pisar lo que escriba el siguiente.
+        actual.attempt_id = uuid.uuid4().hex
+        store.escribir(actual)
+    log.warning("Peticion %s descartada a mano: %s", request_id, motivo)
+    return {"request_id": request_id, "discarded": True,
+            "previous_state": IN_FLIGHT, "state": FAILED,
+            "note": "El siguiente intento con ese request_id se autorizara."}
 
 
 def estado(store: Store, request_id: str) -> Optional[Dict[str, Any]]:

--- a/src/horizun_pbi_mcp/tools/_common.py
+++ b/src/horizun_pbi_mcp/tools/_common.py
@@ -135,10 +135,17 @@ def guard_mutation(fn: Callable[[], Any]) -> Dict[str, Any]:
     store = idempotency.store_por_defecto()
 
     try:
-        previo = idempotency.comenzar(store, rid, op, payload)
+        intento = idempotency.comenzar_intento(store, rid, op, payload)
+        previo = intento.replay
     except PowerBIMCPError as exc:
-        return envelope.failure(exc.code, exc.message, exc.details,
-                                operation=op, request_id=rid, duration_ms=0)
+        salida = envelope.failure(exc.code, exc.message, exc.details,
+                                  operation=op, request_id=rid, duration_ms=0)
+        # Un resultado desconocido NO es seguro de reintentar: pudo aplicarse.
+        # Decirlo en el sobre, y no solo en `details`, es lo que impide que un
+        # cliente lo reintente en bucle.
+        if isinstance(exc.details, dict) and "safe_to_retry" in exc.details:
+            salida["safe_to_retry"] = exc.details["safe_to_retry"]
+        return salida
     except Exception as exc:                           # noqa: BLE001
         # Todavia no se ejecuto la mutacion: es seguro fallar cerrado.
         log.exception("No se pudo iniciar la idempotencia de %s", op)
@@ -155,7 +162,8 @@ def guard_mutation(fn: Callable[[], Any]) -> Dict[str, Any]:
     salida = guard(fn, operation=op, request_id=rid)
     if salida.get("ok"):
         try:
-            idempotency.terminar_ok(store, rid, op, payload, salida)
+            idempotency.terminar_ok(store, rid, op, payload, salida,
+                                    attempt_id=intento.attempt_id)
         except Exception as exc:                       # noqa: BLE001
             # La mutacion YA termino. Propagar esta excepcion haria que el
             # cliente creyera que fallo y la repitiera, duplicando paginas o
@@ -174,7 +182,8 @@ def guard_mutation(fn: Callable[[], Any]) -> Dict[str, Any]:
         salida["safe_to_retry"] = seguro
         try:
             idempotency.terminar_error(store, rid, op, payload, salida,
-                                       safe_to_retry=seguro)
+                                       safe_to_retry=seguro,
+                                       attempt_id=intento.attempt_id)
         except Exception as exc:                       # noqa: BLE001
             log.exception("No se pudo persistir el fallo de %s", op)
             salida.setdefault("warnings", []).append(

--- a/tests/test_all_tools_safety.py
+++ b/tests/test_all_tools_safety.py
@@ -238,7 +238,10 @@ def test_fallo_del_registro_idempotente_no_convierte_commit_en_error(
     from horizun_pbi_mcp.services import idempotency
 
     monkeypatch.setattr(idempotency, "store_por_defecto", lambda: object())
-    monkeypatch.setattr(idempotency, "comenzar", lambda *a, **k: None)
+    monkeypatch.setattr(
+        idempotency, "comenzar_intento",
+        lambda _s, rid, *a, **k: idempotency.Intento(request_id=rid,
+                                                     attempt_id="intento-1"))
     monkeypatch.setattr(
         idempotency, "terminar_ok",
         lambda *a, **k: (_ for _ in ()).throw(OSError("disco lleno")))

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -116,10 +116,19 @@ def test_en_vuelo_que_termina_durante_la_espera_devuelve_el_resultado(store, mon
 
     leer_real = store.leer
     primera_lectura = True   # todas salen del hilo principal: no hace falta lock
+    principal = threading.current_thread()
 
     def leer_coordinado(request_id):
-        """Convierte cada lectura del registro en una cita con el otro hilo."""
+        """Convierte cada lectura del registro en una cita con el otro hilo.
+
+        Solo las del hilo PRINCIPAL. `terminar_ok` tambien lee ahora —para
+        comprobar que sigue siendo el dueno de la reserva antes de escribir— y
+        si esa lectura entrara en la cita, el hilo que termina se quedaria
+        esperandose a si mismo.
+        """
         nonlocal primera_lectura
+        if threading.current_thread() is not principal:
+            return leer_real(request_id)
         if primera_lectura:
             primera_lectura = False
             registro = leer_real(request_id)
@@ -155,20 +164,37 @@ def test_en_vuelo_que_termina_durante_la_espera_devuelve_el_resultado(store, mon
     assert salida == {"ok": True, "n": 7, "idempotent_replay": True}
 
 
-def test_en_vuelo_abandonado_se_reclama(store, monkeypatch):
-    """Un proceso muerto no puede bloquear el request_id para siempre."""
-    idempotency.comenzar(store, "r1", "op", PAYLOAD)
-    reg = store.leer("r1")
-    reg.updated_at = time.time() - idempotency.STALE_IN_FLIGHT_SECONDS - 10
-    store.escribir(reg)
-    # `escribir` refresca updated_at: se fuerza en el archivo directamente.
-    f = store.root / "r1.json"
-    datos = json.loads(f.read_text(encoding="utf-8"))
-    datos["updated_at"] = time.time() - idempotency.STALE_IN_FLIGHT_SECONDS - 10
-    f.write_text(json.dumps(datos), encoding="utf-8")
+def test_en_vuelo_antiguo_no_se_reclama_solo(store):
+    """Antes se reclamaba, y eso era la carrera.
 
-    assert idempotency.comenzar(store, "r1", "op", PAYLOAD) is None, (
-        "un in_flight abandonado debe poder reclamarse")
+    Un `in_flight` con mas de `STALE_IN_FLIGHT_SECONDS` se daba por abandonado
+    y se AUTORIZABA otra ejecucion. "Antiguo" no prueba que el primero haya
+    muerto —`pbi_open_and_refresh` pasa de cinco minutos sin despeinarse— y
+    aunque hubiera muerto, nadie sabe si la escritura llego a aplicarse.
+
+    La regresion viva de esa carrera esta en
+    `tests/test_idempotency_intentos.py`; aqui se fija la regla.
+    """
+    idempotency.comenzar(store, "r1", "op", PAYLOAD)
+    envejecer(store, "r1", idempotency.STALE_IN_FLIGHT_SECONDS + 10)
+
+    with pytest.raises(idempotency.ResultadoDesconocidoError) as exc:
+        idempotency.comenzar(store, "r1", "op", PAYLOAD)
+    assert exc.value.code == "request_outcome_unknown"
+    assert exc.value.details["safe_to_retry"] is False
+    assert "recovery" in exc.value.details, "fallar cerrado sin salida es un muro"
+
+
+def envejecer(store, request_id, segundos):
+    """Retrasa `updated_at` en el archivo.
+
+    `escribir` lo refresca, asi que no vale pasar por el Store: hay que tocar
+    el JSON directamente.
+    """
+    f = store.root / f"{request_id}.json"
+    datos = json.loads(f.read_text(encoding="utf-8"))
+    datos["updated_at"] = time.time() - segundos
+    f.write_text(json.dumps(datos), encoding="utf-8")
 
 
 def test_fallo_dice_si_es_seguro_reintentar(store):

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -259,14 +259,22 @@ def test_request_id_malicioso_no_escribe_fuera(store):
 
 
 def test_caducados_se_purgan(store, monkeypatch):
+    """Caduca lo que ACABO bien. Lo incierto no prescribe.
+
+    Antes caducaba cualquier cosa por edad, `in_flight` incluido, y eso era
+    el reclaim inseguro por la puerta del calendario: pasadas 24h el mismo
+    request_id volvia a autorizarse. Lo que se puede purgar y lo que no tiene
+    su propio archivo: `tests/test_idempotency_veredicto_y_purgado.py`.
+    """
     idempotency.comenzar(store, "viejo", "op", PAYLOAD)
+    idempotency.terminar_ok(store, "viejo", "op", PAYLOAD, {"ok": True})
     f = store.root / "viejo.json"
     datos = json.loads(f.read_text(encoding="utf-8"))
     datos["created_at"] = time.time() - idempotency.TTL_SECONDS - 10
     f.write_text(json.dumps(datos), encoding="utf-8")
 
-    assert store.leer("viejo") is None, "un registro caducado no se reproduce"
     assert store.purgar() == 1
+    assert store.leer("viejo") is None, "ya no esta: se purgo"
 
 
 # ================================================ extremo a extremo por tool ==

--- a/tests/test_idempotency_intentos.py
+++ b/tests/test_idempotency_intentos.py
@@ -1,0 +1,307 @@
+"""Reclamar un `in_flight` por viejo era una carrera con la mutacion viva.
+
+El PR anterior cerro la carrera del alta —dos llamadas que no ven registro—
+pero dejo abierta la grave:
+
+1. `comenzar(..., request_id="r1")` autoriza y arranca la mutacion A;
+2. A tarda mas de `STALE_IN_FLIGHT_SECONDS` **y sigue viva**;
+3. una segunda llamada ve el registro "antiguo", lo reclama, y `comenzar()`
+   vuelve a autorizar: arranca la mutacion B;
+4. A termina y su `terminar_ok()` pisa el registro de B.
+
+Dos mutaciones con el mismo `request_id`. **Antiguo no prueba muerto**: un
+`pbi_open_and_refresh` sobre un modelo grande pasa de cinco minutos sin
+despeinarse. Y aunque el proceso hubiera muerto, nadie sabe si la escritura
+llego a aplicarse, asi que autorizar tampoco seria correcto.
+
+Dos barreras, y las dos se prueban aqui:
+
+- **no se autoriza** por antiguedad: `request_outcome_unknown`, cerrado, con
+  `safe_to_retry=False` y una salida explicita;
+- **el cierre es condicional**: un intento solo escribe su resultado si sigue
+  siendo el dueno de la reserva.
+
+Nada de esto depende del planificador ni de dormir a ver si sale: el tiempo se
+falsifica envejeciendo el registro, que es la unica variable que importaba.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from horizun_pbi_mcp.services import idempotency
+from horizun_pbi_mcp.services.idempotency import Store
+
+PAYLOAD = {"operation": "pbi_open_and_refresh", "arguments": {"pbip": "X.pbip"}}
+
+
+@pytest.fixture
+def store(tmp_path):
+    return Store(tmp_path / "_idem")
+
+
+def envejecer(store, request_id, segundos):
+    """Retrasa `updated_at` en el archivo: `escribir` lo refrescaria."""
+    f = store.root / f"{request_id}.json"
+    datos = json.loads(f.read_text(encoding="utf-8"))
+    datos["updated_at"] = time.time() - segundos
+    f.write_text(json.dumps(datos, ensure_ascii=False), encoding="utf-8")
+
+
+def matar_al_dueno(store, request_id):
+    """Deja el registro apuntando a un proceso que no existe."""
+    f = store.root / f"{request_id}.json"
+    datos = json.loads(f.read_text(encoding="utf-8"))
+    datos["owner_pid"] = 2 ** 22          # fuera del rango de pid de Windows
+    datos["owner_started"] = None
+    f.write_text(json.dumps(datos, ensure_ascii=False), encoding="utf-8")
+
+
+# ================================================= la carrera, entera =========
+def test_nunca_se_autorizan_dos_mutaciones(store):
+    """El escenario reportado, paso por paso, con A todavia viva.
+
+    A se autoriza; el registro envejece por encima del umbral; B lo intenta;
+    A termina despues. En ningun momento puede haber dos autorizaciones.
+    """
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert a.hay_que_ejecutar, "el primero si se autoriza"
+
+    envejecer(store, "r1", idempotency.STALE_IN_FLIGHT_SECONDS + 60)
+
+    with pytest.raises(idempotency.ResultadoDesconocidoError) as exc:
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+    assert exc.value.details["safe_to_retry"] is False
+    assert exc.value.details["owner_alive"] is True, (
+        "A sigue viva: el diagnostico tiene que decirlo")
+
+    # Y A, que era la unica autorizada, cierra sin problema.
+    idempotency.terminar_ok(store, "r1", "op", PAYLOAD, {"ok": True, "n": 1},
+                            attempt_id=a.attempt_id)
+    assert idempotency.estado(store, "r1")["state"] == idempotency.SUCCEEDED
+
+
+def test_una_operacion_legitima_de_mas_de_300s_no_se_pisa(store):
+    """`pbi_open_and_refresh` pasa del umbral y esta perfectamente viva.
+
+    Es el caso que convertia el umbral en un generador de duplicados: la
+    operacion mas lenta del servidor es justo la que mas facil lo cruza.
+    """
+    a = idempotency.comenzar_intento(store, "r1", "pbi_open_and_refresh", PAYLOAD)
+    envejecer(store, "r1", 600)                    # diez minutos refrescando
+
+    with pytest.raises(idempotency.ResultadoDesconocidoError):
+        idempotency.comenzar_intento(store, "r1", "pbi_open_and_refresh", PAYLOAD)
+
+    # La operacion larga termina y su resultado se guarda tal cual.
+    idempotency.terminar_ok(store, "r1", "pbi_open_and_refresh", PAYLOAD,
+                            {"ok": True, "rows": 900_000},
+                            attempt_id=a.attempt_id)
+    guardado = idempotency.estado(store, "r1")
+    assert guardado["state"] == idempotency.SUCCEEDED
+    assert guardado["result"]["rows"] == 900_000
+
+    # Y el reintento posterior reproduce, no vuelve a mutar.
+    repetido = idempotency.comenzar_intento(store, "r1", "pbi_open_and_refresh",
+                                            PAYLOAD)
+    assert repetido.replay["idempotent_replay"] is True
+    assert not repetido.hay_que_ejecutar
+
+
+def test_el_dueno_muerto_tampoco_autoriza_solo(store):
+    """Que A haya muerto no dice si el cambio se aplico.
+
+    Se distingue del caso anterior en el DIAGNOSTICO, no en el permiso: los
+    dos fallan cerrado.
+    """
+    idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    envejecer(store, "r1", idempotency.STALE_IN_FLIGHT_SECONDS + 60)
+    matar_al_dueno(store, "r1")
+
+    with pytest.raises(idempotency.ResultadoDesconocidoError) as exc:
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert exc.value.details["owner_alive"] is False
+    assert exc.value.details["safe_to_retry"] is False
+    assert "YA NO EXISTE" in str(exc.value)
+    assert "no dice si el cambio llego a aplicarse" in str(exc.value), (
+        "el diagnostico no puede leerse como un permiso")
+
+
+# ============================================ el cierre es condicional ========
+def test_un_intento_caducado_no_pisa_el_registro_del_nuevo(store):
+    """El paso 4 del escenario: A termina tarde, despues de que B empezara.
+
+    Aunque alguien reabra la peticion —a mano, con la recuperacion
+    explicita—, el resultado de A ya no puede escribirse encima.
+    """
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    envejecer(store, "r1", idempotency.STALE_IN_FLIGHT_SECONDS + 60)
+
+    idempotency.descartar_en_vuelo(store, "r1", motivo="comprobado a mano")
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert b.hay_que_ejecutar and b.attempt_id != a.attempt_id
+
+    with pytest.raises(idempotency.IntentoCaducadoError) as exc:
+        idempotency.terminar_ok(store, "r1", "op", PAYLOAD,
+                                {"ok": True, "de": "A"}, attempt_id=a.attempt_id)
+    assert exc.value.code == "idempotency_attempt_superseded"
+
+    guardado = idempotency.estado(store, "r1")
+    assert guardado["state"] == idempotency.IN_FLIGHT, (
+        "el registro sigue siendo el de B, que es quien esta ejecutando")
+    assert guardado["attempt_id"] == b.attempt_id
+
+    # Y B si puede cerrar.
+    idempotency.terminar_ok(store, "r1", "op", PAYLOAD, {"ok": True, "de": "B"},
+                            attempt_id=b.attempt_id)
+    assert idempotency.estado(store, "r1")["result"]["de"] == "B"
+
+
+def test_un_intento_caducado_tampoco_escribe_el_fallo(store):
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    envejecer(store, "r1", idempotency.STALE_IN_FLIGHT_SECONDS + 60)
+    idempotency.descartar_en_vuelo(store, "r1")
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+    with pytest.raises(idempotency.IntentoCaducadoError):
+        idempotency.terminar_error(store, "r1", "op", PAYLOAD, {"ok": False},
+                                   safe_to_retry=True, attempt_id=a.attempt_id)
+    assert idempotency.estado(store, "r1")["attempt_id"] == b.attempt_id
+
+
+def test_el_attempt_id_no_se_reutiliza_nunca(store):
+    vistos = set()
+    for _ in range(5):
+        it = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+        assert it.attempt_id not in vistos, "un attempt_id no puede repetirse"
+        vistos.add(it.attempt_id)
+        idempotency.terminar_error(store, "r1", "op", PAYLOAD, {"ok": False},
+                                   safe_to_retry=True, attempt_id=it.attempt_id)
+
+
+# ============================================ recuperacion explicita ==========
+def test_descartar_es_lo_unico_que_reabre(store):
+    idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    envejecer(store, "r1", idempotency.STALE_IN_FLIGHT_SECONDS + 60)
+
+    r = idempotency.descartar_en_vuelo(store, "r1", motivo="el cambio no estaba")
+    assert r["discarded"] is True and r["state"] == idempotency.FAILED
+    est = idempotency.estado(store, "r1")
+    assert est["safe_to_retry"] is False, (
+        "se reabre, pero sin mentir sobre si era seguro")
+
+    assert idempotency.comenzar_intento(store, "r1", "op", PAYLOAD).hay_que_ejecutar
+
+
+def test_descartar_no_toca_lo_que_ya_termino(store):
+    """No es un borrador de registros: solo saca de `in_flight`."""
+    it = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_ok(store, "r1", "op", PAYLOAD, {"ok": True},
+                            attempt_id=it.attempt_id)
+
+    r = idempotency.descartar_en_vuelo(store, "r1")
+    assert r["discarded"] is False
+    assert idempotency.estado(store, "r1")["state"] == idempotency.SUCCEEDED
+
+
+def test_descartar_lo_que_no_existe_no_inventa_nada(store):
+    assert idempotency.descartar_en_vuelo(store, "nada")["discarded"] is False
+
+
+# ============================================ compatibilidad de registros =====
+def test_un_registro_de_una_version_anterior_se_sigue_leyendo(store):
+    """Sin `attempt_id` ni dueno: no puede romper una instalacion ya en uso."""
+    store.root.mkdir(parents=True, exist_ok=True)
+    (store.root / "viejo.json").write_text(json.dumps({
+        "request_id": "viejo", "operation": "op",
+        "payload_fingerprint": idempotency.plan_contract.fingerprint_de(PAYLOAD),
+        "state": idempotency.SUCCEEDED, "created_at": time.time(),
+        "updated_at": time.time(), "result": {"ok": True, "v": 1},
+    }), encoding="utf-8")
+
+    it = idempotency.comenzar_intento(store, "viejo", "op", PAYLOAD)
+    assert it.replay == {"ok": True, "v": 1, "idempotent_replay": True}
+
+
+def test_cerrar_sin_attempt_id_sigue_funcionando(store):
+    """La firma vieja se conserva: hay llamadas que no pasan el intento."""
+    idempotency.comenzar(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_ok(store, "r1", "op", PAYLOAD, {"ok": True})
+    assert idempotency.estado(store, "r1")["state"] == idempotency.SUCCEEDED
+
+
+# ============================================ el registro parcial =============
+def test_un_corte_al_reservar_no_deja_un_registro_a_medias(store, monkeypatch):
+    """`reservar` escribia directo sobre el descriptor del destino.
+
+    Un corte a mitad dejaba JSON truncado en el archivo bueno. Ahora son dos
+    pasos: el `O_EXCL` reclama el hueco y el contenido va por `durable_write`
+    (tmp + fsync + replace), asi que el destino pasa de vacio a completo sin
+    estados intermedios. Se provoca el corte justo en el commit.
+    """
+    import os as _os
+
+    def replace_que_revienta(*_a, **_k):
+        raise OSError("proceso interrumpido en el commit")
+
+    monkeypatch.setattr(_os, "replace", replace_que_revienta)
+    with pytest.raises(OSError):
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    monkeypatch.undo()
+
+    f = store.root / "r1.json"
+    assert f.exists(), "el hueco quedo reclamado, que es lo que impide dos altas"
+    assert f.read_bytes() == b"", (
+        "el destino no puede quedar con JSON a medias: o vacio o completo")
+    assert not list(store.root.glob("*.tmp")), "no puede quedar un temporal"
+
+    # Y ese registro incompleto BLOQUEA, que es lo correcto: si se murio
+    # reservando, nadie sabe si la mutacion llego a empezar.
+    with pytest.raises(idempotency.RegistroCorruptoError):
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+
+def test_la_reserva_deja_el_registro_completo(store):
+    idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    datos = json.loads((store.root / "r1.json").read_text(encoding="utf-8"))
+    assert datos["attempt_id"] and datos["state"] == idempotency.IN_FLIGHT
+    assert datos["owner_pid"] == __import__("os").getpid()
+    assert not list(store.root.glob("*.tmp")), "no puede quedar un temporal"
+
+
+# ============================================ ilegible != inexistente =========
+def test_un_registro_que_no_se_puede_leer_no_es_uno_que_no_existe(store,
+                                                                  monkeypatch):
+    """Un fallo de disco no puede convertirse en permiso para mutar."""
+    idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+    real = type(store.root).read_text
+
+    def read_text_que_falla(self, *a, **k):
+        if self.name == "r1.json":
+            raise OSError("disco ocupado")
+        return real(self, *a, **k)
+
+    monkeypatch.setattr(type(store.root), "read_text", read_text_que_falla)
+    with pytest.raises(idempotency.RegistroIlegibleError) as exc:
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert exc.value.code == "idempotency_record_unreadable"
+
+
+def test_tampoco_se_pisa_a_ciegas_lo_que_no_se_pudo_leer(store, monkeypatch):
+    idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    real = type(store.root).read_text
+
+    def read_text_que_falla(self, *a, **k):
+        if self.name == "r1.json":
+            raise OSError("disco ocupado")
+        return real(self, *a, **k)
+
+    monkeypatch.setattr(type(store.root), "read_text", read_text_que_falla)
+    with pytest.raises(idempotency.RegistroIlegibleError):
+        store.escribir(idempotency.Registro(
+            request_id="r1", operation="op", payload_fingerprint="fp",
+            state=idempotency.SUCCEEDED))

--- a/tests/test_idempotency_intentos.py
+++ b/tests/test_idempotency_intentos.py
@@ -190,8 +190,12 @@ def test_descartar_es_lo_unico_que_reabre(store):
     r = idempotency.descartar_en_vuelo(store, "r1", motivo="el cambio no estaba")
     assert r["discarded"] is True and r["state"] == idempotency.FAILED
     est = idempotency.estado(store, "r1")
-    assert est["safe_to_retry"] is False, (
-        "se reabre, pero sin mentir sobre si era seguro")
+    assert est["safe_to_retry"] is True, (
+        "descartar ES la afirmacion humana de que el cambio no se aplico, y "
+        "por tanto de que reintentar es seguro; ahora que el veredicto "
+        "gobierna la autorizacion, tiene que decir lo que se comprobo")
+    assert est["error"]["reviewed_by_human"] is True, (
+        "y hay que poder distinguirlo de un fallo que se declaro seguro solo")
 
     assert idempotency.comenzar_intento(store, "r1", "op", PAYLOAD).hay_que_ejecutar
 

--- a/tests/test_idempotency_veredicto_y_purgado.py
+++ b/tests/test_idempotency_veredicto_y_purgado.py
@@ -1,0 +1,350 @@
+"""El veredicto de reintento manda, y la duda no prescribe.
+
+Dos bloqueos encontrados revisando el PR anterior, con la misma forma que
+todo lo demas de esta pieza: una via lateral por la que un `request_id` con
+resultado incierto volvia a autorizarse.
+
+1. **`safe_to_retry=False` se ignoraba.** `_decidir()` reabria cualquier
+   `failed` sin consultar el veredicto: un `bulk_partially_applied` cerrado
+   con `safe_to_retry=False` se ejecutaba OTRA VEZ con el mismo request_id.
+   Guardar el veredicto y no consultarlo es no tenerlo.
+
+2. **El TTL borraba estados inciertos.** `leer()` ocultaba cualquier registro
+   de mas de 24h y `purgar()` lo eliminaba, incluidos `in_flight` y fallos
+   inseguros. "Caducado" se convertia en "no existe", y el siguiente
+   `comenzar()` autorizaba: el reclaim inseguro, otra vez, por la puerta del
+   calendario.
+
+El contrato que fijan estas pruebas:
+
+- `succeeded`  -> reproducir;
+- `compensated` -> intento nuevo (el cambio se deshizo entero);
+- `failed` + `safe_to_retry=True`  -> intento nuevo;
+- `failed` + `safe_to_retry=False` -> reproducir el error guardado, SIN
+  ejecutar, con `safe_to_retry=False` en la raiz;
+- `failed` sin veredicto (registros de versiones anteriores) -> cerrado,
+  `request_outcome_unknown`;
+- `in_flight` no caduca; los fallos no seguros tampoco; solo lo terminal
+  inequivocamente seguro se purga, y decidiendolo bajo el cerrojo del
+  request_id, no sobre una lectura vieja.
+
+Todas las pruebas provocan las transiciones reales y cuentan ejecuciones.
+Ninguna hace grep del codigo fuente.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import time
+
+import pytest
+
+from horizun_pbi_mcp.services import idempotency, plan_contract
+from horizun_pbi_mcp.services.idempotency import Store
+
+PAYLOAD = {"operation": "pbi_apply_page_spec", "arguments": {"spec": {"n": 1}}}
+
+#: Margen para la cita entre hilos: agotarlo significa coordinacion rota,
+#: nunca maquina lenta.
+TIMEOUT = 30.0
+
+
+@pytest.fixture
+def store(tmp_path):
+    return Store(tmp_path / "_idem")
+
+
+def envejecer(store, request_id, *, updated=None, created=None):
+    """Retrasa los relojes del registro en el archivo, sin pasar por el Store."""
+    f = store.root / f"{request_id}.json"
+    datos = json.loads(f.read_text(encoding="utf-8"))
+    if updated is not None:
+        datos["updated_at"] = time.time() - updated
+    if created is not None:
+        datos["created_at"] = time.time() - created
+    f.write_text(json.dumps(datos, ensure_ascii=False), encoding="utf-8")
+
+
+def registro_a_mano(store, request_id, **campos):
+    """Un registro escrito tal cual, como lo dejaria una version anterior."""
+    store.root.mkdir(parents=True, exist_ok=True)
+    base = {"request_id": request_id, "operation": "op",
+            "payload_fingerprint": plan_contract.fingerprint_de(PAYLOAD),
+            "state": idempotency.FAILED, "created_at": time.time(),
+            "updated_at": time.time(), "result": None, "error": None,
+            "safe_to_retry": None}
+    base.update(campos)
+    (store.root / f"{request_id}.json").write_text(
+        json.dumps(base, ensure_ascii=False), encoding="utf-8")
+
+
+# ================================================== bloqueo 1: el veredicto ==
+def test_fallo_inseguro_no_vuelve_a_ejecutar(store):
+    """El escenario exacto: bulk parcialmente aplicado, cerrado como NO
+    seguro, y el mismo request_id vuelve a llegar."""
+    ejecuciones = 0
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert a.hay_que_ejecutar
+    ejecuciones += 1
+    idempotency.terminar_error(
+        store, "r1", "op", PAYLOAD,
+        {"ok": False, "error": "bulk_partially_applied",
+         "message": "3 de 7 archivos escritos"},
+        safe_to_retry=False, attempt_id=a.attempt_id)
+
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    if b.hay_que_ejecutar:                                # pragma: no cover
+        ejecuciones += 1
+    assert ejecuciones == 1, (
+        "un fallo declarado NO seguro no puede autorizar otra mutacion: "
+        "medio bulk aplicado dos veces es el desastre que esto impide")
+
+    assert b.replay["idempotent_replay"] is True
+    assert b.replay["safe_to_retry"] is False
+    assert b.replay["error"] == "bulk_partially_applied", (
+        "se reproduce EL error que paso, no uno generico")
+    # Y el registro no se toco: sigue contando el fallo original.
+    est = idempotency.estado(store, "r1")
+    assert est["state"] == idempotency.FAILED
+    assert est["safe_to_retry"] is False
+
+
+def test_fallo_sin_veredicto_falla_cerrado(store):
+    """`safe_to_retry=None` no es permiso: es un registro que no dijo nada.
+
+    Lo dejan las versiones anteriores y los cierres incompletos. Decidir
+    "si se puede" por quien no dijo nada seria inventarse el veredicto.
+    """
+    registro_a_mano(store, "legacy", state=idempotency.FAILED,
+                    safe_to_retry=None,
+                    error={"ok": False, "error": "algo_fallo"})
+
+    with pytest.raises(idempotency.ResultadoDesconocidoError) as exc:
+        idempotency.comenzar_intento(store, "legacy", "op", PAYLOAD)
+    assert exc.value.code == "request_outcome_unknown"
+    assert exc.value.details["safe_to_retry"] is False
+    assert "recovery" in exc.value.details
+
+
+def test_fallo_inseguro_sin_error_guardado_tambien_falla_cerrado(store):
+    """No hay nada que reproducir: cerrado, no autorizado."""
+    registro_a_mano(store, "r1", state=idempotency.FAILED,
+                    safe_to_retry=False, error=None)
+
+    with pytest.raises(idempotency.ResultadoDesconocidoError):
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+
+def test_fallo_seguro_si_permite_intento_nuevo(store):
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_error(store, "r1", "op", PAYLOAD,
+                               {"ok": False, "error": "validation_error"},
+                               safe_to_retry=True, attempt_id=a.attempt_id)
+
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert b.hay_que_ejecutar, "True es un veredicto: quien cerro lo afirmo"
+    assert b.attempt_id != a.attempt_id
+
+
+def test_compensado_si_permite_intento_nuevo(store):
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_error(store, "r1", "op", PAYLOAD,
+                               {"ok": False, "error": "bulk_apply_failed"},
+                               safe_to_retry=False, compensado=True,
+                               attempt_id=a.attempt_id)
+
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert b.hay_que_ejecutar, (
+        "compensated significa que el cambio se deshizo ENTERO: es el unico "
+        "fallo cuyo reintento es seguro por construccion")
+
+
+def test_descartar_autoriza_exactamente_un_intento_nuevo(store, monkeypatch):
+    """La recuperacion explicita tiene que ser coherente con la autorizacion.
+
+    Quien descarta afirma que miro el proyecto y el cambio NO se aplico. Esa
+    afirmacion es exactamente lo que hace seguro reintentar: guardar
+    `safe_to_retry=False` y luego reabrir ignorandolo seria incoherente por
+    los dos lados a la vez.
+    """
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    envejecer(store, "r1", updated=idempotency.STALE_IN_FLIGHT_SECONDS + 60)
+    with pytest.raises(idempotency.ResultadoDesconocidoError):
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+    r = idempotency.descartar_en_vuelo(
+        store, "r1", motivo="comprobado: el cambio no esta en el proyecto")
+    assert r["discarded"] is True
+
+    est = idempotency.estado(store, "r1")
+    assert est["safe_to_retry"] is True, (
+        "el descarte ES la afirmacion humana de que reintentar es seguro; "
+        "guardar False y reabrir igualmente seria mentir dos veces")
+
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert b.hay_que_ejecutar
+    assert b.attempt_id != a.attempt_id, "identidad nueva, no la del muerto"
+
+    # Exactamente UNO: el siguiente se encuentra el vuelo del nuevo intento.
+    monkeypatch.setattr(idempotency, "WAIT_SECONDS", 0.15)
+    with pytest.raises(idempotency.RequestInProgressError):
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+
+# ============================================== bloqueo 2: el TTL y el purgado ==
+def test_un_in_flight_mas_viejo_que_el_ttl_ni_se_oculta_ni_se_purga(store):
+    """Ocultarlo por edad convertia "caducado" en "no existe": reclaim."""
+    idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    envejecer(store, "r1", updated=idempotency.TTL_SECONDS + 3600,
+              created=idempotency.TTL_SECONDS + 3600)
+
+    est = idempotency.estado(store, "r1")
+    assert est is not None, "un in_flight viejo NO es un in_flight inexistente"
+    assert est["state"] == idempotency.IN_FLIGHT
+
+    assert store.purgar() == 0, "la duda no prescribe"
+    assert (store.root / "r1.json").exists()
+
+    # Y la peticion sigue cerrada, no reabierta por vieja.
+    with pytest.raises(idempotency.ResultadoDesconocidoError):
+        idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+
+
+def test_un_fallo_inseguro_mas_viejo_que_el_ttl_no_se_purga(store):
+    """Borrar la evidencia de un fallo inseguro es autorizar su repeticion."""
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_error(
+        store, "r1", "op", PAYLOAD,
+        {"ok": False, "error": "bulk_partially_applied"},
+        safe_to_retry=False, attempt_id=a.attempt_id)
+    envejecer(store, "r1", created=idempotency.TTL_SECONDS + 3600)
+
+    assert store.purgar() == 0
+    assert (store.root / "r1.json").exists()
+
+    # El registro sigue mandando: reproduce, no ejecuta.
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert not b.hay_que_ejecutar
+    assert b.replay["error"] == "bulk_partially_applied"
+
+
+def test_un_fallo_sin_veredicto_viejo_tampoco_se_purga(store):
+    registro_a_mano(store, "legacy", state=idempotency.FAILED,
+                    safe_to_retry=None,
+                    created_at=time.time() - idempotency.TTL_SECONDS - 3600)
+    assert store.purgar() == 0
+    assert (store.root / "legacy.json").exists()
+
+
+def test_lo_terminal_inequivocamente_seguro_si_se_purga(store):
+    """El guard no puede convertir el purgado en un no-op: succeeded,
+    compensated y failed-seguro caducados si se van."""
+    for rid, extra in (
+            ("ok", {"state": idempotency.SUCCEEDED, "result": {"ok": True}}),
+            ("comp", {"state": idempotency.COMPENSATED, "safe_to_retry": True}),
+            ("fs", {"state": idempotency.FAILED, "safe_to_retry": True})):
+        registro_a_mano(store, rid,
+                        created_at=time.time() - idempotency.TTL_SECONDS - 3600,
+                        **extra)
+
+    assert store.purgar() == 3
+    assert not list(store.root.glob("*.json"))
+    # Y tras el purgado, ese request_id vuelve a estar disponible.
+    assert idempotency.comenzar_intento(store, "ok", "op",
+                                        PAYLOAD).hay_que_ejecutar
+
+
+def test_el_purgado_no_borra_un_intento_reabierto(store, monkeypatch):
+    """La decision de borrar se toma bajo el cerrojo, no sobre lo ya leido.
+
+    Se para al purgado JUSTO antes de tomar la exclusion del request_id, se
+    reabre la peticion desde el hilo principal, y se le deja seguir: tiene
+    que releer y no borrar el intento vivo.
+    """
+    it = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_error(store, "r1", "op", PAYLOAD,
+                               {"ok": False, "error": "x"},
+                               safe_to_retry=True, attempt_id=it.attempt_id)
+    envejecer(store, "r1", created=idempotency.TTL_SECONDS + 3600)
+
+    real = idempotency._exclusion
+    purgado_en_la_puerta = threading.Event()
+    puede_seguir = threading.Event()
+    hilo_purga = []
+
+    @contextlib.contextmanager
+    def exclusion_con_cita(s, rid):
+        if threading.current_thread() in hilo_purga:
+            purgado_en_la_puerta.set()
+            assert puede_seguir.wait(TIMEOUT)
+        with real(s, rid):
+            yield
+
+    monkeypatch.setattr(idempotency, "_exclusion", exclusion_con_cita)
+    borrados = []
+    t = threading.Thread(target=lambda: borrados.append(store.purgar()))
+    hilo_purga.append(t)
+    t.start()
+    try:
+        assert purgado_en_la_puerta.wait(TIMEOUT), (
+            "el purgado no paso por la exclusion del request_id: decide "
+            "sobre una lectura que nadie protege")
+        # Con el purgado parado en la puerta, la peticion se reabre.
+        b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+        assert b.hay_que_ejecutar
+    finally:
+        puede_seguir.set()
+        t.join(TIMEOUT)
+
+    assert borrados == [0], "borro un intento que acababa de reabrirse"
+    est = idempotency.estado(store, "r1")
+    assert est is not None and est["state"] == idempotency.IN_FLIGHT
+    assert est["attempt_id"] == b.attempt_id
+    # Y ese intento sigue siendo dueno: puede cerrar.
+    idempotency.terminar_ok(store, "r1", "op", PAYLOAD, {"ok": True},
+                            attempt_id=b.attempt_id)
+
+
+# =========================================== el veredicto llega al sobre raiz ==
+def test_el_replay_inseguro_lleva_el_veredicto_en_la_raiz(store):
+    """Aunque el error guardado no trajera la clave, la raiz la lleva."""
+    a = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    idempotency.terminar_error(store, "r1", "op", PAYLOAD,
+                               {"ok": False, "error": "media_escritura"},
+                               safe_to_retry=False, attempt_id=a.attempt_id)
+
+    b = idempotency.comenzar_intento(store, "r1", "op", PAYLOAD)
+    assert b.replay["safe_to_retry"] is False, (
+        "sin la clave en la raiz, un cliente decide reintentar a ciegas")
+
+
+def test_el_resultado_incierto_llega_al_sobre_de_la_tool(store, monkeypatch,
+                                                         tmp_path):
+    """Por el camino real de `guard_mutation`, no por el servicio a pelo."""
+    from horizun_pbi_mcp.tools import _common
+
+    monkeypatch.setattr(idempotency, "store_por_defecto", lambda: store)
+    ejecutadas = []
+
+    def pbi_mutacion(request_id="rid-x"):
+        return _common.guard_mutation(
+            lambda: ejecutadas.append(True) or {"applied": 1})
+
+    primera = pbi_mutacion()
+    assert primera["ok"] is True and ejecutadas == [True]
+
+    # El registro queda en vuelo y viejo: como si el proceso anterior
+    # hubiera desaparecido a mitad.
+    f = store.root / "rid-x.json"
+    datos = json.loads(f.read_text(encoding="utf-8"))
+    datos["state"] = idempotency.IN_FLIGHT
+    datos["updated_at"] = time.time() - idempotency.STALE_IN_FLIGHT_SECONDS - 60
+    f.write_text(json.dumps(datos, ensure_ascii=False), encoding="utf-8")
+
+    salida = pbi_mutacion()
+    assert ejecutadas == [True], "la mutacion no puede repetirse"
+    assert salida["ok"] is False
+    assert salida["error"] == "request_outcome_unknown"
+    assert salida["safe_to_retry"] is False, (
+        "en la RAIZ del sobre: details no lo lee ningun cliente automatico")


### PR DESCRIPTION
[PR #17](https://github.com/HorizunGroup/horizun-pbi-mcp/pull/17) cerró la carrera del alta y dejó abierta la grave, que estaba en el otro extremo del protocolo. Reproducción confirmada:

1. `comenzar()` autoriza y arranca la mutación **A**;
2. A tarda más de `STALE_IN_FLIGHT_SECONDS` y **sigue viva**;
3. una segunda llamada ve el registro "antiguo", lo reclama, y `comenzar()` vuelve a autorizar: arranca **B**;
4. A termina y su `terminar_ok()` pisa el registro de B.

Dos mutaciones con el mismo `request_id` — exactamente lo que esta pieza existe para impedir. **El umbral no medía lo que decía medir**: "antiguo" no prueba "muerto", y la operación más lenta del servidor (`pbi_open_and_refresh` sobre un modelo grande) es justo la que más fácil lo cruza. Y aunque el proceso hubiera muerto, nadie sabe si la escritura llegó a aplicarse, así que autorizar tampoco sería correcto en ese caso.

## Se quita el reclaim automático

Un `in_flight` por encima del umbral ya no autoriza nada: falla cerrado con `request_outcome_unknown` y `safe_to_retry=False` — que además sale **en el sobre** y no sólo en `details`, para que un cliente no lo reintente en bucle.

El error mira si el proceso dueño sigue vivo (pid **+ instante de arranque**, que los pid se reciclan) y lo dice. Es **diagnóstico, no permiso**: los dos casos fallan igual de cerrado, pero quien lee sabe si está esperando a algo que trabaja o mirando un cadáver. "No existe el proceso" y "no se pudo comprobar" se distinguen; mezclarlos deja sin la única pista útil.

La salida es explícita: `descartar_en_vuelo()`, que se llama **después** de haber mirado el proyecto. Queda como `failed` con `safe_to_retry=False` —se reabre sin mentir sobre si era seguro— y con identidad nueva.

## Identidad de intento

Cada autorización acuña un `attempt_id` irrepetible y anota el dueño. Cerrar es un **compare-and-set bajo la misma exclusión** que la reserva: si el registro ya pertenece a otro intento, el resultado no se escribe (`idempotency_attempt_superseded`). Un intento antiguo que despierta tarde no puede completar ni borrar el rastro de uno nuevo.

`comenzar_intento()` lo devuelve; `comenzar()` se conserva con su firma y su forma de siempre. Los tres campos nuevos del registro son opcionales: un registro escrito por una versión anterior se sigue leyendo.

## Los dos apuntes de la revisión

- **`reservar()` escribía directo sobre el descriptor del destino** y un corte a mitad dejaba JSON truncado. Ahora son dos pasos: `O_EXCL` reclama el hueco y `durable_write` pone el contenido. Un corte entre ambos deja el archivo vacío, que bloquea — correcto: si se murió reservando, nadie sabe si la mutación empezó.
- **Un `OSError` al leer se trataba como ausencia**, o sea que un fallo de disco se convertía en permiso para mutar. Ahora `idempotency_record_unreadable`, y tampoco se pisa a ciegas al escribir.

## Verificación

Cinco mutaciones, cada una acusada por un test que la nombra:

| mutación | la acusa |
|---|---|
| devolver el reclaim por antigüedad | `test_nunca_se_autorizan_dos_mutaciones`, `test_una_operacion_legitima_de_mas_de_300s_no_se_pisa`, +2 |
| quitar el compare-and-set | `test_un_intento_caducado_no_pisa_el_registro_del_nuevo`, +1 |
| reserva sin `durable_write` | `test_un_corte_al_reservar_no_deja_un_registro_a_medias` |
| `OSError` como ausencia | `test_un_registro_que_no_se_puede_leer_no_es_uno_que_no_existe` |
| "no existe" como "no se sabe" | `test_el_dueno_muerto_tampoco_autoriza_solo` |

La primera versión del test del registro parcial hacía grep del código fuente y **no acusaba nada**; se reescribió provocando el corte en el commit. `test_en_vuelo_abandonado_se_reclama` codificaba el defecto: se sustituye por `test_en_vuelo_antiguo_no_se_reclama_solo`.

**Contrato intacto**: 128 tools, `El contrato MCP no cambio.` — 1991 tests en verde, 3 saltados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)