### PR TITLE
Exportar el contenido del tablero sin inventarle filas ni filtros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,25 @@ Semantic versioning. **The contract of the original 34 tools is never broken.**
 
 ---
 
-## [1.4.0] — 2026-08-05
+## [1.4.0] — 2026-08-06
 
-Four additive tools (132 total), zero breaking changes.
+Five additive tools (133 total), zero breaking changes.
 
 ### Added
+
+- **`pbi_export_report_content`** — exports the report CONTENT, not its
+  metadata: the table behind each visual, or a query the client declares
+  (`rows`/`values`/`filters`/`top_n`). Selection by `pages`, `visuals` or
+  `queries`, output to `.xlsx`/`.pdf` under `outputs/content/`.
+  Each visual's query is reconstructed from its fields and its PBIR filters,
+  and every sheet declares which filters were applied and — the part that
+  matters — which could not be. Visuals with no tabular query (text boxes,
+  images, shapes) are listed with the reason instead of exported empty.
+  Needs the live model, so it opens Desktop when there is none, and it
+  **refuses to export a model that is open but unprocessed**: a freshly
+  opened `.pbip` answers every query with zero rows and would produce a blank
+  workbook without a single error. `dry_run` returns the DAX without touching
+  the engine.
 
 - **`pbi_export_excel`** — verified `.xlsx` with summary, model metadata,
   relationships, report pages/visuals, audit findings and optional read-only
@@ -23,6 +37,56 @@ Four additive tools (132 total), zero breaking changes.
 - **`pbi_sharepoint_download_folder`** — filtered, staged, all-or-nothing
   download to `outputs/sharepoint/`, with byte limits, SHA-256 and post-write
   verification.
+
+### Added
+
+- **Two audit rules for visuals Power BI refuses to draw.** A visual in error
+  shows a banner instead of content, and nothing catches it: the PBIR schema
+  accepts the JSON, the official CLI passes, and the synthesized DAX even
+  returns rows — because the fault is in the *field configuration*, not the
+  query. Both were found by looking at a real report, and both now fail the
+  audit as `error`:
+  - `report_scatter_axis_not_aggregated` — a scatter with a field in Details
+    and non-aggregated X/Y renders nothing ("remove the values to show X and
+    Y pairs").
+  - `report_slicer_below_height_floor` — a slicer below its height floor is
+    clipped in dropdown mode and shows a single scrollbarred item in list
+    mode. The floor depends on the header: **76px** with it (header 28 +
+    selector 32 + padding 8/8) and **48px** without (selector 32 + padding
+    8/8). Both numbers are measured against the official CLI, not derived:
+    feeding it the same report at varying heights, 74 fails and 76 passes
+    with a header, 47 fails and 48 passes without one. A first version used
+    76 unconditionally and reported nine healthy slicers — the ones that hide
+    their header — as broken.
+
+### Fixed
+
+- **A visual with columns from two tables exported a cartesian product.**
+  `SUMMARIZECOLUMNS` only applies auto-exists within one table: grouping by
+  columns of two related tables with no measure crosses them. Measured
+  against the engine — 20 risks by 20 mitigation measures returned 400 rows
+  where the visual shows 20. The query now carries an auxiliary
+  `CALCULATE(COUNTROWS(<fact table>))`, resolved from the model's
+  relationships, and that column is stripped before the file is written. When
+  no single fact table covers every column, the visual is declared
+  non-exportable rather than exported wrong.
+- **`reuse_open` never reused a `.pbip` session.** Detection relied on the
+  open file descriptors, and Desktop keeps none on a `.pbip` project folder
+  (verified with `open_files()`: zero files). Every `pbi_open_in_desktop` on a
+  project therefore launched ANOTHER window of the same report, and
+  `reuse_open=false` could not fail closed either. It now falls back to
+  matching the main window title, reusing only when exactly one window
+  matches.
+- **`pbi_generate_pdf_report` named no object in its audit table.** Every
+  finding carries `object` — the measure, column, visual or page it is about —
+  and the PDF dropped it, printing seven identical `measure_possibly_unused`
+  rows. It now has an `Objeto` column resolving page ids to their visible name.
+  The Excel export already carried the column.
+- **The same table printed raw JSON.** No audit engine emits `message`, so the
+  `message or summary or evidence` fallback always landed on the evidence dict
+  and rendered `{"visual_count": 13, "threshold": 12}` in a document a person
+  reads. Evidence is now flattened to `visual_count: 13; threshold: 12`. Found
+  by rendering the PDF and looking at it; the existing tests only counted pages.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **MCP** (Model Context Protocol) server for working with **local Power BI Desktop** and **`.pbip`** projects from Claude Code.
 
-**v1.4.0** — 132 tools. Covers two complementary Power BI layers plus verified document exports and read-only SharePoint ingestion:
+**v1.4.0** — 133 tools. Covers two complementary Power BI layers plus verified document exports, report **content** export and read-only SharePoint ingestion:
 
 | Layer | For what | How |
 |---|---|---|
@@ -22,7 +22,7 @@
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Current architecture, structural debt and invariants |
 | [`docs/CAPABILITY_MATRIX.md`](docs/CAPABILITY_MATRIX.md) | Coexistence with other Power BI MCPs, with verification levels |
 | [`AGENTS.md`](AGENTS.md) | Rules for modifying this repository without breaking the contract |
-| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 132 tools by block, with their risk class |
+| [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md) | The 133 tools by block, with their risk class |
 | [`docs/DUAL_MODE.md`](docs/DUAL_MODE.md) | Why `mode="both"` is blocked (R15) |
 | [`docs/VALIDATION.md`](docs/VALIDATION.md) | The two PBIR validation layers and their limits |
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | What is checked before publishing |
@@ -93,7 +93,7 @@ claude plugin install horizun-pbi-mcp@horizun
 
 When the first session opens, the plugin runs the full setup automatically in
 the background. Check `pbi_install_status`; once it finishes, restart the
-client and the 132 `pbi_*` tools will be available. There are no downloads or
+client and the 133 `pbi_*` tools will be available. There are no downloads or
 additional scripts the user needs to run manually.
 
 > **Honest technical limit:** there's no dedicated executable, but you do need
@@ -195,7 +195,7 @@ Exits with code **0** if everything mandatory is fine. It distinguishes missing 
 
 ---
 
-## Available tools (132)
+## Available tools (133)
 
 > Full catalog by block: [`docs/TOOL_CATALOG.md`](docs/TOOL_CATALOG.md).
 > Baseline inventory with risk class and preconditions: [`docs/TOOL_INVENTORY.md`](docs/TOOL_INVENTORY.md).
@@ -219,6 +219,7 @@ Exits with code **0** if everything mandatory is fine. It distinguishes missing 
 - `pbi_generate_pdf_report` — executive/technical/audit PDF with optional dashboard PNG/JPEG captures.
 - `pbi_sharepoint_list_folder` — lists SharePoint Online folders through Microsoft Graph with pagination and limits.
 - `pbi_sharepoint_download_folder` — staged all-or-nothing download to `outputs/sharepoint/`, verified by size and SHA-256.
+- `pbi_export_report_content` — exports the report **content**: the data behind each visual, or a query the client declares. Needs the live model; refuses to export an unprocessed one instead of writing a blank file.
 
 **Measures (Phase 4)** — `mode: live|pbip|both`, `overwrite`
 - `pbi_create_measure`, `pbi_update_measure`, `pbi_delete_measure` (destructive: `confirm=true`).
@@ -380,7 +381,7 @@ python -m pytest -m live                # against an open Power BI Desktop
 python -m pytest -m live_validator      # against Microsoft's official CLI
 ```
 
-Verify the MCP contract (the 132 tools are frozen):
+Verify the MCP contract (the 133 tools are frozen):
 
 ```bash
 python -m tests.contract_utils

--- a/RELEASE_NOTES_1.4.0.md
+++ b/RELEASE_NOTES_1.4.0.md
@@ -1,0 +1,94 @@
+# Horizun PBI MCP v1.4.0
+
+Five new tools (133 total), zero breaking changes — and a theme that runs
+through every fix in this release: **the server produced something that
+looked right and nobody could see it was wrong.** A workbook the schema
+accepts, a PDF that opens, a query that returns rows, a slicer whose colours
+are written down. All valid. All silently not doing what they claimed.
+
+Every defect below was found by opening the artifact and looking at it, and
+every one is verified by mutation: revert the fix and a named test fails.
+
+## Added
+
+- **`pbi_export_report_content`** — exports the report CONTENT, not its
+  metadata: the table behind each visual, or a query the client declares
+  (`rows` / `values` / `filters` / `top_n`). Selection by `pages`, `visuals`
+  or `queries`; output to `.xlsx` and `.pdf`.
+
+  Each visual's query is reconstructed from its fields and its PBIR filters.
+  Every sheet declares which filters were applied and — the part that matters
+  — which could **not** be translated, because a number that silently ignores
+  a filter is worse than no export. Visuals with no tabular query (text
+  boxes, images, shapes) are listed with the reason instead of exported
+  empty, and an unrecognised aggregation makes the visual decline rather than
+  guess.
+
+  It needs the live model, so it opens Desktop when there is none — and it
+  **refuses to export a model that is open but unprocessed**. A freshly
+  opened `.pbip` answers every query with zero rows: the workbook would come
+  out blank without a single error.
+
+- **`pbi_export_excel`**, **`pbi_generate_pdf_report`** — verified document
+  exports: `.xlsx` with model, report and audit; executive, technical and
+  audit PDFs with optional dashboard captures. Both reopen what they wrote
+  before reporting success.
+
+- **`pbi_sharepoint_list_folder`**, **`pbi_sharepoint_download_folder`** —
+  read-only SharePoint Online ingestion through Microsoft Graph, app-only
+  MSAL, all-or-nothing staged download with SHA-256 verification.
+
+- **Two audit rules for visuals Power BI refuses to draw.** A visual in error
+  shows a banner instead of content, and nothing catches it: the PBIR schema
+  accepts the JSON, the official CLI passes, and the synthesized DAX even
+  returns rows — the fault is in the *field configuration*, not the query.
+  `report_scatter_axis_not_aggregated` (a field in Details with
+  non-aggregated X/Y) and `report_slicer_below_height_floor` (a slicer under
+  its height floor).
+
+## Fixed
+
+- **A visual with columns from two tables exported a cartesian product.**
+  `SUMMARIZECOLUMNS` only applies auto-exists within one table. Measured
+  against the engine: 20 risks by 20 mitigation measures returned **400 rows
+  where the visual shows 20**. The query now carries an auxiliary
+  `CALCULATE(COUNTROWS(<fact table>))` resolved from the model's
+  relationships, stripped again before the file is written. With no single
+  fact table covering every column, the visual is declared non-exportable.
+
+- **`pbi_generate_pdf_report` named no object in its audit table**, and
+  printed raw JSON. Every finding carries the measure, column, visual or page
+  it is about; the PDF dropped it and printed seven identical
+  `measure_possibly_unused` rows with `{"referenced_by_measures": 0}` as the
+  description. There is now an `Objeto` column, page ids resolve to their
+  visible name, and evidence reads as `visual_count: 13; threshold: 12`.
+
+- **`reuse_open` never reused a `.pbip` session.** Detection relied on open
+  file descriptors and Desktop keeps none on a project folder — verified with
+  `open_files()`: zero files. Every `pbi_open_in_desktop` on a project
+  launched ANOTHER window of the same report. It now falls back to the main
+  window title, reusing only when exactly one window matches.
+
+## Measured, not derived
+
+The slicer height floor shipped wrong first. The rule used 76px
+unconditionally (header 28 + selector 32 + padding 8/8) and reported nine
+healthy slicers as broken — the ones that hide their header. The floor is
+**76px with a visible header and 48px without**, and both numbers now come
+from feeding the official CLI the same report at varying heights: 74 fails
+and 76 passes with a header, 47 fails and 48 passes without one.
+
+The lesson is the method, not the constant: when the oracle and I disagree,
+the one who has to explain themselves is me.
+
+## Known limits
+
+Unchanged from 1.3.0 and documented in
+[`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md): three PBIR schema
+versions unpublished upstream, `both` mode blocked by mutually exclusive
+preconditions, and full visual equivalence of the `objects` block still
+partial.
+
+Content export needs Power BI Desktop: the data lives in the engine, and the
+engine only exists as a child of Desktop. There is no XMLA path to the
+Service in this version.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 What remains open, why it matters and how to check it. Ordered by what
 hurts the most.
 
-Updated on 2026-08-05 for **v1.4.0** (132 tools). Excel/PDF exports and
+Updated on 2026-08-06 for **v1.4.0** (133 tools). Excel/PDF exports and
 SharePoint folder ingestion are now built in. Two things closed since
 1.0.1: the fourteen-item field report from the first real end-to-end session,
 and **the four phases of the product vision** — intent brief, content-level

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -19,7 +19,7 @@ Every statement carries its **verification level**. They are not mixed.
 
 | Server | Version | Status | Highest level reached |
 |---|---|---|---|
-| **Horizun PBI MCP** (this repo) | 1.4.0 | Present, starts | **Tested** — stdio handshake, 132 tools, live DAX, PBIR fixture, verified Excel/PDF exports, Desktop capture by PID and simulated Graph folder traversal/download |
+| **Horizun PBI MCP** (this repo) | 1.4.0 | Present, starts | **Tested** — stdio handshake, 133 tools, live DAX, PBIR fixture, verified Excel/PDF exports, Desktop capture by PID and simulated Graph folder traversal/download |
 | **powerbi-report-mcp** | 0.9.6 | Present and built at `..\PowerBI MCP\powerbi-report-mcp\dist\index.js` | **Observed** — 57 tool names extracted from the bundle and the README. **Not run** |
 | **@microsoft/powerbi-modeling-mcp** | 0.5.0-beta.11 | Downloaded to a temp folder, extracted and read. **Not run** | **Declared** — README + CHANGELOG + `index.js`. Execution **halted** due to a stop condition (§2.1) |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,14 +17,14 @@ claude plugin install horizun-pbi-mcp@horizun
 
 Setup starts automatically on the first session. While it progresses
 you'll see `pbi_install_runtime` and `pbi_install_status`; after restarting
-the client the 132 tools will appear. Nothing needs to be downloaded or run
+the client the 133 tools will appear. Nothing needs to be downloaded or run
 separately. The runtime and verified downloads stay in the plugin's local
 data, outside the repository and your projects.
 
 Python 3.10+ is still a requirement: it's the local process that talks to
 Power BI Desktop. Node 20 is only needed for the optional PBIR validator.
 
-Reproducible guide from scratch. At the end, an MCP client should see 132 `pbi_*` tools.
+Reproducible guide from scratch. At the end, an MCP client should see 133 `pbi_*` tools.
 
 ---
 

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -1,4 +1,4 @@
-# Tool catalog — 132
+# Tool catalog — 133
 
 Generated from the contract frozen in `tests/golden/tools_v1.json`.
 The **34 baseline** tools keep their name, parameters, types, defaults and response shape since version 0.1.0.
@@ -33,8 +33,8 @@ tools registered.
 | Q — data diagnostics | 1 |
 | R — external sources | 1 |
 | S — ecosystem port | 2 |
-| T — exports and SharePoint | 4 |
-| **Total** | **132** |
+| T — exports and SharePoint | 5 |
+| **Total** | **133** |
 
 ---
 
@@ -163,10 +163,17 @@ tools registered.
 | `pbi_plan_audit_fixes` | Plans fixes for **specific** rules |
 | `pbi_apply_audit_fixes` | **Destructive** (`confirm`) |
 
+`pbi_audit_report_only` includes two rules for visuals that Power BI refuses
+to draw — the failure no schema can see, because the JSON is valid and the
+fault is in the field configuration: `report_scatter_axis_not_aggregated`
+(Details plus non-aggregated X/Y) and `report_slicer_below_height_floor` (under its floor: 76px with a visible
+header, 48px without — both measured against the official CLI).
+
 ## Excel, PDF and SharePoint
 
 | Tool | What it does |
 |---|---|
+| `pbi_export_report_content` | Exports the report CONTENT — the data behind each visual, or a query the client declares — to `.xlsx`/`.pdf` under `outputs/content/`. Needs the live model: opens Desktop if needed and refuses to export when the model is open but unprocessed. Every sheet declares which filters were applied and which could not be |
 | `pbi_export_excel` | Verified `.xlsx` with summary, model, relationships, pages, visuals, audit and optional read-only DAX data. Reopens the workbook before publishing it under `outputs/excel/` |
 | `pbi_generate_pdf_report` | Executive, technical or audit PDF; can embed PNG/JPEG captures returned by `pbi_validate_desktop_render`; logical verification is mandatory and Poppler render verification is reported when available |
 | `pbi_sharepoint_list_folder` | Lists a SharePoint Online folder through Microsoft Graph v1.0, with pagination, optional recursion and explicit item limit |
@@ -217,7 +224,7 @@ that can quietly drift.
 | Class | No. | Behavior | `readOnlyHint` |
 |---|---|---|---|
 | `read_only` | 54 | Doesn't modify anything of the user's and leaves no file behind | `true` |
-| `read_only_emits_file` | 11 | Doesn't touch the project, but writes a report/export into `outputs/` | `false` |
+| `read_only_emits_file` | 12 | Doesn't touch the project, but writes a report/export into `outputs/` | `false` |
 | `read_external` | 1 | Reads SharePoint through Microsoft Graph; no local or remote write | `true`, `openWorldHint: true` |
 | `read_external_emits_file` | 1 | Reads SharePoint and publishes a verified download under `outputs/` | `false`, `openWorldHint: true` |
 | `side_effect_external` | 2 | Opens — and sometimes closes — Power BI Desktop: `pbi_open_in_desktop`, `pbi_validate_desktop_render` | `false` |

--- a/src/horizun_pbi_mcp/pbip/filter_reader.py
+++ b/src/horizun_pbi_mcp/pbip/filter_reader.py
@@ -1,0 +1,143 @@
+"""Lectura de `filterConfig`: el inverso de `filter_builder`.
+
+Existe para una sola pregunta: cuando se exporta el CONTENIDO de un visual,
+que estaba filtrando lo que se ve en pantalla. Un export que ignora los
+filtros da cifras que no cuadran con el tablero, y eso es peor que no
+exportar: nadie duda de un Excel.
+
+Por eso la salida separa tres cosas que no son lo mismo:
+
+- `applied`: filtros que se entienden y se pueden llevar a DAX.
+- `untranslated`: filtros que ESTAN y NO se supieron traducir. Quien exporta
+  tiene que declararlos; callarlos convierte el numero en mentira.
+- `unset`: campos presentes en el panel sin seleccion. No acotan nada, y
+  contarlos como riesgo seria ruido.
+
+Solo se traduce el filtro categorico -`In` y su negacion-, que es el que
+Power BI escribe al marcar casillas. Todo lo demas cae en `untranslated` con
+el motivo, a proposito: es preferible decir "esto no lo se aplicar" a
+inventar una equivalencia parecida.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from horizun_pbi_mcp.logging_config import get_logger
+
+log = get_logger("filter_reader")
+
+
+def _parse_literal(valor: Any) -> Any:
+    """`{'Value': "'Abierto'"}` -> `Abierto`. El inverso de `_literal`."""
+    texto = str(valor if valor is not None else "").strip()
+    if texto == "" or texto == "null":
+        return None
+    if texto in ("true", "false"):
+        return texto == "true"
+    if len(texto) >= 2 and texto[0] == "'" and texto[-1] == "'":
+        return texto[1:-1].replace("''", "'")
+    if texto[-1:] in ("L", "D", "M") and texto[:-1].lstrip("-+").replace(".", "", 1).isdigit():
+        cuerpo = texto[:-1]
+        try:
+            return int(cuerpo) if texto[-1] == "L" else float(cuerpo)
+        except ValueError:                    # pragma: no cover - defensivo
+            return cuerpo
+    return texto
+
+
+def _campo_de(field: Any) -> Tuple[Optional[str], bool]:
+    """Referencia `Tabla[Columna]` y si el campo es una medida."""
+    if not isinstance(field, dict):
+        return None, False
+    for clave, es_medida in (("Column", False), ("Measure", True)):
+        if clave in field:
+            nodo = field[clave] or {}
+            entidad = ((nodo.get("Expression") or {}).get("SourceRef") or {}).get("Entity")
+            propiedad = nodo.get("Property")
+            if not propiedad:
+                return None, es_medida
+            return (f"{entidad}[{propiedad}]" if entidad else propiedad), es_medida
+    return None, False
+
+
+def _condicion_categorica(condicion: Any) -> Optional[Dict[str, Any]]:
+    """`In` (o `Not(In)`) sobre UNA columna -> `{values, exclude}`."""
+    if not isinstance(condicion, dict):
+        return None
+    excluir = False
+    if "Not" in condicion:
+        condicion = (condicion.get("Not") or {}).get("Expression")
+        excluir = True
+        if not isinstance(condicion, dict):
+            return None
+    nodo = condicion.get("In")
+    if not isinstance(nodo, dict):
+        return None
+    expresiones = nodo.get("Expressions") or []
+    # Un `In` sobre dos columnas a la vez ("estos pares") no equivale a filtrar
+    # una columna por una lista. Traducirlo como si lo fuera cambiaria el dato.
+    if len(expresiones) != 1:
+        return None
+    valores = []
+    for fila in nodo.get("Values") or []:
+        if not isinstance(fila, list) or len(fila) != 1:
+            return None
+        literal = (fila[0] or {}).get("Literal") if isinstance(fila[0], dict) else None
+        if literal is None:
+            return None
+        valores.append(_parse_literal(literal.get("Value")))
+    return {"values": valores, "exclude": excluir}
+
+
+def leer_filtro(entrada: Any, *, scope: str) -> Dict[str, Any]:
+    """Clasifica UN elemento de `filterConfig.filters`."""
+    if not isinstance(entrada, dict):
+        return {"state": "untranslated", "scope": scope, "field": None,
+                "reason": "El filtro no es un objeto."}
+    referencia, es_medida = _campo_de(entrada.get("field"))
+    tipo = entrada.get("type") or "Advanced"
+    base = {"scope": scope, "field": referencia, "type": tipo,
+            "display_name": entrada.get("displayName")}
+
+    if "filter" not in entrada or entrada.get("filter") is None:
+        return {**base, "state": "unset"}
+    if referencia is None:
+        return {**base, "state": "untranslated",
+                "reason": "No se pudo leer sobre que campo filtra."}
+    if es_medida:
+        return {**base, "state": "untranslated",
+                "reason": "Filtra sobre una medida; no equivale a acotar una "
+                          "columna y aplicarlo mal cambiaria el resultado."}
+
+    consulta = entrada.get("filter") or {}
+    condiciones = consulta.get("Where") or []
+    if len(condiciones) != 1:
+        return {**base, "state": "untranslated",
+                "reason": f"La consulta del filtro tiene {len(condiciones)} "
+                          "condiciones; solo se traduce una."}
+    traducido = _condicion_categorica((condiciones[0] or {}).get("Condition"))
+    if traducido is None:
+        return {**base, "state": "untranslated",
+                "reason": f"Condicion de tipo '{tipo}' que este lector no "
+                          "traduce (solo lista de valores)."}
+    return {**base, "state": "applied", **traducido}
+
+
+def read_filters(nodo: Any, *, scope: str) -> List[Dict[str, Any]]:
+    """Lee el `filterConfig` de un informe, una pagina o un visual."""
+    if not isinstance(nodo, dict):
+        return []
+    config = nodo.get("filterConfig")
+    if not isinstance(config, dict):
+        return []
+    return [leer_filtro(f, scope=scope) for f in (config.get("filters") or [])]
+
+
+def resumen(filtros: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Agrupa por estado para que quien exporta pueda declararlo tal cual."""
+    aplicados = [f for f in filtros if f.get("state") == "applied"]
+    sin_traducir = [f for f in filtros if f.get("state") == "untranslated"]
+    sin_seleccion = [f for f in filtros if f.get("state") == "unset"]
+    return {"applied": aplicados, "untranslated": sin_traducir,
+            "unset": sin_seleccion,
+            "trustworthy": not sin_traducir}

--- a/src/horizun_pbi_mcp/powerbi/desktop_launcher.py
+++ b/src/horizun_pbi_mcp/powerbi/desktop_launcher.py
@@ -180,16 +180,50 @@ def _preflight_pbip_model(pbip: Path) -> None:
     )
 
 
-def proceso_con_archivo_abierto(pbix: Path) -> Optional[int]:
-    """PID del Desktop que tiene ese .pbix abierto, si se puede averiguar.
+def _pid_por_titulo_de_ventana(stem: str) -> Optional[int]:
+    """PID cuya ventana principal se llama exactamente como el proyecto.
 
-    Desktop mantiene el archivo abierto mientras el informe esta cargado, asi
-    que la lista de descriptores lo delata. En Windows `open_files()` puede
-    fallar por permisos; en ese caso devolvemos None y el llamador decide.
+    Es la unica correlacion posible para un .pbip: Desktop NO deja ningun
+    descriptor abierto sobre la carpeta del proyecto -comprobado con
+    `open_files()`, que devuelve cero archivos de esa carpeta-, asi que la
+    busqueda por descriptores da None y, sin esto, cada apertura del mismo
+    proyecto lanzaba OTRA ventana.
+
+    Se exige coincidencia exacta y una sola ventana: ante dos candidatas no se
+    elige, porque reutilizar la equivocada es peor que no reutilizar.
+    """
+    if os.name != "nt":
+        return None
+    try:
+        from horizun_pbi_mcp.powerbi.desktop_capture import _enumerate_windows
+    except Exception:                          # noqa: BLE001 - sin captura
+        return None
+
+    objetivo = stem.casefold()
+    coincidencias: List[int] = []
+    for proc in _procesos_desktop():
+        try:
+            titulos = [w.title.strip().casefold()
+                       for w in _enumerate_windows(proc.pid) if w.title]
+        except Exception:                      # noqa: BLE001
+            continue
+        if objetivo in titulos and proc.pid not in coincidencias:
+            coincidencias.append(proc.pid)
+    return coincidencias[0] if len(coincidencias) == 1 else None
+
+
+def proceso_con_archivo_abierto(pbix: Path) -> Optional[int]:
+    """PID del Desktop que tiene ese informe abierto, si se puede averiguar.
+
+    Con un .pbix, Desktop mantiene el archivo abierto mientras el informe esta
+    cargado y la lista de descriptores lo delata. Con un .pbip no hay ningun
+    descriptor que mirar y se cae al titulo de la ventana. En Windows
+    `open_files()` puede fallar por permisos; en ese caso devolvemos None y el
+    llamador decide.
     """
     import psutil
 
-    objetivo = _normalized_open_path(pbix.resolve())
+    objetivo = _normalized_open_path(Path(pbix).resolve())
     for proc in _procesos_desktop():
         try:
             for archivo in proc.open_files():
@@ -197,6 +231,8 @@ def proceso_con_archivo_abierto(pbix: Path) -> Optional[int]:
                     return proc.pid
         except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
             continue
+    if Path(pbix).suffix.casefold() == ".pbip":
+        return _pid_por_titulo_de_ventana(Path(pbix).stem)
     return None
 
 

--- a/src/horizun_pbi_mcp/services/content_export.py
+++ b/src/horizun_pbi_mcp/services/content_export.py
@@ -1,0 +1,598 @@
+"""Exportar el CONTENIDO de un informe: los datos, no los metadatos.
+
+`exporting` documenta el proyecto -que tablas hay, que visuales, que
+hallazgos-. Esto exporta lo que el tablero MUESTRA: la tabla que hay detras
+de cada visual, o la que el cliente declare.
+
+Tres cosas que este modulo se niega a hacer, porque son las tres formas de
+entregar un archivo que miente:
+
+1. **Exportar sin datos.** Un .pbip recien abierto en Desktop trae el modelo
+   SIN procesar: las consultas responden vacio y el Excel sale en blanco sin
+   un solo error. Se comprueba el estado de las particiones antes de
+   consultar y se rechaza con instrucciones en vez de publicar el vacio.
+2. **Ignorar un filtro que no se supo traducir.** Cada hoja declara sus
+   filtros aplicados y, sobre todo, los que NO se pudieron aplicar.
+3. **Inventarle una consulta a un visual que no la tiene.** Los que no son
+   tabulares se listan aparte, con el motivo, en vez de salir vacios.
+"""
+from __future__ import annotations
+
+import io
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from horizun_pbi_mcp.config import Session
+from horizun_pbi_mcp.logging_config import get_logger
+from horizun_pbi_mcp.pbip import filter_reader, pbir_reader
+from horizun_pbi_mcp.powerbi import dax_runner
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+from horizun_pbi_mcp.services import content_query, exporting
+from horizun_pbi_mcp.utils.json_utils import read_json
+
+log = get_logger("content_export")
+
+#: Tope de consultas por export. No es una cifra magica: cada una es un viaje
+#: al motor, y un informe grande con `pages` sin acotar puede lanzar cientos
+#: sin que nadie lo haya pedido explicitamente.
+MAX_CONSULTAS = 60
+
+#: Hueco de una celda. Un guion suelto lo neutraliza el guardia de
+#: formulas de Excel y llega al cliente como `'-`.
+SIN_DATO = "n/a"
+
+
+def _pagina_por_nombre(active, referencia: str) -> Dict[str, Any]:
+    """Acepta el id interno de la pagina o su nombre visible."""
+    paginas = pbir_reader.list_pages(active)
+    texto = str(referencia).strip()
+    for p in paginas:
+        if p.get("name") == texto or (p.get("display_name") or "") == texto:
+            return p
+    disponibles = [p.get("display_name") or p.get("name") for p in paginas]
+    raise ValidationError(
+        f"No existe la pagina '{referencia}' en el informe activo.",
+        details={"requested": referencia, "available": disponibles})
+
+
+def _filtros_de_pagina(active, page_id: str) -> List[Dict[str, Any]]:
+    ruta = pbir_reader.resolve_page_dir(active, page_id) / "page.json"
+    if not ruta.exists():
+        return []
+    return filter_reader.read_filters(read_json(ruta), scope="pagina")
+
+
+def _filtros_de_visual(visual: Dict[str, Any]) -> List[Dict[str, Any]]:
+    archivo = visual.get("file")
+    if not archivo or not Path(archivo).exists():
+        return []
+    return filter_reader.read_filters(read_json(Path(archivo)), scope="visual")
+
+
+def _relaciones(session: Session) -> List[Dict[str, Any]]:
+    """Relaciones del modelo, para saber que combinaciones existen.
+
+    Se leen del TMDL y no del motor a proposito: `dry_run` tiene que poder
+    decir el DAX exacto sin Desktop abierto.
+    """
+    from horizun_pbi_mcp.pbip import tmdl_reader
+
+    try:
+        active = session.require_active_pbip()
+    except Exception:                          # noqa: BLE001 - sin pbip activo
+        active = None
+    if active is not None and active.has_tmdl:
+        try:
+            return tmdl_reader.read_semantic_model(active).get("relationships") or []
+        except Exception as exc:               # noqa: BLE001
+            log.warning("No se pudieron leer las relaciones del TMDL: %s", exc)
+    try:
+        from horizun_pbi_mcp.powerbi import model_reader
+
+        return model_reader.read_model(session).get("relationships") or []
+    except Exception:                          # noqa: BLE001 - sin modelo vivo
+        return []
+
+
+def _plan_de_visual_en_pagina(active, pagina: Dict[str, Any],
+                              visual: Dict[str, Any],
+                              filtros_pagina: List[Dict[str, Any]],
+                              relaciones: List[Dict[str, Any]]) -> Dict[str, Any]:
+    filtros = filtros_pagina + _filtros_de_visual(visual)
+    resumen = filter_reader.resumen(filtros)
+    plan = content_query.plan_de_visual(visual, resumen["applied"], relaciones)
+    plan["page"] = pagina.get("display_name") or pagina.get("name")
+    plan["page_id"] = pagina.get("name")
+    plan["filters_applied"] = resumen["applied"]
+    plan["filters_untranslated"] = resumen["untranslated"]
+    plan["filters_unset"] = resumen["unset"]
+    return plan
+
+
+def resolver_seleccion(session: Session, select: Dict[str, Any]) -> Dict[str, Any]:
+    """`select` -> planes de consulta, mas lo que se dejo fuera y por que."""
+    if not isinstance(select, dict) or not any(
+            select.get(k) for k in ("pages", "visuals", "queries")):
+        raise ValidationError(
+            "`select` necesita al menos uno de 'pages', 'visuals' o 'queries'.",
+            details={"select": select})
+
+    planes: List[Dict[str, Any]] = []
+    omitidos: List[Dict[str, Any]] = []
+    necesita_pbip = bool(select.get("pages") or select.get("visuals"))
+    active = session.require_active_pbip() if necesita_pbip else None
+    relaciones = _relaciones(session)
+
+    for referencia in select.get("pages") or []:
+        pagina = _pagina_por_nombre(active, referencia)
+        filtros_pagina = _filtros_de_pagina(active, pagina["name"])
+        for visual in pbir_reader.list_visuals(active, pagina["name"], strict=True):
+            plan = _plan_de_visual_en_pagina(active, pagina, visual,
+                                             filtros_pagina, relaciones)
+            (planes if plan["exportable"] else omitidos).append(plan)
+
+    pedidos = [str(v) for v in (select.get("visuals") or [])]
+    if pedidos:
+        pendientes = set(pedidos)
+        for pagina in pbir_reader.list_pages(active):
+            if not pendientes:
+                break
+            filtros_pagina = _filtros_de_pagina(active, pagina["name"])
+            for visual in pbir_reader.list_visuals(active, pagina["name"], strict=True):
+                if visual.get("id") not in pendientes:
+                    continue
+                pendientes.discard(visual["id"])
+                plan = _plan_de_visual_en_pagina(active, pagina, visual,
+                                                 filtros_pagina, relaciones)
+                (planes if plan["exportable"] else omitidos).append(plan)
+        for huerfano in sorted(pendientes):
+            raise ValidationError(
+                f"No existe el visual '{huerfano}' en el informe activo.",
+                details={"visual_id": huerfano})
+
+    for spec in select.get("queries") or []:
+        planes.append(content_query.plan_declarado(spec, relaciones))
+
+    if not planes:
+        raise ValidationError(
+            "La seleccion no dejo ninguna consulta que exportar.",
+            details={"skipped": [{"title": o.get("title"), "reason": o.get("reason")}
+                                 for o in omitidos]})
+    if len(planes) > MAX_CONSULTAS:
+        raise ValidationError(
+            f"La seleccion produce {len(planes)} consultas y el tope es "
+            f"{MAX_CONSULTAS}. Acota `pages` o pide visuales concretos.",
+            details={"queries": len(planes), "max": MAX_CONSULTAS})
+    return {"plans": planes, "skipped": omitidos}
+
+
+def estado_de_datos(session: Session) -> Dict[str, Any]:
+    """Dice si el modelo activo tiene datos cargados, no solo esquema.
+
+    Es la comprobacion que evita el Excel en blanco: un .pbip recien abierto
+    sirve el modelo, responde a las consultas y devuelve cero filas.
+    """
+    from horizun_pbi_mcp.powerbi.adomd_client import AdomdClient
+
+    model = session.require_active_model()
+    with AdomdClient(model.connection_string, model.catalog) as client:
+        _cols, filas, _t, _e = client.execute_reader(
+            "SELECT [TableID], [State], [RefreshedTime] "
+            "FROM $SYSTEM.TMSCHEMA_PARTITIONS", max_rows=5_000)
+    # `State` 1 es Ready; cualquier otra cosa es una particion sin procesar.
+    listas = [f for f in filas if f and str(f[1]) == "1"]
+    return {"partitions": len(filas), "ready": len(listas),
+            "processed": bool(listas)}
+
+
+def _modelo_en_vivo(session: Session, *, auto_open: bool,
+                    timeout: int = 300) -> List[str]:
+    """Deja un modelo en vivo seleccionado. Devuelve avisos."""
+    from horizun_pbi_mcp.powerbi.errors import NoActiveModelError
+
+    try:
+        session.require_active_model()
+        return []
+    except NoActiveModelError:
+        if not auto_open:
+            raise
+    active = session.require_active_pbip()
+    from horizun_pbi_mcp.powerbi import desktop_discovery, desktop_launcher
+
+    abierto = desktop_launcher.open_pbix(active.pbip_path, timeout=timeout,
+                                         reuse_open=True)
+    desktop_discovery.select_model(
+        session, port=(abierto.instance or {}).get("port"))
+    return ["No habia modelo en vivo: se abrio el informe en Power BI Desktop "
+            + ("arrancando Desktop." if abierto.launched_by_us
+               else "reutilizando la ventana que ya estaba abierta.")]
+
+
+def _asegurar_modelo(session: Session, *, auto_open: bool,
+                     timeout: int = 300) -> List[str]:
+    """Modelo en vivo Y con datos. Lo segundo es lo que nadie comprueba."""
+    avisos = _modelo_en_vivo(session, auto_open=auto_open, timeout=timeout)
+    datos = estado_de_datos(session)
+    if not datos["processed"]:
+        raise ValidationError(
+            "El modelo esta abierto pero SIN DATOS: ninguna de sus "
+            f"{datos['partitions']} particiones esta procesada. Un export "
+            "ahora saldria en blanco sin un solo error. Refresca el modelo "
+            "(pbi_refresh_model) y vuelve a intentarlo.",
+            details=datos)
+    return avisos
+
+
+#: `2026-09-11T00:00:00.0000000`, tal como lo devuelve el motor. Es un
+#: round-trip de .NET, no algo que un cliente deba leer en un informe.
+_FECHA_ISO = re.compile(
+    r"^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?$")
+
+
+def valor_legible(valor: Any) -> Any:
+    """Deja el valor como lo leeria una persona, sin cambiar el dato."""
+    if not isinstance(valor, str):
+        return valor
+    coincidencia = _FECHA_ISO.match(valor.strip())
+    if not coincidencia:
+        return valor
+    fecha, hora, fraccion = coincidencia.groups()
+    if hora == "00:00:00" and not (fraccion or "").strip("0"):
+        return fecha
+    return f"{fecha} {hora}"
+
+
+def encabezados_legibles(columnas: Sequence[Any]) -> List[str]:
+    """`Riesgos[Fase]` -> `Fase`; `[Total]` -> `Total`.
+
+    Si al desnudarlos dos columnas se llamarian igual, TODAS las que chocan
+    conservan su forma completa: un encabezado ambiguo en una entrega es peor
+    que uno feo.
+    """
+    desnudos = []
+    for columna in columnas:
+        texto = str(columna)
+        if texto.endswith("]") and "[" in texto:
+            desnudos.append(texto[texto.index("[") + 1:-1])
+        else:
+            desnudos.append(texto)
+    repetidos = {n for n in desnudos if desnudos.count(n) > 1}
+    return [str(original) if corto in repetidos else corto
+            for original, corto in zip(columnas, desnudos)]
+
+
+def _sin_auxiliares(plan: Dict[str, Any], columnas: List[Any],
+                    filas: List[List[Any]]) -> Any:
+    """Quita del resultado la medida que solo existia para forzar la relacion.
+
+    El motor devuelve la columna como `[__existe]`. Es andamiaje nuestro: al
+    cliente le llega la tabla que pidio, no la que necesitamos para pedirla.
+    """
+    if not any(m.get("aux") for m in plan.get("measures") or []):
+        return columnas, filas
+    sobran = {i for i, c in enumerate(columnas)
+              if content_query.ALIAS_EXISTENCIA in str(c)}
+    if not sobran:
+        return columnas, filas
+    limpias = [c for i, c in enumerate(columnas) if i not in sobran]
+    return limpias, [[v for i, v in enumerate(f) if i not in sobran]
+                     for f in filas]
+
+
+def _ejecutar(session: Session, plan: Dict[str, Any], *,
+              max_rows: int) -> Dict[str, Any]:
+    resultado = dax_runner.run_dax(session, plan["dax"], max_rows=max_rows)
+    columnas, filas = _sin_auxiliares(
+        plan, list(resultado.get("columns") or []),
+        [list(f) for f in (resultado.get("rows") or [])])
+    columnas = encabezados_legibles(columnas)
+    filas = [[valor_legible(v) for v in fila] for fila in filas]
+    return {"columns": columnas, "rows": filas,
+            "row_count": resultado.get("row_count", 0),
+            "truncated": bool(resultado.get("truncated")),
+            "elapsed_ms": resultado.get("elapsed_ms")}
+
+
+def _nombre_de_hoja(plan: Dict[str, Any], usados: set) -> str:
+    """Excel: 31 caracteres, sin `[]:*?/\\` y sin repetir."""
+    base = str(plan.get("title") or plan.get("visual_id") or "Consulta")
+    for prohibido in "[]:*?/\\":
+        base = base.replace(prohibido, " ")
+    base = " ".join(base.split())[:31] or "Consulta"
+    candidato, n = base, 2
+    while candidato.lower() in usados:
+        sufijo = f" {n}"
+        candidato, n = base[:31 - len(sufijo)] + sufijo, n + 1
+    usados.add(candidato.lower())
+    return candidato
+
+
+def _descripcion_filtros(plan: Dict[str, Any]) -> str:
+    partes = []
+    for f in plan.get("filters_applied") or plan.get("filters") or []:
+        valores = ", ".join(str(v) for v in (f.get("values") or []))
+        signo = "no esta en" if f.get("exclude") else "esta en"
+        partes.append(f"{f.get('field')} {signo} ({valores})")
+    return "; ".join(partes) or "ninguno"
+
+
+def _descripcion_sin_traducir(plan: Dict[str, Any]) -> str:
+    partes = [f"{f.get('field') or 'campo desconocido'}: {f.get('reason')}"
+              for f in plan.get("filters_untranslated") or []]
+    return "; ".join(partes)
+
+
+def _hoja_indice(planes: Sequence[Dict[str, Any]],
+                 omitidos: Sequence[Dict[str, Any]],
+                 avisos: Sequence[str]) -> List[List[Any]]:
+    filas: List[List[Any]] = []
+    for plan in planes:
+        filas.append([
+            plan.get("sheet"), plan.get("page") or SIN_DATO,
+            plan.get("visual_type"), plan.get("title"),
+            plan.get("data", {}).get("row_count"),
+            "si" if plan.get("data", {}).get("truncated") else "no",
+            _descripcion_filtros(plan),
+            _descripcion_sin_traducir(plan) or "ninguno",
+            plan.get("dax"),
+        ])
+    for omitido in omitidos:
+        filas.append(["(no exportado)", omitido.get("page") or SIN_DATO,
+                      omitido.get("visual_type"), omitido.get("title"),
+                      None, SIN_DATO, SIN_DATO, omitido.get("reason"),
+                      SIN_DATO])
+    for aviso in avisos:
+        filas.append(["(aviso)", SIN_DATO, SIN_DATO, aviso, None,
+                      SIN_DATO, SIN_DATO, SIN_DATO, SIN_DATO])
+    return filas
+
+
+def _construir_excel(planes: Sequence[Dict[str, Any]],
+                     omitidos: Sequence[Dict[str, Any]],
+                     avisos: Sequence[str]) -> bytes:
+    from openpyxl import Workbook
+    from openpyxl.styles import Alignment, Font, PatternFill
+    from openpyxl.utils import get_column_letter
+
+    wb = Workbook()
+    indice = wb.active
+    indice.title = "Contenido"
+    indice.append(["Exportacion", "Horizun PBI MCP"])
+    indice.append(["Generado UTC", datetime.now(timezone.utc).isoformat()])
+    indice.append([])
+    encabezados = ["Hoja", "Pagina", "Tipo de visual", "Titulo", "Filas",
+                   "Truncado", "Filtros aplicados", "Filtros NO aplicados",
+                   "Consulta DAX"]
+    indice.append(encabezados)
+    for fila in _hoja_indice(planes, omitidos, avisos):
+        indice.append([exporting._json_cell(v) for v in fila])
+
+    cabecera = PatternFill("solid", fgColor="123047")
+    acento = PatternFill("solid", fgColor="17A6A6")
+    blanco = Font(color="FFFFFF", bold=True)
+    for celda in indice[4]:
+        celda.fill, celda.font = cabecera, blanco
+    indice.freeze_panes = "A5"
+    for i, ancho in enumerate([24, 20, 16, 30, 9, 10, 34, 34, 60], 1):
+        indice.column_dimensions[get_column_letter(i)].width = ancho
+
+    for plan in planes:
+        ws = wb.create_sheet(plan["sheet"])
+        datos = plan["data"]
+        # El encabezado de contexto va ARRIBA del dato, no en una hoja aparte:
+        # quien abre esta hoja tiene que ver con que filtros se saco esto sin
+        # tener que ir a buscarlo.
+        ws.append([plan.get("title")])
+        ws.append(["Pagina", plan.get("page") or SIN_DATO])
+        ws.append(["Filtros aplicados", _descripcion_filtros(plan)])
+        sin_traducir = _descripcion_sin_traducir(plan)
+        if sin_traducir:
+            ws.append(["FILTROS NO APLICADOS", sin_traducir])
+        if datos["truncated"]:
+            ws.append(["AVISO", f"Resultado truncado en {datos['row_count']} filas."])
+        ws.append([])
+        primera_fila_datos = ws.max_row + 1
+
+        columnas = exporting._unique_headers(datos["columns"]) or ["Sin columnas"]
+        ws.append(columnas)
+        for fila in datos["rows"]:
+            ws.append([exporting._json_cell(v) for v in fila])
+
+        ws["A1"].font = Font(bold=True, size=13, color="123047")
+        for celda in ws[primera_fila_datos]:
+            celda.fill, celda.font = acento, blanco
+            celda.alignment = Alignment(wrap_text=True, vertical="top")
+        ws.freeze_panes = f"A{primera_fila_datos + 1}"
+        for indice_col, nombre in enumerate(columnas, 1):
+            muestra = [str(nombre)] + [
+                str(f[indice_col - 1]) for f in datos["rows"][:200]
+                if indice_col - 1 < len(f) and f[indice_col - 1] is not None]
+            ancho = min(60, max(12, max((len(v) for v in muestra), default=12) + 2))
+            ws.column_dimensions[get_column_letter(indice_col)].width = ancho
+
+    wb.properties.title = "Contenido de Power BI"
+    wb.properties.creator = "Horizun PBI MCP"
+    buffer = io.BytesIO()
+    wb.save(buffer)
+    return buffer.getvalue()
+
+
+def _construir_pdf(planes: Sequence[Dict[str, Any]],
+                   omitidos: Sequence[Dict[str, Any]],
+                   avisos: Sequence[str], *, titulo: str,
+                   max_filas_pdf: int) -> bytes:
+    from reportlab.lib import colors
+    from reportlab.lib.enums import TA_CENTER
+    from reportlab.lib.pagesizes import A4, landscape
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import mm
+    from reportlab.platypus import (Paragraph, SimpleDocTemplate, Spacer, Table,
+                                    TableStyle)
+
+    page_size = landscape(A4)
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buffer, pagesize=page_size, rightMargin=14 * mm, leftMargin=14 * mm,
+        topMargin=16 * mm, bottomMargin=14 * mm,
+        title=exporting._pdf_text(titulo), author="Horizun PBI MCP")
+    estilos = getSampleStyleSheet()
+    estilos.add(ParagraphStyle(name="HzC", parent=estilos["Title"], fontSize=22,
+                               leading=26, alignment=TA_CENTER,
+                               textColor=colors.HexColor("#123047")))
+    estilos.add(ParagraphStyle(name="HzH", parent=estilos["Heading2"],
+                               textColor=colors.HexColor("#123047"),
+                               spaceBefore=10, spaceAfter=5))
+    estilos.add(ParagraphStyle(name="HzS", parent=estilos["BodyText"],
+                               fontSize=8.5, leading=11))
+    estilos.add(ParagraphStyle(name="HzHead", parent=estilos["HzS"],
+                               textColor=colors.white, fontName="Helvetica-Bold"))
+
+    historia: List[Any] = [
+        Paragraph(exporting._pdf_text(titulo), estilos["HzC"]),
+        Paragraph(exporting._pdf_text(
+            f"Generado {datetime.now(timezone.utc).isoformat()}"), estilos["HzS"]),
+        Spacer(1, 6 * mm)]
+
+    def tabla(filas: List[List[Any]], anchos: Optional[List[float]] = None) -> None:
+        formateadas = [[Paragraph(exporting._pdf_text(v),
+                                  estilos["HzHead"] if i == 0 else estilos["HzS"])
+                        for v in fila] for i, fila in enumerate(filas)]
+        obj = Table(formateadas, colWidths=anchos, repeatRows=1, hAlign="LEFT")
+        obj.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#123047")),
+            ("GRID", (0, 0), (-1, -1), 0.3, colors.HexColor("#B7C5CC")),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("ROWBACKGROUNDS", (0, 1), (-1, -1),
+             [colors.white, colors.HexColor("#F3F7F8")]),
+            ("LEFTPADDING", (0, 0), (-1, -1), 4),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+            ("TOPPADDING", (0, 0), (-1, -1), 3),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+        ]))
+        historia.append(obj)
+
+    for aviso in avisos:
+        historia.append(Paragraph("- " + exporting._pdf_text(aviso), estilos["HzS"]))
+
+    for plan in planes:
+        datos = plan["data"]
+        historia.append(Paragraph(exporting._pdf_text(plan.get("title")), estilos["HzH"]))
+        contexto = (f"Pagina: {plan.get('page') or '-'} | Filas: "
+                    f"{datos['row_count']}{' (truncado)' if datos['truncated'] else ''} "
+                    f"| Filtros: {_descripcion_filtros(plan)}")
+        historia.append(Paragraph(exporting._pdf_text(contexto), estilos["HzS"]))
+        sin_traducir = _descripcion_sin_traducir(plan)
+        if sin_traducir:
+            historia.append(Paragraph(exporting._pdf_text(
+                "FILTROS NO APLICADOS: " + sin_traducir), estilos["HzS"]))
+        historia.append(Spacer(1, 2 * mm))
+
+        columnas = list(datos["columns"]) or ["Sin columnas"]
+        filas = [columnas] + [list(f) for f in datos["rows"][:max_filas_pdf]]
+        ancho_util = page_size[0] - 28 * mm
+        tabla(filas, [ancho_util / max(1, len(columnas))] * len(columnas))
+        if datos["row_count"] > max_filas_pdf:
+            historia.append(Paragraph(exporting._pdf_text(
+                f"... {datos['row_count'] - max_filas_pdf} filas mas. El "
+                "archivo Excel las lleva todas."), estilos["HzS"]))
+
+    if omitidos:
+        historia.append(Paragraph("No exportado", estilos["HzH"]))
+        tabla([["Titulo", "Tipo", "Motivo"]] +
+              [[o.get("title"), o.get("visual_type"), o.get("reason")]
+               for o in omitidos])
+
+    doc.build(historia)
+    return buffer.getvalue()
+
+
+def export_content(session: Session, *, select: Dict[str, Any],
+                   format: str = "xlsx", dry_run: bool = False,
+                   auto_open: bool = True, max_rows: int = 100_000,
+                   max_rows_pdf: int = 40, title: str = "",
+                   file_name: str = "") -> Dict[str, Any]:
+    """Exporta el contenido que el cliente seleccione a Excel y/o PDF."""
+    formato = str(format or "xlsx").strip().lower()
+    if formato not in ("xlsx", "pdf", "both"):
+        raise ValidationError(
+            f"Formato '{format}' no admitido. Usa 'xlsx', 'pdf' o 'both'.",
+            details={"format": format})
+
+    resuelto = resolver_seleccion(session, select)
+    planes, omitidos = resuelto["plans"], resuelto["skipped"]
+
+    if dry_run:
+        return {
+            "dry_run": True, "queries": [
+                {"title": p.get("title"), "page": p.get("page"),
+                 "visual_id": p.get("visual_id"), "dax": p.get("dax"),
+                 "filters_applied": p.get("filters_applied") or p.get("filters"),
+                 "filters_untranslated": p.get("filters_untranslated") or []}
+                for p in planes],
+            "skipped": [{"title": o.get("title"), "visual_type": o.get("visual_type"),
+                         "reason": o.get("reason")} for o in omitidos],
+            "outputs": [], "warnings": [
+                "dry_run: no se consulto el motor ni se escribio ningun archivo."],
+        }
+
+    avisos = _asegurar_modelo(session, auto_open=auto_open)
+    for plan in planes:
+        plan["data"] = _ejecutar(session, plan, max_rows=max_rows)
+
+    usados: set = set()
+    for plan in planes:
+        plan["sheet"] = _nombre_de_hoja(plan, usados)
+
+    titulo = title.strip() or "Contenido del informe de Power BI"
+    salidas: List[Dict[str, Any]] = []
+
+    if formato in ("xlsx", "both"):
+        payload = _construir_excel(planes, omitidos, avisos)
+        destino = exporting._target("content", ".xlsx",
+                                    file_name if formato == "xlsx" else "")
+        from openpyxl import load_workbook
+        reabierto = load_workbook(io.BytesIO(payload), read_only=True)
+        esperadas = {"Contenido", *(p["sheet"] for p in planes)}
+        if not esperadas.issubset(set(reabierto.sheetnames)):
+            reabierto.close()
+            raise ValidationError("El Excel generado no conserva todas sus hojas.")
+        reabierto.close()
+        exporting._publish_new_file(destino, payload)
+        salidas.append({"format": "xlsx", "output_path": str(destino),
+                        "bytes": len(payload), "verified": True})
+
+    if formato in ("pdf", "both"):
+        payload = _construir_pdf(planes, omitidos, avisos, titulo=titulo,
+                                 max_filas_pdf=max_rows_pdf)
+        destino = exporting._target("content", ".pdf",
+                                    file_name if formato == "pdf" else "")
+        from pypdf import PdfReader
+        paginas = len(PdfReader(io.BytesIO(payload)).pages)
+        if paginas < 1:
+            raise ValidationError("El PDF generado no tiene paginas.")
+        exporting._publish_new_file(destino, payload)
+        salidas.append({"format": "pdf", "output_path": str(destino),
+                        "bytes": len(payload), "pages": paginas, "verified": True})
+
+    sin_traducir = sum(len(p.get("filters_untranslated") or []) for p in planes)
+    if sin_traducir:
+        avisos.append(
+            f"{sin_traducir} filtro(s) del informe no se pudieron aplicar; "
+            "estan declarados en cada hoja. Las cifras pueden no coincidir "
+            "con lo que se ve en pantalla.")
+
+    return {
+        "dry_run": False, "outputs": salidas,
+        "queries": [{"title": p["title"], "sheet": p.get("sheet"),
+                     "page": p.get("page"), "rows": p["data"]["row_count"],
+                     "truncated": p["data"]["truncated"], "dax": p["dax"],
+                     "filters_applied": p.get("filters_applied") or p.get("filters"),
+                     "filters_untranslated": p.get("filters_untranslated") or []}
+                    for p in planes],
+        "skipped": [{"title": o.get("title"), "visual_type": o.get("visual_type"),
+                     "reason": o.get("reason")} for o in omitidos],
+        "row_total": sum(p["data"]["row_count"] for p in planes),
+        "warnings": avisos,
+    }

--- a/src/horizun_pbi_mcp/services/content_query.py
+++ b/src/horizun_pbi_mcp/services/content_query.py
@@ -1,0 +1,362 @@
+"""La consulta que hay DETRAS de un visual, y la que el cliente declara.
+
+El .pbip no guarda datos: guarda que campos pide cada visual y en que rol.
+Para exportar el CONTENIDO hay que reconstruir la consulta y correrla contra
+el motor. Este modulo hace solo esa reconstruccion; ejecutar y escribir el
+archivo es de `content_export`.
+
+Dos reglas gobiernan todo lo de aqui:
+
+1. **Antes que adivinar, se declina.** Si una proyeccion usa una agregacion
+   que no se reconoce, o una jerarquia, el visual sale marcado como no
+   exportable con el motivo. Un numero equivocado en un Excel no se nota:
+   se firma.
+2. **Los filtros van DENTRO de `SUMMARIZECOLUMNS`.** DAX prohibe usar
+   `SUMMARIZECOLUMNS` en un contexto modificado por `CALCULATE`, asi que
+   envolverlo en `CALCULATETABLE` falla en el motor. Van como argumentos de
+   filtro, que es la forma que el motor acepta.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from horizun_pbi_mcp.logging_config import get_logger
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+
+log = get_logger("content_query")
+
+#: Codigo numerico de `Aggregation.Function` -> nombre. Solo los que se han
+#: visto escritos por Desktop y cuyo equivalente en DAX es inequivoco.
+_FUNCION_A_NOMBRE = {0: "sum", 1: "avg", 2: "min", 3: "max", 5: "countnonnull"}
+
+#: Nombre de agregacion -> funcion DAX. `CountNonNull` es `COUNTA` y no
+#: `COUNT`: `COUNT` solo cuenta numeros, y la columna puede ser de texto.
+_AGREGACION_A_DAX = {
+    "sum": "SUM", "avg": "AVERAGE", "average": "AVERAGE",
+    "min": "MIN", "max": "MAX", "countnonnull": "COUNTA",
+}
+
+#: `Sum(Tabla.Columna)` dentro de `queryRef`: es el nombre que escribio
+#: Desktop, y vale mas que el codigo numerico cuando los dos estan.
+_QUERYREF_AGREGADO = re.compile(r"^([A-Za-z]+)\(")
+
+
+def _partes(ref: str) -> Tuple[str, str]:
+    """`Tabla[Columna]` -> `('Tabla', 'Columna')`."""
+    texto = str(ref or "").strip()
+    if "[" not in texto or not texto.endswith("]"):
+        raise ValidationError(
+            f"Referencia de campo invalida: {ref!r}. Se espera 'Tabla[Columna]'.",
+            details={"field": ref})
+    tabla = texto[:texto.index("[")].strip()
+    columna = texto[texto.index("[") + 1:-1]
+    if not tabla or not columna:
+        raise ValidationError(f"Referencia de campo incompleta: {ref!r}.",
+                              details={"field": ref})
+    return tabla, columna
+
+
+def columna_dax(ref: str) -> str:
+    """`Tabla[Columna]` -> `'Tabla'[Columna]`, con las comillas escapadas."""
+    tabla, columna = _partes(ref)
+    return "'" + tabla.replace("'", "''") + "'[" + columna.replace("]", "]]") + "]"
+
+
+def medida_dax(nombre: str) -> str:
+    """Nombre de medida -> `[Medida]`. Acepta `Tabla[Medida]` y la desnuda."""
+    texto = str(nombre or "").strip()
+    if "[" in texto and texto.endswith("]"):
+        texto = texto[texto.index("[") + 1:-1]
+    if not texto:
+        raise ValidationError("Nombre de medida vacio.")
+    return "[" + texto.replace("]", "]]") + "]"
+
+
+def literal_dax(valor: Any) -> str:
+    """Valor de filtro -> literal DAX."""
+    if valor is None:
+        return "BLANK()"
+    if isinstance(valor, bool):
+        return "TRUE()" if valor else "FALSE()"
+    if isinstance(valor, (int, float)):
+        return repr(valor)
+    return '"' + str(valor).replace('"', '""') + '"'
+
+
+def _alias(texto: str, usados: set) -> str:
+    """Nombre de columna de salida, unico y sin comillas que rompan el DAX."""
+    base = str(texto or "Valor").replace('"', "'").strip() or "Valor"
+    candidato, n = base, 2
+    while candidato.lower() in usados:
+        candidato, n = f"{base} {n}", n + 1
+    usados.add(candidato.lower())
+    return candidato
+
+
+def filtro_dax(filtro: Dict[str, Any]) -> str:
+    """Filtro categorico traducido -> tabla de filtro para SUMMARIZECOLUMNS."""
+    referencia = filtro.get("field")
+    valores = list(filtro.get("values") or [])
+    if not referencia or not valores:
+        raise ValidationError(
+            "Un filtro necesita 'field' y al menos un valor.",
+            details={"filter": filtro})
+    columna = columna_dax(referencia)
+    lista = ", ".join(literal_dax(v) for v in valores)
+    condicion = f"{columna} IN {{{lista}}}"
+    if filtro.get("exclude"):
+        condicion = f"NOT ({condicion})"
+    # ALL() sobre la columna, no sobre la tabla: acotar la columna sin arrasar
+    # con el resto del contexto es justo lo que hace el panel de filtros.
+    return f"FILTER(ALL({columna}), {condicion})"
+
+
+def construir_dax(dimensiones: Sequence[str], medidas: Sequence[Dict[str, str]],
+                  filtros: Sequence[Dict[str, Any]] = (),
+                  *, top_n: Optional[int] = None,
+                  order_desc: bool = True) -> str:
+    """`EVALUATE SUMMARIZECOLUMNS(...)` con filtros, orden y tope.
+
+    `medidas`: [{'alias': 'Total', 'expr': '[Total]'}]. El alias es el titulo
+    de la columna en el archivo exportado.
+    """
+    if not dimensiones and not medidas:
+        raise ValidationError(
+            "Una consulta necesita al menos una dimension o una medida.")
+    partes: List[str] = [columna_dax(d) for d in dimensiones]
+    partes += [filtro_dax(f) for f in filtros]
+    for m in medidas:
+        partes.append(f'"{m["alias"]}", {m["expr"]}')
+    consulta = "SUMMARIZECOLUMNS(\n    " + ",\n    ".join(partes) + "\n)"
+
+    if top_n:
+        # La medida de existencia no sirve como criterio: vale 1 en todas las
+        # filas y el corte quedaria al azar.
+        reales = [m for m in medidas if not m.get("aux")]
+        if not reales:
+            raise ValidationError(
+                "`top_n` necesita una medida por la cual ordenar el corte.")
+        criterio = f'[{reales[0]["alias"]}]'
+        consulta = (f"TOPN({int(top_n)}, {consulta}, {criterio}, "
+                    f"{'DESC' if order_desc else 'ASC'})")
+
+    orden = ""
+    if dimensiones:
+        orden = "\nORDER BY " + ", ".join(columna_dax(d) for d in dimensiones)
+    elif top_n:
+        orden = f"\nORDER BY {criterio} " + ("DESC" if order_desc else "ASC")
+    return f"EVALUATE\n{consulta}{orden}"
+
+
+#: Alias de la medida auxiliar que fuerza la relacion. Se quita del archivo
+#: antes de entregarlo: es andamiaje, no un dato del cliente.
+ALIAS_EXISTENCIA = "__existe"
+
+
+def tabla_de_hechos(tablas: Sequence[str],
+                    relaciones: Sequence[Dict[str, Any]]) -> Optional[str]:
+    """La tabla del lado MUCHOS de la que cuelgan todas las demas.
+
+    En una relacion de Power BI el lado `from` es el de muchos. Si desde una
+    de las tablas implicadas se llega a todas las otras siguiendo aristas
+    muchos -> uno, esa es la que define que combinaciones existen.
+    """
+    involucradas = [t for t in dict.fromkeys(tablas) if t]
+    if len(involucradas) < 2:
+        return involucradas[0] if involucradas else None
+
+    aristas: Dict[str, set] = {}
+    for r in relaciones or []:
+        if not r.get("is_active", True):
+            continue
+        origen, destino = r.get("from_table"), r.get("to_table")
+        if origen and destino:
+            aristas.setdefault(origen, set()).add(destino)
+
+    def alcanzables(inicio: str) -> set:
+        vistas, pila = {inicio}, [inicio]
+        while pila:
+            for siguiente in aristas.get(pila.pop(), ()):
+                if siguiente not in vistas:
+                    vistas.add(siguiente)
+                    pila.append(siguiente)
+        return vistas
+
+    candidatas = [t for t in involucradas
+                  if set(involucradas).issubset(alcanzables(t))]
+    # Si hay dos, el modelo tiene un ciclo o relaciones bidireccionales: no se
+    # elige una por sorteo, se declina mas arriba.
+    return candidatas[0] if len(candidatas) == 1 else None
+
+
+def _tablas_de(referencias: Sequence[str]) -> List[str]:
+    return [_partes(r)[0] for r in referencias]
+
+
+def _medida_de_existencia(tabla: str) -> Dict[str, str]:
+    """Fuerza a `SUMMARIZECOLUMNS` a respetar la relacion.
+
+    Sin una medida que apunte al lado de muchos, `SUMMARIZECOLUMNS` CRUZA las
+    columnas de tablas distintas: 20 riesgos por 20 medidas dan 400 filas
+    donde el visual muestra 20. Comprobado contra el motor.
+    """
+    return {"alias": ALIAS_EXISTENCIA,
+            "expr": f"CALCULATE(COUNTROWS({_tabla_dax(tabla)}))", "aux": True}
+
+
+def _tabla_dax(tabla: str) -> str:
+    return "'" + str(tabla).replace("'", "''") + "'"
+
+
+def _resolver_cruce(dimensiones: Sequence[str], medidas: List[Dict[str, str]],
+                    relaciones: Sequence[Dict[str, Any]]
+                    ) -> Tuple[List[Dict[str, str]], Optional[str]]:
+    """Anade la medida de existencia si las columnas cruzan tablas."""
+    tablas = list(dict.fromkeys(_tablas_de(dimensiones)))
+    if len(tablas) < 2:
+        return medidas, None
+    hechos = tabla_de_hechos(tablas, relaciones)
+    if not hechos:
+        return medidas, (
+            "Las columnas vienen de las tablas " + ", ".join(tablas) +
+            ", y no hay una sola tabla de hechos de la que cuelguen todas. "
+            "Sin eso el resultado seria un producto cartesiano, con mas filas "
+            "de las que muestra el visual.")
+    return list(medidas) + [_medida_de_existencia(hechos)], None
+
+
+def _agregacion_de(proyeccion: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+    """Nombre de la agregacion de una proyeccion, y el motivo si no se sabe."""
+    referencia = str(proyeccion.get("queryRef") or "")
+    coincidencia = _QUERYREF_AGREGADO.match(referencia)
+    nombre_ref = coincidencia.group(1).lower() if coincidencia else None
+    nombre_codigo = _FUNCION_A_NOMBRE.get(proyeccion.get("aggregation"))
+
+    # El nombre que escribio Desktop manda; el codigo solo confirma. Si los
+    # dos estan y no coinciden, no se elige: se declina.
+    if nombre_ref and nombre_codigo and nombre_ref != nombre_codigo:
+        return None, (f"La proyeccion dice '{nombre_ref}' en queryRef y "
+                      f"'{nombre_codigo}' en el codigo de agregacion.")
+    nombre = nombre_ref or nombre_codigo
+    if not nombre:
+        return None, (f"Agregacion desconocida (codigo "
+                      f"{proyeccion.get('aggregation')!r}).")
+    if nombre not in _AGREGACION_A_DAX:
+        return None, f"Agregacion '{nombre}' sin equivalente exacto en DAX."
+    return nombre, None
+
+
+def plan_de_visual(visual: Dict[str, Any],
+                   filtros: Sequence[Dict[str, Any]] = (),
+                   relaciones: Sequence[Dict[str, Any]] = ()) -> Dict[str, Any]:
+    """Convierte un visual leido del PBIR en un plan de consulta.
+
+    Devuelve siempre un plan; si no es exportable, `exportable` es False y
+    `reason` dice por que. Nunca devuelve una consulta a medias.
+    """
+    plan: Dict[str, Any] = {
+        "visual_id": visual.get("id"), "visual_type": visual.get("type"),
+        "title": visual.get("title") or visual.get("id"),
+        "dimensions": [], "measures": [], "filters": list(filtros),
+        "exportable": False, "reason": None, "dax": None,
+    }
+    roles = visual.get("fields") or {}
+    if not roles:
+        plan["reason"] = ("El visual no consulta datos (no tiene campos): "
+                          "cuadro de texto, imagen o forma.")
+        return plan
+
+    usados: set = set()
+    dimensiones: List[str] = []
+    medidas: List[Dict[str, str]] = []
+    for rol, proyecciones in roles.items():
+        for proyeccion in proyecciones or []:
+            tipo = proyeccion.get("kind")
+            referencia = proyeccion.get("ref")
+            if tipo == "measure" and referencia:
+                medidas.append({"alias": _alias(
+                    proyeccion.get("nativeQueryRef") or
+                    _partes_medida(referencia), usados),
+                    "expr": medida_dax(referencia), "role": rol})
+            elif tipo == "column" and referencia and proyeccion.get("aggregation") is not None:
+                nombre, motivo = _agregacion_de(proyeccion)
+                if not nombre:
+                    plan["reason"] = f"{motivo} Campo: {referencia}."
+                    return plan
+                medidas.append({"alias": _alias(
+                    proyeccion.get("nativeQueryRef") or
+                    f"{nombre.upper()} de {referencia}", usados),
+                    "expr": f"{_AGREGACION_A_DAX[nombre]}({columna_dax(referencia)})",
+                    "role": rol})
+            elif tipo == "column" and referencia:
+                if referencia not in dimensiones:
+                    dimensiones.append(referencia)
+            else:
+                plan["reason"] = (
+                    f"El campo de rol '{rol}' es de tipo '{tipo}' y no se "
+                    "sabe llevar a una consulta tabular (jerarquias y "
+                    "expresiones a medida quedan fuera).")
+                return plan
+
+    if not dimensiones and not medidas:
+        plan["reason"] = "El visual no proyecta ni columnas ni medidas."
+        return plan
+
+    medidas, motivo = _resolver_cruce(dimensiones, medidas, relaciones)
+    if motivo:
+        plan["reason"] = motivo
+        return plan
+
+    plan["dimensions"] = dimensiones
+    plan["measures"] = medidas
+    plan["dax"] = construir_dax(dimensiones, medidas, filtros)
+    plan["exportable"] = True
+    return plan
+
+
+def _partes_medida(referencia: str) -> str:
+    texto = str(referencia)
+    return texto[texto.index("[") + 1:-1] if "[" in texto and texto.endswith("]") else texto
+
+
+def plan_declarado(spec: Dict[str, Any],
+                   relaciones: Sequence[Dict[str, Any]] = ()) -> Dict[str, Any]:
+    """Plan a partir de lo que el cliente pide, sin referirse a un visual.
+
+    `spec`: {name, rows: ['Tabla[Columna]'], values: ['Medida'],
+             filters: [{field, values, exclude?}], top_n?, order_desc?}
+    """
+    if not isinstance(spec, dict):
+        raise ValidationError("Cada consulta declarada debe ser un objeto.",
+                              details={"query": spec})
+    filas = [str(r) for r in (spec.get("rows") or []) if str(r).strip()]
+    usados: set = set()
+    medidas = [{"alias": _alias(_partes_medida(v), usados),
+                "expr": medida_dax(v)}
+               for v in (spec.get("values") or []) if str(v).strip()]
+    if not filas and not medidas:
+        raise ValidationError(
+            "Una consulta declarada necesita 'rows' o 'values'.",
+            details={"query": spec})
+
+    filtros = []
+    for f in spec.get("filters") or []:
+        if not isinstance(f, dict) or not f.get("field"):
+            raise ValidationError(
+                "Cada filtro necesita 'field' y 'values'.", details={"filter": f})
+        filtros.append({"field": f["field"], "values": list(f.get("values") or []),
+                        "exclude": bool(f.get("exclude")), "state": "applied",
+                        "scope": "declarado"})
+
+    medidas, motivo = _resolver_cruce(filas, medidas, relaciones)
+    if motivo:
+        raise ValidationError(motivo, details={"query": spec.get("name")})
+
+    nombre = str(spec.get("name") or "").strip() or "Consulta"
+    return {"visual_id": None, "visual_type": "declarado", "title": nombre,
+            "dimensions": filas, "measures": medidas, "filters": filtros,
+            "exportable": True, "reason": None,
+            "dax": construir_dax(filas, medidas, filtros,
+                                 top_n=spec.get("top_n"),
+                                 order_desc=bool(spec.get("order_desc", True)))}

--- a/src/horizun_pbi_mcp/services/exporting.py
+++ b/src/horizun_pbi_mcp/services/exporting.py
@@ -438,6 +438,90 @@ def _pdf_text(value: Any, limit: int = 500) -> str:
     return html.escape(encoded, quote=False)
 
 
+# Los hallazgos de `report_audit`/`model_audit` identifican SIEMPRE su objeto
+# en `object`, nunca en el texto. Un PDF que solo imprime regla y evidencia
+# deja siete filas identicas de `measure_possibly_unused` sin decir que medida
+# es. Estas dos funciones son las que hacen accionable la tabla de hallazgos.
+_MAX_IDS_VISUALES = 4
+_ETIQUETA_OBJETO = {
+    "model": "Modelo", "report": "Informe", "table": "Tabla",
+    "column": "Columna", "measure": "Medida", "relationship": "Relacion",
+    "page": "Pagina", "visual": "Visual", "visual_pair": "Visuales",
+    "visual_group": "Visuales",
+}
+
+
+def _finding_object_label(objeto: Any,
+                          page_names: Optional[Dict[str, str]] = None) -> str:
+    """Nombre humano del objeto de un hallazgo: 'Medida Total (Ventas)'."""
+    if not isinstance(objeto, dict) or not objeto:
+        return ""
+    kind = str(objeto.get("kind") or "")
+    partes = [_ETIQUETA_OBJETO.get(kind, kind.replace("_", " ")).strip()]
+
+    nombre = objeto.get("name")
+    if kind in ("visual", "visual_pair", "visual_group"):
+        ids = objeto.get("visuals") or ([objeto["id"]] if objeto.get("id") else [])
+        tipo = objeto.get("type")
+        if tipo:
+            partes.append(str(tipo))
+        if ids:
+            # Un grupo puede traer los trece visuales de la pagina: la celda
+            # crece hasta comerse la fila. El Excel conserva la lista entera.
+            visibles = [str(i) for i in ids[:_MAX_IDS_VISUALES]]
+            if len(ids) > _MAX_IDS_VISUALES:
+                visibles.append(f"(+{len(ids) - _MAX_IDS_VISUALES} mas)")
+            partes.append(", ".join(visibles))
+    elif kind == "relationship" and not nombre:
+        origen, destino = objeto.get("from"), objeto.get("to")
+        if origen or destino:
+            partes.append(f"{origen or '?'} -> {destino or '?'}")
+    elif nombre:
+        partes.append(str(nombre))
+
+    if kind == "measure" and objeto.get("table"):
+        partes.append(f"({objeto['table']})")
+
+    # `page` es el id interno de la pagina; se traduce al nombre visible.
+    pagina = objeto.get("page")
+    if pagina and kind != "page":
+        visible = (page_names or {}).get(str(pagina)) or str(pagina)
+        partes.append(f"- pagina {visible}")
+    elif kind == "page":
+        visible = nombre or (page_names or {}).get(str(pagina or "")) or pagina
+        if visible and not nombre:
+            partes.append(str(visible))
+
+    return " ".join(p for p in partes if p).strip()
+
+
+def _finding_message(finding: Dict[str, Any]) -> str:
+    """Texto del hallazgo. Sin `message`, la evidencia se lee como pares.
+
+    Los motores de auditoria no producen `message`: solo `evidence`, que es un
+    dict. Volcarlo como JSON deja `{"visual_count": 13}` en un reporte que lee
+    una persona. Aqui se aplana a `visual_count: 13`, sin inventar prosa.
+    """
+    directo = finding.get("message") or finding.get("summary")
+    if isinstance(directo, str) and directo.strip():
+        return directo
+    evidencia = finding.get("evidence")
+    if not isinstance(evidencia, dict):
+        return "" if evidencia in (None, {}, []) else str(evidencia)
+    pares = []
+    for clave, valor in evidencia.items():
+        if valor is None:
+            valor = "(vacio)"
+        elif isinstance(valor, bool):        # antes de int: bool es int
+            valor = "si" if valor else "no"
+        elif isinstance(valor, (list, tuple)):
+            valor = ", ".join(str(v) for v in valor)
+        elif isinstance(valor, dict):
+            valor = json.dumps(valor, ensure_ascii=False, default=str)
+        pares.append(f"{clave}: {valor}")
+    return "; ".join(pares)
+
+
 def _capture_files(capture_paths: Optional[Sequence[str]]) -> List[Path]:
     paths: List[Path] = []
     for raw in list(capture_paths or []):
@@ -745,15 +829,20 @@ def generate_pdf_report(session: Session, *, report_type: str = "executive",
                         context.audit.get("hallazgos") or [])[:max_findings]
         section("Hallazgos de auditoria")
         if findings:
-            finding_rows = [["Severidad", "Regla", "Hallazgo", "Recomendacion"]]
+            page_names = {str(p.get("name")): (p.get("display_name") or
+                                               p.get("name"))
+                          for p in context.pages}
+            finding_rows = [["Severidad", "Regla", "Objeto", "Hallazgo",
+                             "Recomendacion"]]
             for finding in findings:
                 finding_rows.append([
                     finding.get("severity"), finding.get("rule") or finding.get("id"),
-                    finding.get("message") or finding.get("summary") or
-                    finding.get("evidence"), finding.get("recommendation")])
+                    _finding_object_label(finding.get("object"), page_names),
+                    _finding_message(finding), finding.get("recommendation")])
             available = page_size[0] - 32 * mm
-            table(finding_rows, [24 * mm, 40 * mm, available * 0.38,
-                                 available - 64 * mm - available * 0.38])
+            resto = available - 54 * mm
+            table(finding_rows, [20 * mm, 34 * mm, resto * 0.30, resto * 0.30,
+                                 resto * 0.40])
         else:
             story.append(Paragraph("No se registraron hallazgos.", styles["BodyText"]))
 

--- a/src/horizun_pbi_mcp/services/report_audit.py
+++ b/src/horizun_pbi_mcp/services/report_audit.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import html as html_mod
 import json
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from horizun_pbi_mcp.config import ActivePbip
@@ -27,6 +28,105 @@ def _h(rule: str, severity: str, objeto: Dict[str, Any], evidencia: Dict[str, An
     return {"rule": rule, "severity": severity, "domain": "report",
             "object": objeto, "evidence": evidencia,
             "recommendation": recomendacion, "auto_fix_available": auto_fix}
+
+
+#: Alto minimo de un slicer, en px. Depende de si la cabecera esta visible:
+#: con ella, 28 + selector 32 + relleno 8/8 = 76; sin ella, 32 + 16 = 48.
+#:
+#: Las dos cifras estan MEDIDAS contra el CLI oficial, no deducidas: se le
+#: paso el mismo informe variando el alto y se busco donde deja de quejarse.
+#: Con cabecera, 74 falla y 76 pasa; sin cabecera, 47 falla y 48 pasa. La
+#: primera version de esta regla usaba 76 siempre y marcaba como rotos nueve
+#: slicers sanos que ocultaban su cabecera.
+ALTO_MINIMO_SLICER = 76
+ALTO_MINIMO_SLICER_SIN_CABECERA = 48
+
+#: Roles de eje de un scatter. Si hay campo en Detalles, estos DEBEN venir
+#: agregados o Power BI no dibuja la nube de puntos.
+_EJES_SCATTER = ("X", "Y")
+
+
+def _propiedad_de_objeto(datos: Dict[str, Any], grupo: str,
+                         propiedad: str) -> Optional[str]:
+    """Valor literal de `visual.objects.<grupo>.<propiedad>`, si esta."""
+    try:
+        for entrada in datos["visual"]["objects"][grupo]:
+            valor = entrada["properties"][propiedad]["expr"]["Literal"]["Value"]
+            return str(valor).strip("'")
+    except (KeyError, IndexError, TypeError):
+        return None
+    return None
+
+
+def _formato_de_slicer(visual: Dict[str, Any]) -> Dict[str, Any]:
+    """Modo y visibilidad de la cabecera, leidos del bloque `objects`.
+
+    `read_visual_file` no devuelve `objects` -no lo necesita nadie mas-, asi
+    que se relee el JSON. Es un archivo ya en disco y son pocos.
+    """
+    vacio = {"mode": None, "header": True}
+    ruta = visual.get("file")
+    if not ruta:
+        return vacio
+    from horizun_pbi_mcp.utils.json_utils import read_json
+
+    try:
+        datos = read_json(Path(ruta))
+    except Exception:                          # noqa: BLE001 - visual ilegible
+        return vacio
+    cabecera = _propiedad_de_objeto(datos, "header", "show")
+    return {"mode": _propiedad_de_objeto(datos, "data", "mode"),
+            # Sin la propiedad, la cabecera se muestra: es el valor por defecto.
+            "header": cabecera is None or cabecera.casefold() != "false"}
+
+
+def _visual_no_renderiza(visual: Dict[str, Any], pid: str) -> List[Dict[str, Any]]:
+    """Configuraciones que dejan al visual con un cartel en vez de datos."""
+    hallazgos: List[Dict[str, Any]] = []
+    tipo = visual.get("type")
+    roles = visual.get("fields") or {}
+    objeto = {"kind": "visual", "page": pid, "id": visual.get("id"),
+              "type": tipo}
+
+    if tipo == "scatterChart" and (roles.get("Category") or roles.get("Series")):
+        sin_agregar = [
+            p.get("ref") for eje in _EJES_SCATTER
+            for p in roles.get(eje) or []
+            if p.get("kind") == "column" and p.get("aggregation") is None]
+        if sin_agregar:
+            hallazgos.append(_h(
+                "report_scatter_axis_not_aggregated", ERROR, objeto,
+                {"fields": [r for r in sin_agregar if r],
+                 "has_details": bool(roles.get("Category"))},
+                "Con un campo en Detalles, Power BI exige que X e Y esten "
+                "resumidos: sin eso NO dibuja el visual y muestra 'Quite los "
+                "valores para mostrar los pares del eje X y el eje Y'. Pon un "
+                "resumen (promedio o suma) en esos campos, o quita Detalles."))
+
+    if tipo == "slicer":
+        alto = float((visual.get("position") or {}).get("height") or 0)
+        formato = _formato_de_slicer(visual)
+        con_cabecera = formato["header"]
+        piso = (ALTO_MINIMO_SLICER if con_cabecera
+                else ALTO_MINIMO_SLICER_SIN_CABECERA)
+        if 0 < alto < piso:
+            modo = formato["mode"]
+            desplegable = (modo or "").casefold() == "dropdown"
+            desglose = ("cabecera 28 + selector 32 + relleno 8/8"
+                        if con_cabecera else
+                        "selector 32 + relleno 8/8, sin cabecera")
+            hallazgos.append(_h(
+                "report_slicer_below_height_floor", ERROR, objeto,
+                {"height": alto, "minimum": piso, "header_shown": con_cabecera,
+                 "mode": modo or "lista (por defecto)"},
+                f"Un slicer con este formato necesita {piso} px ({desglose}). "
+                f"Con {alto:.0f} " + ("se recorta." if desplegable else
+                                      "solo se ve un elemento y una barra de "
+                                      "scroll.")
+                + " Sube el alto y, si aun no lo es, ponlo desplegable "
+                  "(`data.mode = 'Dropdown'`)."))
+
+    return hallazgos
 
 
 def audit_report(active: ActivePbip,
@@ -69,6 +169,14 @@ def audit_report(active: ActivePbip,
                     {"title": None},
                     "Un visual sin titulo obliga a adivinar que muestra. "
                     "Ponle uno descriptivo.", auto_fix=True))
+
+        # --- visuales que Power BI se NIEGA a dibujar ---------------------
+        # No es lo mismo un visual feo que uno en error: estos dos salen con
+        # un cartel en vez de contenido, y ni el esquema PBIR ni el DAX que
+        # generan delatan nada. Solo se veian abriendo el informe.
+        for v in visuales:
+            for hallazgo in _visual_no_renderiza(v, pid):
+                hallazgos.append(hallazgo)
 
         # --- referencias rotas -------------------------------------------
         if indice is not None:

--- a/src/horizun_pbi_mcp/tools/export_tools.py
+++ b/src/horizun_pbi_mcp/tools/export_tools.py
@@ -4,11 +4,49 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from horizun_pbi_mcp.config import get_session
-from horizun_pbi_mcp.services import exporting, sharepoint
+from horizun_pbi_mcp.services import content_export, exporting, sharepoint
 from horizun_pbi_mcp.tools._common import guard
 
 
 def register(mcp) -> None:
+    @mcp.tool()
+    def pbi_export_report_content(
+            select: Dict[str, Any], format: str = "xlsx",
+            dry_run: bool = False, auto_open: bool = True,
+            max_rows: int = 100_000, max_rows_pdf: int = 40,
+            title: str = "", file_name: str = "") -> Dict[str, Any]:
+        """Exporta el CONTENIDO del informe: los datos que muestra el tablero.
+
+        A diferencia de `pbi_export_excel` y `pbi_generate_pdf_report`, que
+        documentan el proyecto, esto exporta lo que el cliente ve. `select`
+        admite tres formas, combinables:
+
+        - `pages`: ["Matriz de Riesgos"] -> la tabla que hay detras de CADA
+          visual de esas paginas (por nombre visible o id interno).
+        - `visuals`: ["15b0fc11e628..."] -> solo esos visuales.
+        - `queries`: [{name, rows:["Tabla[Columna]"], values:["Medida"],
+          filters:[{field, values, exclude?}], top_n?}] -> lo que el cliente
+          declare, sin referirse a ningun visual.
+
+        Cada consulta se reconstruye a partir de los campos del visual, se
+        ejecuta en SOLO LECTURA contra el modelo en vivo y sale como una hoja
+        de Excel (`format`: `xlsx|pdf|both`).
+
+        Necesita el modelo en vivo: los datos solo existen en el motor, no en
+        el .pbip. Con `auto_open` abre el informe en Desktop si hace falta, y
+        se NIEGA a exportar si el modelo esta abierto pero sin procesar, en
+        vez de publicar un archivo en blanco. Con `dry_run` devuelve el DAX
+        que ejecutaria sin tocar el motor ni escribir nada.
+
+        Cada hoja declara con que filtros se saco y, sobre todo, cuales no se
+        pudieron aplicar. Los visuales sin consulta tabular -textos, imagenes,
+        formas- se listan aparte con el motivo.
+        """
+        return guard(lambda: content_export.export_content(
+            get_session(), select=select, format=format, dry_run=dry_run,
+            auto_open=auto_open, max_rows=max_rows, max_rows_pdf=max_rows_pdf,
+            title=title, file_name=file_name))
+
     @mcp.tool()
     def pbi_export_excel(source: str = "auto", query: str = "",
                          include_report: bool = True,

--- a/src/horizun_pbi_mcp/tools/risk.py
+++ b/src/horizun_pbi_mcp/tools/risk.py
@@ -148,6 +148,7 @@ RISK_BY_TOOL: Dict[str, str] = {
     "pbi_profile_data": READ_ONLY_EMITS_FILE,
     "pbi_run_dax": READ_ONLY_EMITS_FILE,
     "pbi_export_excel": READ_ONLY_EMITS_FILE,
+    "pbi_export_report_content": READ_ONLY_EMITS_FILE,
     "pbi_generate_pdf_report": READ_ONLY_EMITS_FILE,
 
     # -- SharePoint / Microsoft Graph --

--- a/tests/golden/tools_v1.json
+++ b/tests/golden/tools_v1.json
@@ -1,6 +1,6 @@
 {
   "contract_version": 1,
-  "tool_count": 132,
+  "tool_count": 133,
   "tools": [
     {
       "name": "pbi_add_custom_visual",
@@ -2482,6 +2482,69 @@
       },
       "required": [
         "page"
+      ],
+      "output_shape": {
+        "type": "object",
+        "properties": [
+          "result"
+        ],
+        "required": [
+          "result"
+        ]
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      }
+    },
+    {
+      "name": "pbi_export_report_content",
+      "description": "Exporta el CONTENIDO del informe: los datos que muestra el tablero.\n\nA diferencia de `pbi_export_excel` y `pbi_generate_pdf_report`, que\ndocumentan el proyecto, esto exporta lo que el cliente ve. `select`\nadmite tres formas, combinables:\n\n- `pages`: [\"Matriz de Riesgos\"] -> la tabla que hay detras de CADA\n  visual de esas paginas (por nombre visible o id interno).\n- `visuals`: [\"15b0fc11e628...\"] -> solo esos visuales.\n- `queries`: [{name, rows:[\"Tabla[Columna]\"], values:[\"Medida\"],\n  filters:[{field, values, exclude?}], top_n?}] -> lo que el cliente\n  declare, sin referirse a ningun visual.\n\nCada consulta se reconstruye a partir de los campos del visual, se\nejecuta en SOLO LECTURA contra el modelo en vivo y sale como una hoja\nde Excel (`format`: `xlsx|pdf|both`).\n\nNecesita el modelo en vivo: los datos solo existen en el motor, no en\nel .pbip. Con `auto_open` abre el informe en Desktop si hace falta, y\nse NIEGA a exportar si el modelo esta abierto pero sin procesar, en\nvez de publicar un archivo en blanco. Con `dry_run` devuelve el DAX\nque ejecutaria sin tocar el motor ni escribir nada.\n\nCada hoja declara con que filtros se saco y, sobre todo, cuales no se\npudieron aplicar. Los visuales sin consulta tabular -textos, imagenes,\nformas- se listan aparte con el motivo.",
+      "params": {
+        "auto_open": {
+          "required": false,
+          "type": "boolean",
+          "default": true
+        },
+        "dry_run": {
+          "required": false,
+          "type": "boolean",
+          "default": false
+        },
+        "file_name": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        },
+        "format": {
+          "required": false,
+          "type": "string",
+          "default": "xlsx"
+        },
+        "max_rows": {
+          "required": false,
+          "type": "integer",
+          "default": 100000
+        },
+        "max_rows_pdf": {
+          "required": false,
+          "type": "integer",
+          "default": 40
+        },
+        "select": {
+          "required": true,
+          "type": "object"
+        },
+        "title": {
+          "required": false,
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "select"
       ],
       "output_shape": {
         "type": "object",

--- a/tests/test_content_export.py
+++ b/tests/test_content_export.py
@@ -1,0 +1,349 @@
+"""Export del CONTENIDO: reconstruccion de la consulta y verdad del dato."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from horizun_pbi_mcp.pbip import filter_builder, filter_reader, project_locator
+from horizun_pbi_mcp.powerbi import dax_runner
+from horizun_pbi_mcp.powerbi.errors import ValidationError
+from horizun_pbi_mcp.services import content_export, content_query
+
+# --- relaciones de juguete: Medidas (muchos) -> Riesgos (uno) ---------------
+RELACIONES = [{"name": "r1", "from_table": "Medidas", "from_column": "ID",
+               "to_table": "Riesgos", "to_column": "ID", "is_active": True}]
+
+
+def _proyeccion_columna(entidad, propiedad, **extra):
+    return {"kind": "column", "entity": entidad, "property": propiedad,
+            "ref": f"{entidad}[{propiedad}]", **extra}
+
+
+def _proyeccion_medida(entidad, nombre, **extra):
+    return {"kind": "measure", "entity": entidad, "property": nombre,
+            "ref": f"{entidad}[{nombre}]", **extra}
+
+
+# ===========================================================================
+# Lectura de filtros
+# ===========================================================================
+
+def test_filtro_categorico_se_traduce_con_sus_valores():
+    entrada = filter_builder.build_filter(
+        {"field": "Riesgos[Estado]", "values": ["Abierto", "En curso"]})
+    leido = filter_reader.leer_filtro(entrada, scope="pagina")
+
+    assert leido["state"] == "applied"
+    assert leido["field"] == "Riesgos[Estado]"
+    assert leido["values"] == ["Abierto", "En curso"]
+    assert leido["exclude"] is False
+
+
+def test_filtro_de_exclusion_conserva_el_signo():
+    entrada = filter_builder.build_filter(
+        {"field": "Riesgos[Estado]", "values": ["Cerrado"], "exclude": True})
+    leido = filter_reader.leer_filtro(entrada, scope="visual")
+
+    assert leido["state"] == "applied" and leido["exclude"] is True
+
+
+def test_campo_en_el_panel_sin_seleccion_no_es_un_filtro():
+    entrada = filter_builder.build_filter({"field": "Riesgos[Estado]"})
+    assert filter_reader.leer_filtro(entrada, scope="pagina")["state"] == "unset"
+
+
+def test_filtro_sobre_medida_no_se_traduce():
+    entrada = {"field": {"Measure": {"Expression": {"SourceRef": {"Entity": "M"}},
+                                     "Property": "Total"}},
+               "type": "Advanced", "filter": {"Where": [{"Condition": {}}]}}
+    leido = filter_reader.leer_filtro(entrada, scope="visual")
+
+    assert leido["state"] == "untranslated"
+    assert "medida" in leido["reason"]
+
+
+def test_in_sobre_dos_columnas_no_equivale_a_una_lista():
+    campo = {"Column": {"Expression": {"SourceRef": {"Source": "r"}},
+                        "Property": "Estado"}}
+    entrada = {"field": {"Column": {"Expression": {"SourceRef": {"Entity": "Riesgos"}},
+                                    "Property": "Estado"}},
+               "type": "Categorical",
+               "filter": {"Where": [{"Condition": {"In": {
+                   "Expressions": [campo, campo],
+                   "Values": [[{"Literal": {"Value": "'a'"}},
+                               {"Literal": {"Value": "'b'"}}]]}}}]}}
+    assert filter_reader.leer_filtro(entrada, scope="visual")["state"] == "untranslated"
+
+
+def test_literales_vuelven_a_su_tipo():
+    assert filter_reader._parse_literal("'Ana''s'") == "Ana's"
+    assert filter_reader._parse_literal("5L") == 5
+    assert filter_reader._parse_literal("true") is True
+    assert filter_reader._parse_literal("null") is None
+
+
+def test_resumen_marca_como_no_fiable_lo_que_no_se_tradujo():
+    filtros = [{"state": "applied"}, {"state": "untranslated"}]
+    assert filter_reader.resumen(filtros)["trustworthy"] is False
+    assert filter_reader.resumen([{"state": "applied"}])["trustworthy"] is True
+
+
+# ===========================================================================
+# Sintesis de la consulta
+# ===========================================================================
+
+def test_referencias_escapan_comillas_y_corchetes():
+    assert content_query.columna_dax("O'Brien[Col]") == "'O''Brien'[Col]"
+    assert content_query.medida_dax("Ventas[Total]") == "[Total]"
+
+
+def test_los_filtros_van_dentro_de_summarizecolumns():
+    dax = content_query.construir_dax(
+        ["Riesgos[Estado]"], [{"alias": "Total", "expr": "[Total]"}],
+        [{"field": "Riesgos[Fase]", "values": ["Obra"]}])
+
+    assert dax.startswith("EVALUATE")
+    assert "FILTER(ALL('Riesgos'[Fase])" in dax
+    # DAX prohibe SUMMARIZECOLUMNS dentro de un contexto modificado por
+    # CALCULATE: envolverlo en CALCULATETABLE falla en el motor.
+    assert "CALCULATETABLE" not in dax
+
+
+def test_la_tabla_de_hechos_es_la_del_lado_muchos():
+    assert content_query.tabla_de_hechos(["Riesgos", "Medidas"], RELACIONES) == "Medidas"
+    assert content_query.tabla_de_hechos(["Medidas"], RELACIONES) == "Medidas"
+
+
+def test_sin_tabla_de_hechos_no_se_exporta_un_producto_cartesiano():
+    visual = {"id": "v1", "type": "tableEx", "title": "Cruce",
+              "fields": {"Rows": [_proyeccion_columna("A", "X"),
+                                  _proyeccion_columna("B", "Y")]}}
+    plan = content_query.plan_de_visual(visual, (), [])
+
+    assert plan["exportable"] is False
+    assert "producto cartesiano" in plan["reason"]
+
+
+def test_columnas_de_dos_tablas_agregan_la_medida_de_existencia():
+    visual = {"id": "v1", "type": "tableEx", "title": "Plan",
+              "fields": {"Rows": [_proyeccion_columna("Riesgos", "ID"),
+                                  _proyeccion_columna("Medidas", "Accion")]}}
+    plan = content_query.plan_de_visual(visual, (), RELACIONES)
+
+    assert plan["exportable"] is True
+    aux = [m for m in plan["measures"] if m.get("aux")]
+    assert len(aux) == 1
+    # Comprobado contra el motor: sin esto son 400 filas donde el visual
+    # muestra 20.
+    assert aux[0]["expr"] == "CALCULATE(COUNTROWS('Medidas'))"
+    assert content_query.ALIAS_EXISTENCIA in plan["dax"]
+
+
+def test_una_sola_tabla_no_necesita_andamiaje():
+    visual = {"id": "v1", "type": "barChart", "title": "Por fase",
+              "fields": {"Category": [_proyeccion_columna("Riesgos", "Fase")],
+                         "Y": [_proyeccion_medida("Riesgos", "Total")]}}
+    plan = content_query.plan_de_visual(visual, (), RELACIONES)
+
+    assert plan["exportable"] is True
+    assert not any(m.get("aux") for m in plan["measures"])
+
+
+def test_agregacion_implicita_se_traduce_por_su_nombre():
+    visual = {"id": "v1", "type": "card", "title": "Monto",
+              "fields": {"Values": [_proyeccion_columna(
+                  "Ventas", "Monto", aggregation=0, queryRef="Sum(Ventas.Monto)")]}}
+    plan = content_query.plan_de_visual(visual, (), RELACIONES)
+
+    assert plan["exportable"] is True
+    assert plan["measures"][0]["expr"] == "SUM('Ventas'[Monto])"
+
+
+def test_agregacion_desconocida_declina_en_vez_de_adivinar():
+    visual = {"id": "v1", "type": "card", "title": "Raro",
+              "fields": {"Values": [_proyeccion_columna(
+                  "Ventas", "Monto", aggregation=42)]}}
+    plan = content_query.plan_de_visual(visual, (), RELACIONES)
+
+    assert plan["exportable"] is False and "Agregacion" in plan["reason"]
+
+
+def test_nombre_y_codigo_de_agregacion_que_no_coinciden_declinan():
+    visual = {"id": "v1", "type": "card", "title": "Contradictorio",
+              "fields": {"Values": [_proyeccion_columna(
+                  "Ventas", "Monto", aggregation=0, queryRef="Max(Ventas.Monto)")]}}
+    plan = content_query.plan_de_visual(visual, (), RELACIONES)
+
+    assert plan["exportable"] is False
+    assert "queryRef" in plan["reason"]
+
+
+def test_un_cuadro_de_texto_no_es_un_dato_vacio():
+    plan = content_query.plan_de_visual(
+        {"id": "t1", "type": "textbox", "title": "", "fields": {}}, (), ())
+    assert plan["exportable"] is False and "no consulta datos" in plan["reason"]
+
+
+def test_top_n_no_ordena_por_la_medida_de_existencia():
+    with pytest.raises(ValidationError, match="top_n"):
+        content_query.plan_declarado(
+            {"name": "Top", "rows": ["Riesgos[ID]", "Medidas[Accion]"],
+             "top_n": 5}, RELACIONES)
+
+
+def test_consulta_declarada_por_el_cliente():
+    plan = content_query.plan_declarado(
+        {"name": "Costo por fase", "rows": ["Riesgos[Fase]"],
+         "values": ["Costo"], "filters": [{"field": "Riesgos[Estado]",
+                                           "values": ["Abierto"]}],
+         "top_n": 3}, RELACIONES)
+
+    assert plan["title"] == "Costo por fase"
+    assert "TOPN(3" in plan["dax"] and "[Costo]" in plan["dax"]
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+@pytest.fixture
+def proyecto(session, sample_pbip):
+    """El .pbip de siempre, con dos visuales y un cuadro de texto."""
+    project_locator.open_project(session, str(sample_pbip))
+    paginas = sample_pbip.parent / "MyReport.Report" / "definition" / "pages"
+    visuales = paginas / "pg1" / "visuals"
+
+    def escribir(vid: str, cuerpo: dict) -> None:
+        (visuales / vid).mkdir(parents=True, exist_ok=True)
+        (visuales / vid / "visual.json").write_text(
+            json.dumps(cuerpo), encoding="utf-8")
+
+    escribir("v_barras", {
+        "name": "v_barras",
+        "position": {"x": 0, "y": 0, "width": 300, "height": 200, "z": 0},
+        "visual": {"visualType": "barChart", "query": {"queryState": {
+            "Category": {"projections": [{"field": {"Column": {
+                "Expression": {"SourceRef": {"Entity": "Ventas"}},
+                "Property": "Monto"}}, "nativeQueryRef": "Monto"}]},
+            "Y": {"projections": [{"field": {"Measure": {
+                "Expression": {"SourceRef": {"Entity": "Ventas"}},
+                "Property": "Total"}}, "nativeQueryRef": "Total"}]}}}},
+        "filterConfig": {"filters": [filter_builder.build_filter(
+            {"field": "Ventas[Monto]", "values": [10]})]},
+    })
+    escribir("v_texto", {
+        "name": "v_texto",
+        "position": {"x": 0, "y": 210, "width": 300, "height": 60, "z": 1},
+        "visual": {"visualType": "textbox"},
+    })
+    return session
+
+
+def test_la_seleccion_separa_lo_exportable_de_lo_que_no(proyecto):
+    resuelto = content_export.resolver_seleccion(proyecto, {"pages": ["P1"]})
+
+    assert len(resuelto["plans"]) == 1
+    assert resuelto["plans"][0]["visual_type"] == "barChart"
+    assert len(resuelto["skipped"]) == 1
+    assert resuelto["skipped"][0]["visual_type"] == "textbox"
+
+
+def test_la_pagina_se_puede_pedir_por_su_nombre_visible_o_su_id(proyecto):
+    por_nombre = content_export.resolver_seleccion(proyecto, {"pages": ["P1"]})
+    por_id = content_export.resolver_seleccion(proyecto, {"pages": ["pg1"]})
+    assert [p["dax"] for p in por_nombre["plans"]] == [p["dax"] for p in por_id["plans"]]
+
+
+def test_una_pagina_que_no_existe_dice_cuales_hay(proyecto):
+    with pytest.raises(ValidationError, match="No existe la pagina"):
+        content_export.resolver_seleccion(proyecto, {"pages": ["Fantasma"]})
+
+
+def test_dry_run_devuelve_el_dax_sin_tocar_el_motor(proyecto, monkeypatch):
+    def prohibido(*_a, **_k):                  # el motor no se toca
+        raise AssertionError("dry_run no puede consultar el modelo")
+
+    monkeypatch.setattr(dax_runner, "run_dax", prohibido)
+    salida = content_export.export_content(
+        proyecto, select={"pages": ["P1"]}, dry_run=True)
+
+    assert salida["dry_run"] is True and salida["outputs"] == []
+    assert salida["queries"][0]["dax"].startswith("EVALUATE")
+    assert salida["queries"][0]["filters_applied"][0]["field"] == "Ventas[Monto]"
+
+
+def test_el_filtro_del_visual_viaja_a_la_consulta(proyecto):
+    salida = content_export.export_content(
+        proyecto, select={"pages": ["P1"]}, dry_run=True)
+    assert "FILTER(ALL('Ventas'[Monto])" in salida["queries"][0]["dax"]
+
+
+def test_un_modelo_sin_datos_no_se_exporta_en_blanco(proyecto, monkeypatch, tmp_path):
+    """Un .pbip recien abierto responde a las consultas y devuelve cero filas."""
+    monkeypatch.setattr(content_export, "estado_de_datos",
+                        lambda _s: {"partitions": 2, "ready": 0, "processed": False})
+    monkeypatch.setattr(content_export, "_modelo_en_vivo", lambda *a, **k: [])
+    monkeypatch.setattr(dax_runner, "run_dax", lambda *_a, **_k: {
+        "columns": [], "rows": [], "row_count": 0, "truncated": False})
+
+    with pytest.raises(ValidationError, match="SIN DATOS"):
+        content_export.export_content(proyecto, select={"pages": ["P1"]})
+
+    assert not list((tmp_path).rglob("*.xlsx")), "no se publica nada"
+
+
+def test_las_fechas_no_llegan_en_formato_de_maquina():
+    # Asi las devuelve el motor: round-trip de .NET.
+    assert content_export.valor_legible("2026-09-11T00:00:00.0000000") == "2026-09-11"
+    assert content_export.valor_legible("2026-09-11T14:30:00") == "2026-09-11 14:30:00"
+    assert content_export.valor_legible("R-01") == "R-01"
+    assert content_export.valor_legible(35) == 35
+
+
+def test_los_encabezados_pierden_la_tabla_salvo_cuando_hay_ambiguedad():
+    assert content_export.encabezados_legibles(
+        ["Riesgos[Fase]", "[Total Riesgos]"]) == ["Fase", "Total Riesgos"]
+    # Dos columnas 'Nombre' de tablas distintas conservan la forma larga.
+    assert content_export.encabezados_legibles(
+        ["A[Nombre]", "B[Nombre]", "A[Fecha]"]) == ["A[Nombre]", "B[Nombre]", "Fecha"]
+
+
+def test_el_andamiaje_no_llega_al_archivo():
+    plan = {"measures": [{"alias": "Total"}, {"alias": content_query.ALIAS_EXISTENCIA,
+                                              "aux": True}]}
+    columnas = ["Riesgos[ID]", "[Total]", f"[{content_query.ALIAS_EXISTENCIA}]"]
+    filas = [["R1", 5, 1], ["R2", 7, 1]]
+
+    limpias, datos = content_export._sin_auxiliares(plan, columnas, filas)
+
+    assert limpias == ["Riesgos[ID]", "[Total]"]
+    assert datos == [["R1", 5], ["R2", 7]]
+
+
+def test_el_excel_lleva_los_datos_y_declara_sus_filtros(proyecto, monkeypatch):
+    monkeypatch.setattr(content_export, "_asegurar_modelo", lambda *a, **k: [])
+    monkeypatch.setattr(dax_runner, "run_dax", lambda *_a, **_k: {
+        "columns": ["Ventas[Monto]", "[Total]"],
+        "rows": [[10, 100], [20, 200]], "row_count": 2, "truncated": False,
+        "elapsed_ms": 1.0})
+
+    salida = content_export.export_content(
+        proyecto, select={"pages": ["P1"]}, format="xlsx")
+
+    from openpyxl import load_workbook
+    ruta = Path(salida["outputs"][0]["output_path"])
+    libro = load_workbook(ruta)
+    assert "Contenido" in libro.sheetnames
+    hoja = libro[[n for n in libro.sheetnames if n != "Contenido"][0]]
+    celdas = [[c for c in fila] for fila in hoja.iter_rows(values_only=True)]
+    plano = [str(c) for fila in celdas for c in fila if c is not None]
+
+    valores = [c for fila in celdas for c in fila if c is not None]
+    assert salida["queries"][0]["rows"] == 2
+    assert any("Ventas[Monto] esta en (10)" in v for v in plano), \
+        "cada hoja declara con que filtros se saco"
+    assert ["Monto", "Total"] == [
+        c for c in celdas[len(celdas) - 3] if c is not None], "encabezados del dato"
+    assert 100 in valores and 200 in valores, "las filas del motor llegan al archivo"

--- a/tests/test_excel_pdf_exports.py
+++ b/tests/test_excel_pdf_exports.py
@@ -101,6 +101,63 @@ def test_pdf_incluye_captura_y_se_reabre(proyecto, tmp_path):
     assert "Capturas de los tableros" in text
 
 
+def test_etiqueta_de_objeto_nombra_cada_tipo_de_hallazgo():
+    paginas = {"pg1": "Matriz de Riesgos"}
+    etiqueta = exporting._finding_object_label
+
+    assert etiqueta({"kind": "measure", "name": "Total", "table": "Ventas"}) == \
+        "Medida Total (Ventas)"
+    assert etiqueta({"kind": "column", "name": "Ventas[Monto]"}) == \
+        "Columna Ventas[Monto]"
+    assert etiqueta({"kind": "relationship", "from": "A", "to": "B"}) == \
+        "Relacion A -> B"
+    assert etiqueta({"kind": "visual", "id": "abc123", "type": "textbox",
+                     "page": "pg1"}, paginas) == \
+        "Visual textbox abc123 - pagina Matriz de Riesgos"
+    assert etiqueta({"kind": "visual_group", "visuals": ["a1", "b2"],
+                     "page": "pg1"}, paginas) == \
+        "Visuales a1, b2 - pagina Matriz de Riesgos"
+    # Un grupo con toda la pagina dentro no puede reventar la fila del PDF.
+    assert etiqueta({"kind": "visual_group",
+                     "visuals": [f"v{n}" for n in range(7)]}) == \
+        "Visuales v0, v1, v2, v3, (+3 mas)"
+    assert etiqueta({"kind": "page", "page": "pg1", "name": "P1"}) == "Pagina P1"
+    assert etiqueta({"kind": "page", "page": "pg1"}, paginas) == \
+        "Pagina Matriz de Riesgos"
+    assert etiqueta({"kind": "model"}) == "Modelo"
+    assert etiqueta(None) == "" and etiqueta({}) == ""
+
+
+def test_texto_del_hallazgo_no_vuelca_json_crudo():
+    # Los motores de auditoria no producen `message`: solo `evidence`.
+    assert exporting._finding_message(
+        {"evidence": {"visual_count": 13, "threshold": 12}}) == \
+        "visual_count: 13; threshold: 12"
+    assert exporting._finding_message(
+        {"evidence": {"visuals": ["a", "b"]}}) == "visuals: a, b"
+    assert exporting._finding_message({"evidence": {}}) == ""
+    # Ni `None` ni `False` de Python deben llegar a un reporte que lee alguien.
+    assert exporting._finding_message(
+        {"evidence": {"title": None, "has_description": False}}) == \
+        "title: (vacio); has_description: no"
+    assert exporting._finding_message(
+        {"message": "Explicito", "evidence": {"x": 1}}) == "Explicito"
+
+
+def test_pdf_de_auditoria_nombra_el_objeto_de_cada_hallazgo(proyecto):
+    result = exporting.generate_pdf_report(
+        proyecto, source="pbip", report_type="audit", include_audit=True)
+
+    reader = PdfReader(result["output_path"])
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+
+    assert result["findings_included"] >= 1
+    # El reporte de auditoria no lista las tablas del modelo: si aparece
+    # "Ventas" es porque el hallazgo de la medida por fin dice de quien habla.
+    assert "Ventas" in text and "Total" in text
+    assert '{"' not in text, "la evidencia no puede llegar como JSON al PDF"
+
+
 def test_pdf_rechaza_capturas_ajenas_a_imagen(proyecto, tmp_path):
     bad = tmp_path / "captura.txt"
     bad.write_text("no es una imagen", encoding="utf-8")

--- a/tests/test_project_audit.py
+++ b/tests/test_project_audit.py
@@ -291,3 +291,155 @@ def test_catalogo_de_autofixes():
     assert report_audit.AUTOFIXES
     for regla, datos in report_audit.AUTOFIXES.items():
         assert datos["description"] and datos["target"]
+
+
+# ================================= visuales que Power BI se niega a dibujar ===
+def _escribir_visual(active, vid: str, visual: dict, position: dict) -> str:
+    """Deja un visual en la pagina del fixture, tal cual lo escribe Desktop."""
+    ruta = pbir_edit._visual_file(active, P, vid)
+    ruta.parent.mkdir(parents=True, exist_ok=True)
+    ruta.write_text(json.dumps(
+        {"name": vid, "position": position, "visual": visual},
+        indent=2), encoding="utf-8")
+    return vid
+
+
+def _campo(entidad: str, propiedad: str) -> dict:
+    return {"Column": {"Expression": {"SourceRef": {"Entity": entidad}},
+                       "Property": propiedad}}
+
+
+def _scatter(x_agregado: bool = False, con_detalles: bool = True) -> dict:
+    def proyeccion(propiedad: str, agregar: bool) -> dict:
+        campo = _campo("Ventas", propiedad)
+        if agregar:
+            campo = {"Aggregation": {"Expression": campo, "Function": 1}}
+        return {"field": campo, "queryRef": f"Ventas.{propiedad}"}
+
+    estado = {"X": {"projections": [proyeccion("Monto", x_agregado)]},
+              "Y": {"projections": [proyeccion("Monto", x_agregado)]}}
+    if con_detalles:
+        estado["Category"] = {"projections": [proyeccion("Monto", False)]}
+    return {"visualType": "scatterChart", "query": {"queryState": estado}}
+
+
+def test_detecta_scatter_con_detalles_y_ejes_sin_resumir(proyecto):
+    """El error que Power BI muestra en pantalla y ningun esquema ve."""
+    active, md, _p = proyecto
+    vid = _escribir_visual(active, "scatterroto000000", _scatter(),
+                           {"x": 0, "y": 0, "width": 400, "height": 300, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    hallazgos = [h for h in r["findings"]
+                 if h["rule"] == "report_scatter_axis_not_aggregated"]
+
+    assert hallazgos and hallazgos[0]["object"]["id"] == vid
+    assert hallazgos[0]["severity"] == "error", "el visual no se dibuja"
+    assert "Ventas[Monto]" in hallazgos[0]["evidence"]["fields"]
+
+
+def test_un_scatter_con_los_ejes_resumidos_no_se_reporta(proyecto):
+    active, md, _p = proyecto
+    _escribir_visual(active, "scatterbien000000", _scatter(x_agregado=True),
+                     {"x": 0, "y": 0, "width": 400, "height": 300, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    assert not [h for h in r["findings"]
+                if h["rule"] == "report_scatter_axis_not_aggregated"]
+
+
+def test_un_scatter_sin_detalles_puede_dejar_los_ejes_en_bruto(proyecto):
+    """Sin campo en Detalles, Power BI dibuja los pares tal cual."""
+    active, md, _p = proyecto
+    _escribir_visual(active, "scatterpares00000", _scatter(con_detalles=False),
+                     {"x": 0, "y": 0, "width": 400, "height": 300, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    assert not [h for h in r["findings"]
+                if h["rule"] == "report_scatter_axis_not_aggregated"]
+
+
+def _slicer() -> dict:
+    return {"visualType": "slicer", "query": {"queryState": {
+        "Values": {"projections": [{"field": _campo("Ventas", "Monto"),
+                                    "queryRef": "Ventas.Monto"}]}}}}
+
+
+def test_detecta_slicer_por_debajo_del_piso_de_altura(proyecto):
+    active, md, _p = proyecto
+    vid = _escribir_visual(active, "slicercorto000000", _slicer(),
+                           {"x": 0, "y": 0, "width": 296, "height": 64, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    hallazgos = [h for h in r["findings"]
+                 if h["rule"] == "report_slicer_below_height_floor"]
+
+    assert hallazgos and hallazgos[0]["object"]["id"] == vid
+    assert hallazgos[0]["evidence"]["minimum"] == report_audit.ALTO_MINIMO_SLICER
+    assert hallazgos[0]["evidence"]["mode"] == "lista (por defecto)"
+
+
+def test_el_slicer_desplegable_con_alto_suficiente_no_se_reporta(proyecto):
+    active, md, _p = proyecto
+    visual = _slicer()
+    visual["objects"] = {"data": [{"properties": {
+        "mode": {"expr": {"Literal": {"Value": "'Dropdown'"}}}}}]}
+    _escribir_visual(active, "slicerbien0000000", visual,
+                     {"x": 0, "y": 0, "width": 296, "height": 80, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    assert not [h for h in r["findings"]
+                if h["rule"] == "report_slicer_below_height_floor"]
+
+
+def test_sin_cabecera_el_piso_del_slicer_baja(proyecto):
+    """MEDIDO contra el CLI oficial: sin cabecera, 47 falla y 48 pasa.
+
+    La primera version usaba 76 siempre y marcaba como rotos nueve slicers
+    sanos de otro informe que ocultaban su cabecera.
+    """
+    active, md, _p = proyecto
+    visual = _slicer()
+    visual["objects"] = {
+        "data": [{"properties": {
+            "mode": {"expr": {"Literal": {"Value": "'Dropdown'"}}}}}],
+        "header": [{"properties": {
+            "show": {"expr": {"Literal": {"Value": "false"}}}}}]}
+    _escribir_visual(active, "slicersincab00000", visual,
+                     {"x": 0, "y": 0, "width": 296, "height": 74, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    assert not [h for h in r["findings"]
+                if h["rule"] == "report_slicer_below_height_floor"]
+
+
+def test_sin_cabecera_por_debajo_de_48_si_se_reporta(proyecto):
+    active, md, _p = proyecto
+    visual = _slicer()
+    visual["objects"] = {"header": [{"properties": {
+        "show": {"expr": {"Literal": {"Value": "false"}}}}}]}
+    _escribir_visual(active, "slicersincorto000", visual,
+                     {"x": 0, "y": 0, "width": 296, "height": 40, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    hallazgo = [h for h in r["findings"]
+                if h["rule"] == "report_slicer_below_height_floor"][0]
+
+    assert hallazgo["evidence"]["minimum"] == 48
+    assert hallazgo["evidence"]["header_shown"] is False
+
+
+def test_el_modo_del_slicer_se_lee_del_bloque_objects(proyecto):
+    active, md, _p = proyecto
+    visual = _slicer()
+    visual["objects"] = {"data": [{"properties": {
+        "mode": {"expr": {"Literal": {"Value": "'Dropdown'"}}}}}]}
+    _escribir_visual(active, "slicerdrop0000000", visual,
+                     {"x": 0, "y": 0, "width": 296, "height": 64, "z": 1})
+
+    r = report_audit.audit_report(active, md)
+    hallazgo = [h for h in r["findings"]
+                if h["rule"] == "report_slicer_below_height_floor"][0]
+
+    assert hallazgo["evidence"]["mode"] == "Dropdown"
+    assert "se recorta" in hallazgo["recommendation"]

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -217,6 +217,12 @@ EXPORTACION_Y_SHAREPOINT_TOOLS = [
     "pbi_sharepoint_download_folder",
 ]
 
+#: Exportacion del CONTENIDO: los datos que muestra el tablero, no sus
+#: metadatos. Es la unica que necesita el modelo en vivo Y procesado.
+CONTENIDO_TOOLS = [
+    "pbi_export_report_content",
+]
+
 TOOLS_NUEVAS = (MACROFASE_A_TOOLS + MACROFASE_B_TOOLS + MACROFASE_C_TOOLS
                 + MACROFASE_D_TOOLS + MACROFASE_E_TOOLS + MACROFASE_F_TOOLS
                 + FASE_F_R5_TOOLS + CONVERSION_TOOLS + THEME_TOOLS
@@ -224,7 +230,7 @@ TOOLS_NUEVAS = (MACROFASE_A_TOOLS + MACROFASE_B_TOOLS + MACROFASE_C_TOOLS
                 + FILTRO_VISUAL_TOOLS + CICLO_TOOLS + REFACTOR_TOOLS
                 + CIERRE_TOOLS + BRIEF_TOOLS + DIAGNOSTICO_TOOLS
                 + FUENTES_TOOLS + PUERTO_TOOLS
-                + EXPORTACION_Y_SHAREPOINT_TOOLS)
+                + EXPORTACION_Y_SHAREPOINT_TOOLS + CONTENIDO_TOOLS)
 BASELINE_COUNT = 34
 EXPECTED_COUNT = BASELINE_COUNT + len(TOOLS_NUEVAS)
 


### PR DESCRIPTION
Cinco tools nuevas (133) y cuatro defectos con **la misma forma por debajo**:
el servidor producía algo válido que nadie podía ver que estaba mal. Un libro
que el esquema acepta, un PDF que abre, una consulta que devuelve filas, un
slicer con los colores escritos. Todo correcto. Nada haciendo lo que decía.

Todos se encontraron **abriendo el artefacto y mirándolo**, y todos están
verificados por mutación: se revierte el arreglo y falla un test con nombre.

## 1 · `pbi_export_report_content` — exportar lo que el tablero MUESTRA

`pbi_export_excel` y `pbi_generate_pdf_report` documentan el proyecto: qué
tablas hay, qué visuales, qué hallazgos. Ninguno lleva un dato del negocio. Lo
que pide un cliente cuando dice "exportame el reporte" es el contenido.

`select` admite tres formas, combinables: `pages` (la tabla detrás de cada
visual de esas páginas), `visuals` (sueltos) y `queries` (lo que el cliente
declare, sin referirse a ningún visual). Salida a `.xlsx` y `.pdf`.

Cada consulta se reconstruye desde los campos del visual y sus filtros PBIR, y
**cada hoja declara con qué filtros se sacó y cuáles NO se pudieron traducir**.
Un número que ignora un filtro en silencio es peor que no exportar: nadie duda
de un Excel. Los visuales sin consulta tabular se listan con el motivo en vez
de salir vacíos, y una agregación que no se reconoce hace declinar el visual
en lugar de adivinar.

Necesita el modelo en vivo —los datos viven en el motor, no en el `.pbip`—,
así que abre Desktop si no lo hay y **se niega a exportar uno abierto pero sin
procesar**: un `.pbip` recién abierto responde cero filas a todo y el libro
saldría en blanco sin un solo error.

## 2 · Un visual con columnas de dos tablas exportaba un producto cartesiano

`SUMMARIZECOLUMNS` solo aplica auto-exists dentro de una misma tabla. Medido
contra el motor, no deducido:

```
sin nada:            400 filas   <- 20 riesgos x 20 medidas
COUNTROWS(Medidas):   20 filas   <- lo que muestra el visual
COUNTROWS(Riesgos):  400 filas
```

La consulta lleva ahora un `CALCULATE(COUNTROWS(<tabla de hechos>))` resuelto
desde las relaciones del modelo, y esa columna se quita antes de escribir el
archivo. Cuando ninguna tabla de hechos cubre todas las columnas, el visual se
declara **no exportable** en vez de exportarse mal.

## 3 · El PDF de auditoría no decía de qué objeto hablaba

Los hallazgos traen `object` con el nombre de la medida, columna, visual o
página. El PDF lo tiraba: siete filas idénticas de `measure_possibly_unused` y
`{"referenced_by_measures": 0}` por descripción. El Excel sí lo llevaba.

Hay ahora una columna `Objeto`, los ids de página se resuelven a su nombre
visible, y la evidencia se lee como `visual_count: 13; threshold: 12`. Los
tests anteriores contaban páginas; los nuevos leen el texto del PDF.

## 4 · `reuse_open` nunca reutilizaba una sesión de `.pbip`

La detección miraba los descriptores de archivo abiertos, y Desktop **no deja
ninguno** sobre la carpeta de un proyecto — comprobado con `open_files()`: cero
archivos. Cada `pbi_open_in_desktop` sobre un proyecto lanzaba OTRA ventana del
mismo informe, y `reuse_open=false` tampoco podía fallar cerrado. Se cae ahora
al título de la ventana principal, reutilizando solo si hay exactamente una
coincidencia.

## 5 · Dos reglas para visuales que Power BI se niega a dibujar

Un visual en error muestra un cartel en vez de contenido y **no lo caza nada**:
el esquema PBIR acepta el JSON, el CLI oficial pasa y el DAX sintetizado
devuelve filas, porque el fallo está en la configuración de campos, no en la
consulta.

- `report_scatter_axis_not_aggregated` — Detalles con X/Y sin resumir.
- `report_slicer_below_height_floor` — slicer por debajo de su piso de altura.

**El piso se publicó mal primero.** Usaba 76 px siempre y marcó como rotos
nueve slicers sanos: los que ocultan su cabecera. Son **76 con cabecera y 48
sin ella**, y las dos cifras salen ahora de preguntarle al CLI oficial con el
mismo informe a distintas alturas:

```
CON cabecera  47:falla  48:falla  74:falla  76:pasa
SIN cabecera  47:falla  48:pasa   74:pasa   76:pasa
```

La lección es el método, no la constante: cuando el oráculo y yo discrepamos,
el que se explica soy yo.

## Contrato

Aditivo: una tool nueva (`pbi_export_report_content`), cero eliminadas o
renombradas, cero tipos o defaults existentes cambiados. Golden regenerado con
133 congeladas y el diff declarado **compatible** por `tests.contract_utils`.

```
pytest 2123 passed, 3 skipped · empaquetado 14/14 · doctor exit 0
contrato exit 0 · §7 del checklist 11/11 sobre un .pbip real
```

El §7 se corrió completo sobre una copia fuera de OneDrive: huella del
original antes y después idéntica, guarda que bloquea con el proyecto abierto
y no da falso bloqueo con otro, fallo inyectado con rollback **byte a byte**,
recuperación desde journal de los 15 archivos de una página duplicada, y
reapertura en Desktop sin error nuevo.

## Lo que este PR NO toca

Los errores preexistentes de informes del usuario no se arreglan solos, y
tampoco se toca la limitación conocida de equivalencia visual completa del
bloque `objects`, ni los tres esquemas PBIR sin publicar upstream, ni el modo
`both`. Content export **necesita Power BI Desktop**: no hay camino XMLA al
Servicio en esta versión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
