### PR TITLE
El manifiesto del registro se quedo en 1.3.0 y el tag v1.4.0 murio en rojo

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -20,6 +20,20 @@ jobs:
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
           ./mcp-publisher validate .mcp/server.json
 
+      # El registro rechaza republicar una version ya publicada (400
+      # `cannot publish duplicate version`). Si el tag y el manifiesto no
+      # coinciden es que el manifiesto se quedo atras: se para aqui, antes de
+      # tocar la red, y el log dice cual es el numero que sobra.
+      - name: El tag y el manifiesto declaran la misma version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          manifiesto=$(python3 -c "import json;print(json.load(open('.mcp/server.json'))['version'])")
+          if [ "$tag" != "$manifiesto" ]; then
+            echo "::error::el tag dice $tag y .mcp/server.json dice $manifiesto; actualiza el manifiesto y vuelve a taguear"
+            exit 1
+          fi
+
       - name: Authenticate with the MCP Registry
         run: ./mcp-publisher login github-oidc
 

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.HorizunGroup/horizun-pbi-mcp",
   "title": "Horizun PBI MCP",
   "description": "Open-source MCP server for Power BI Desktop, DAX, PBIP, TMDL and PBIR automation.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": {
     "url": "https://github.com/HorizunGroup/horizun-pbi-mcp",
     "source": "github"

--- a/tests/test_mcp_compat.py
+++ b/tests/test_mcp_compat.py
@@ -165,3 +165,19 @@ def test_el_changelog_tiene_la_entrada_de_esta_version():
     texto = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
     assert f"[{branding.VERSION}]" in texto, (
         f"el CHANGELOG no tiene una entrada para {branding.VERSION}")
+
+
+def test_el_manifiesto_del_registro_mcp_declara_esta_version():
+    """`.mcp/server.json` es lo que se publica al registro oficial al taguear.
+
+    Si se queda atras, el workflow del tag reenvia una version ya publicada y
+    el registro responde 400 `cannot publish duplicate version`: la release
+    sale en PyPI pero el registro sigue anunciando la anterior. Aqui se cazaba
+    ya la coherencia de pyproject, README y CHANGELOG; este archivo faltaba.
+    """
+    import json
+
+    datos = json.loads((REPO / ".mcp" / "server.json").read_text(encoding="utf-8"))
+    assert datos["version"] == branding.VERSION, (
+        f".mcp/server.json dice {datos['version']!r} y branding "
+        f"{branding.VERSION!r}")


### PR DESCRIPTION
## Qué pasaba

La X roja de la portada pública es `publish-mcp-registry` sobre el tag `v1.4.0`. El workflow envió `.mcp/server.json`, que seguía en `1.3.0`, y el registro contestó:

```
400 {"message":"invalid version: cannot publish duplicate version"}
```

Consecuencia real, más allá del color: la 1.4.0 salió en PyPI pero el registro MCP sigue anunciando la 1.3.0.

## Por qué no lo cazó nadie

La coherencia de versión ya estaba probada para `pyproject.toml`, el README y el CHANGELOG (`tests/test_mcp_compat.py`). El único archivo que se le manda al registro no estaba en esa lista.

## Qué cambia

- `.mcp/server.json` pasa a `1.4.0`.
- Prueba nueva: ese archivo debe declarar `branding.VERSION`. La próxima incoherencia falla en CI antes de que exista el tag.
- El workflow compara el tag con el manifiesto antes de tocar la red y dice qué número sobra, en vez de traducir un 400 del servidor.

Tras el merge queda pendiente un `workflow_dispatch` de `publish-mcp-registry` para que la 1.4.0 llegue por fin al registro, sin mover el tag ya publicado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)