### PR TITLE
Tell the MCP Registry and the Codex marketplace what they were missing

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,9 +1,11 @@
 {
   "name": "horizun",
+  "description": "Open source plugins by HorizunGroup",
   "interface": {"displayName": "Horizun Open Source"},
   "plugins": [
     {
       "name": "horizun-pbi-mcp",
+      "description": "Safe control of Power BI Desktop and PBIP projects via MCP.",
       "source": {"source": "url", "url": "https://github.com/HorizunGroup/horizun-pbi-mcp.git", "ref": "v2.0.1"},
       "policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
       "category": "Developer Tools"

--- a/.env.example
+++ b/.env.example
@@ -1,49 +1,51 @@
-# Prefijo actual: HORIZUN_PBI_MCP_*
-# Compatibilidad: las PBI_MCP_* siguen funcionando, con MENOR precedencia.
-# ==== Horizun PBI MCP — configuracion de ejemplo ====
-# Copia este archivo como  .env  y ajusta lo que necesites.
-# Todas las variables son OPCIONALES: el servidor tiene valores por defecto sensatos.
+# ==== Horizun PBI MCP - example configuration ====
+# Copy this file to  .env  and adjust what you need.
+# Every variable is OPTIONAL: the server ships with sensible defaults.
+#
+# Current prefix: HORIZUN_PBI_MCP_*
+# Compatibility: the older PBI_MCP_* names still work, at LOWER precedence.
 
-# --- Interop .NET / ADOMD.NET + TOM ---
-# Carpeta con las DLLs de ADOMD.NET y TOM (Microsoft.AnalysisServices.*).
-# Por defecto: <raiz-del-proyecto>/libs
+# --- .NET interop / ADOMD.NET + TOM ---
+# Folder holding the ADOMD.NET and TOM DLLs (Microsoft.AnalysisServices.*).
+# Default: <project-root>/libs
 # PBI_MCP_LIBS_DIR=<PROJECT_ROOT>/libs
 
-# Runtime de pythonnet a forzar: netfx (recomendado en Windows) o coreclr.
+# pythonnet runtime to force: netfx (recommended on Windows) or coreclr.
 # PBI_MCP_DOTNET_RUNTIME=netfx
 
-# --- Consultas DAX ---
-# Maximo de filas devueltas por defecto cuando el tool no especifica max_rows.
+# --- DAX queries ---
+# Default maximum number of rows returned when a tool does not set max_rows.
 HORIZUN_PBI_MCP_MAX_ROWS=1000
 
-# Timeout (segundos) para comandos DAX/TOM.
+# Timeout, in seconds, for DAX/TOM commands.
 HORIZUN_PBI_MCP_COMMAND_TIMEOUT=120
 
-# --- Salidas / backups / logs ---
-# Carpeta donde se guardan documentacion y change_log.md (por defecto ./outputs).
+# --- Outputs / backups / logs ---
+# Folder for generated documentation and change_log.md (default ./outputs).
 # PBI_MCP_OUTPUTS_DIR=<PROJECT_ROOT>/outputs
-# Carpeta donde se guardan los backups de .pbip (por defecto ./backups).
-# OJO: apunta SIEMPRE fuera del .pbip. Si los backups caen dentro del proyecto,
-# Power BI Desktop puede intentar leerlos y ensucian el informe.
+# Folder for .pbip backups (default ./backups).
+# CAREFUL: always point this OUTSIDE the .pbip. Backups written inside the
+# project can be picked up by Power BI Desktop and pollute the report.
 # PBI_MCP_BACKUPS_DIR=<PROJECT_ROOT>/backups
 
-# Nivel de log: DEBUG, INFO, WARNING, ERROR
+# Log level: DEBUG, INFO, WARNING, ERROR
 HORIZUN_PBI_MCP_LOG_LEVEL=INFO
-# Archivo de log (por defecto ./outputs/powerbi_mcp.log). Vacio = solo stderr.
+# Log file (default ./outputs/powerbi_mcp.log). Empty = stderr only.
 # PBI_MCP_LOG_FILE=
 
-# --- Sesion / proyecto activo (opcional, para arrancar ya apuntando a algo) ---
-# Ruta a un .pbip que se marcara como proyecto activo al iniciar.
-# PBI_MCP_DEFAULT_PBIP=C:/ruta/MiInforme.pbip
+# --- Session / active project (optional, to start already pointing somewhere) ---
+# Path to a .pbip that will be marked as the active project on startup.
+# PBI_MCP_DEFAULT_PBIP=C:/path/MyReport.pbip
 
-# --- SharePoint Online / Microsoft Graph (opcionales) ---
-# Autenticacion app-only. Configura la aplicacion Entra ID con el permiso de
-# lectura minimo que corresponda (se recomienda Sites.Selected y acceso solo a
-# los sitios necesarios). El secreto nunca se pasa como parametro MCP.
+# --- SharePoint Online / Microsoft Graph (optional) ---
+# App-only authentication. Configure the Entra ID application with the least
+# read permission that fits your case; Sites.Selected, scoped to just the sites
+# you need, is recommended. The secret is never passed as an MCP parameter.
 # HORIZUN_PBI_MCP_SHAREPOINT_TENANT_ID=00000000-0000-0000-0000-000000000000
 # HORIZUN_PBI_MCP_SHAREPOINT_CLIENT_ID=00000000-0000-0000-0000-000000000000
 # HORIZUN_PBI_MCP_SHAREPOINT_CLIENT_SECRET=
 
-# Ruta opcional a pdftoppm para verificar visualmente los PDF. Si no existe,
-# el PDF se reabre y valida logicamente, y la respuesta declara que falto render.
-# HORIZUN_PBI_MCP_PDFTOPPM=C:/ruta/poppler/bin/pdftoppm.exe
+# Optional path to pdftoppm, used to verify PDFs visually. If it is missing the
+# PDF is reopened and validated logically instead, and the response says
+# outright that the render check did not run.
+# HORIZUN_PBI_MCP_PDFTOPPM=C:/path/poppler/bin/pdftoppm.exe

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -8,5 +8,13 @@
     "url": "https://github.com/HorizunGroup/horizun-pbi-mcp",
     "source": "github"
   },
-  "websiteUrl": "https://horizunhub.com"
+  "websiteUrl": "https://horizunhub.com",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "horizun-pbi-mcp",
+      "version": "2.0.1",
+      "transport": {"type": "stdio"}
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Horizun PBI MCP
 
 [![CI](https://github.com/HorizunGroup/horizun-pbi-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/HorizunGroup/horizun-pbi-mcp/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/horizun-pbi-mcp)](https://pypi.org/project/horizun-pbi-mcp/)
-[![Python](https://img.shields.io/pypi/pyversions/horizun-pbi-mcp)](https://pypi.org/project/horizun-pbi-mcp/)
+[![PyPI](https://img.shields.io/pypi/v/horizun-pbi-mcp?cacheSeconds=3600)](https://pypi.org/project/horizun-pbi-mcp/)
+[![Python](https://img.shields.io/pypi/pyversions/horizun-pbi-mcp?cacheSeconds=3600)](https://pypi.org/project/horizun-pbi-mcp/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 **Build and fix Power BI reports by describing what you want.**

--- a/examples/mcp-config.example.json
+++ b/examples/mcp-config.example.json
@@ -1,10 +1,14 @@
 {
   "_comment": [
-    "HORIZUN-PBI-MCP — ejemplo minimo para un cliente MCP por stdio.",
-    "Sustituye <PYTHON_EXE> y <PROJECT_ROOT> por rutas ABSOLUTAS de TU maquina.",
-    "Si instalaste el paquete: \"command\": \"horizun-pbi-mcp\", \"args\": [].",
-    "Generador automatico: python scripts/make_mcp_config.py --client all",
-    "Guia por cliente (Claude Code / Claude Desktop / Codex): docs/INSTALL.md"
+    "HORIZUN-PBI-MCP - minimal example for an MCP client over stdio.",
+    "Most people do NOT need this file: installing the plugin for Claude Code",
+    "or Codex registers the server for you. See the README.",
+    "If you installed the package from PyPI, this is the whole config:",
+    "  \"command\": \"horizun-pbi-mcp\", \"args\": []",
+    "The form below is for running from a clone, so it needs src/ on the path.",
+    "Replace <PYTHON_EXE> and <PROJECT_ROOT> with ABSOLUTE paths on YOUR machine.",
+    "Generator: python scripts/make_mcp_config.py --client all",
+    "Per-client guide (Claude Code / Claude Desktop / Codex): docs/INSTALL.md"
   ],
   "mcpServers": {
     "horizun-pbi-mcp": {

--- a/examples/sample_model_documentation.md
+++ b/examples/sample_model_documentation.md
@@ -1,70 +1,70 @@
-# Documentacion del modelo — Ventas (ejemplo)
+# Model documentation — Sales (example)
 
-_Este es un ejemplo del tipo de salida que genera `pbi_document_model`._
+_This is an example of the output `pbi_document_model` produces._
 
-## Resumen
+## Summary
 
-- **Modelo:** Ventas
-- **Cultura:** es-ES
-- **Tablas:** 4
-- **Medidas:** 6
-- **Relaciones:** 3
-- **Jerarquias:** 1
+- **Model:** Sales
+- **Culture:** en-US
+- **Tables:** 4
+- **Measures:** 6
+- **Relationships:** 3
+- **Hierarchies:** 1
 - **Roles (RLS):** 1
 
-## Tablas
+## Tables
 
-| Tabla | Oculta | Columnas | Medidas | Fecha |
+| Table | Hidden | Columns | Measures | Date |
 |---|---|---|---|---|
-| Ventas | no | 8 | 6 | |
-| Producto | no | 5 | 0 | |
-| Cliente | no | 6 | 0 | |
-| Calendario | no | 7 | 0 | si |
+| Sales | no | 8 | 6 | |
+| Product | no | 5 | 0 | |
+| Customer | no | 6 | 0 | |
+| Calendar | no | 7 | 0 | yes |
 
-### Ventas
+### Sales
 
-| Columna | Tipo dato | Tipo | Oculta | SummarizeBy |
+| Column | Data type | Type | Hidden | SummarizeBy |
 |---|---|---|---|---|
-| VentaID | Int64 | Data | si | none |
-| Monto | Decimal | Data | no | sum |
-| Fecha | DateTime | Data | no | none |
+| SaleID | Int64 | Data | yes | none |
+| Amount | Decimal | Data | no | sum |
+| Date | DateTime | Data | no | none |
 
-## Medidas
+## Measures
 
-### Ventas[Total Ventas] _(carpeta: KPIs)_
-- Formato: `#,0`
+### Sales[Total Sales] _(folder: KPIs)_
+- Format: `#,0`
 
 ```dax
-SUM(Ventas[Monto])
+SUM(Sales[Amount])
 ```
 
-### Ventas[Margen] _(carpeta: KPIs)_
-- Formato: `0.0%`
+### Sales[Margin] _(folder: KPIs)_
+- Format: `0.0%`
 
 ```dax
-DIVIDE([Utilidad], [Total Ventas])
+DIVIDE([Profit], [Total Sales])
 ```
 
-## Relaciones
+## Relationships
 
-| Desde | Hacia | Cardinalidad | Filtro cruzado | Activa |
+| From | To | Cardinality | Cross filter | Active |
 |---|---|---|---|---|
-| Ventas[ProductoID] | Producto[ProductoID] | Many-One | OneDirection | si |
-| Ventas[ClienteID] | Cliente[ClienteID] | Many-One | OneDirection | si |
-| Ventas[Fecha] | Calendario[Fecha] | Many-One | OneDirection | si |
+| Sales[ProductID] | Product[ProductID] | Many-One | OneDirection | yes |
+| Sales[CustomerID] | Customer[CustomerID] | Many-One | OneDirection | yes |
+| Sales[Date] | Calendar[Date] | Many-One | OneDirection | yes |
 
-## Jerarquias
+## Hierarchies
 
-- **Calendario[Calendario]**: Anio > Trimestre > Mes
+- **Calendar[Calendar]**: Year > Quarter > Month
 
-## Roles / Seguridad a nivel de fila (RLS)
+## Roles / Row-level security (RLS)
 
-### Vendedor
-- `Ventas`: `Ventas[Vendedor] = USERPRINCIPALNAME()`
+### Salesperson
+- `Sales`: `Sales[Salesperson] = USERPRINCIPALNAME()`
 
-## Advertencias de calidad del modelo
+## Model quality warnings
 
 Total: 2 ({'info': 1, 'warning': 1})
 
-- **[warning] relacion_bidireccional** — Relacion bidireccional Ventas <-> Producto ...
-- **[info] id_visible** — Columna de ID visible 'Cliente[ClienteID]' ...
+- **[warning] bidirectional_relationship** — Bidirectional relationship Sales <-> Product ...
+- **[info] visible_id** — Visible ID column 'Customer[CustomerID]' ...

--- a/examples/sample_queries.md
+++ b/examples/sample_queries.md
@@ -1,30 +1,35 @@
-# Ejemplos de consultas DAX (`pbi_run_dax`)
+# DAX query examples (`pbi_run_dax`)
 
-> Requiere un modelo activo: primero `pbi_list_desktop_models` y `pbi_select_model`.
+> Requires an active model: run `pbi_list_desktop_models` and
+> `pbi_select_model` first.
 
-## 1. Prueba mínima
+Table and column names below (`Sales`, `Product[Category]`, …) are placeholders
+from a sample model. Replace them with the ones in your own.
+
+## 1. Minimal check
 ```dax
 EVALUATE ROW("ok", 1)
 ```
 
-## 2. Ver todas las filas de una tabla (con límite)
+## 2. Read a table, with a limit
 ```dax
-EVALUATE TOPN(50, Ventas)
+EVALUATE TOPN(50, Sales)
 ```
-`max_rows` en el tool también limita; usa TOPN para acotar en el motor.
+The tool's `max_rows` also caps the result, but `TOPN` bounds it in the engine,
+which is cheaper.
 
-## 3. Una medida evaluada
+## 3. Evaluate one measure
 ```dax
-EVALUATE ROW("Total Ventas", [Total Ventas])
+EVALUATE ROW("Total Sales", [Total Sales])
 ```
 
-## 4. Medida por categoría
+## 4. A measure broken down by category
 ```dax
 EVALUATE
 SUMMARIZECOLUMNS(
-    Producto[Categoria],
-    "Ventas", [Total Ventas],
-    "Margen", [Margen]
+    Product[Category],
+    "Sales", [Total Sales],
+    "Margin", [Margin]
 )
 ```
 
@@ -33,13 +38,13 @@ SUMMARIZECOLUMNS(
 EVALUATE
 TOPN(
     10,
-    SUMMARIZECOLUMNS(Cliente[Nombre], "Ventas", [Total Ventas]),
-    [Ventas], DESC
+    SUMMARIZECOLUMNS(Customer[Name], "Sales", [Total Sales]),
+    [Sales], DESC
 )
-ORDER BY [Ventas] DESC
+ORDER BY [Sales] DESC
 ```
 
-## 6. Inspección de metadatos con DMVs
+## 6. Metadata inspection with DMVs
 ```dax
 SELECT [Name] FROM $SYSTEM.TMSCHEMA_TABLES
 ```
@@ -47,13 +52,14 @@ SELECT [Name] FROM $SYSTEM.TMSCHEMA_TABLES
 SELECT [Name], [Expression] FROM $SYSTEM.TMSCHEMA_MEASURES
 ```
 
-## 7. Filtro con CALCULATE
+## 7. Filtering with CALCULATE
 ```dax
 EVALUATE
-ROW("Ventas 2024", CALCULATE([Total Ventas], Calendario[Anio] = 2024))
+ROW("Sales 2024", CALCULATE([Total Sales], Calendar[Year] = 2024))
 ```
 
-## Notas
-- Los errores del motor DAX se devuelven tal cual (no se ocultan).
-- `elapsed_ms` reporta el tiempo de ejecución.
-- Si `truncated=true`, aumenta `max_rows` o acota con TOPN/filtros.
+## Notes
+- DAX engine errors are returned verbatim; they are never swallowed.
+- `elapsed_ms` reports execution time.
+- If `truncated=true`, raise `max_rows` or narrow the query with `TOPN` or
+  filters.

--- a/examples/sample_visual_specs.json
+++ b/examples/sample_visual_specs.json
@@ -1,70 +1,70 @@
 {
-  "_comment": "Ejemplos de entrada para pbi_create_visual y pbi_arrange_visuals. Requiere un .pbip activo con PBIR (pbi_open_pbip_project).",
+  "_comment": "Input examples for pbi_create_visual and pbi_arrange_visuals. Requires an active .pbip project with PBIR (pbi_open_pbip_project). Page, table and measure names are placeholders from a sample model: replace them with your own.",
 
   "card": {
-    "page": "Resumen Ejecutivo",
+    "page": "Executive Summary",
     "visual_type": "card",
-    "title": "Ventas Totales",
-    "fields": { "values": ["[Total Ventas]"] },
+    "title": "Total Sales",
+    "fields": { "values": ["[Total Sales]"] },
     "position": { "x": 24, "y": 88, "width": 300, "height": 140 }
   },
 
   "clusteredColumnChart": {
-    "page": "Resumen Ejecutivo",
+    "page": "Executive Summary",
     "visual_type": "clusteredColumnChart",
-    "title": "Ventas por Mes",
+    "title": "Sales by Month",
     "fields": {
-      "category": "Calendario[Mes]",
-      "values": ["[Total Ventas]"],
-      "legend": "Producto[Categoria]"
+      "category": "Calendar[Month]",
+      "values": ["[Total Sales]"],
+      "legend": "Product[Category]"
     },
     "position": { "x": 24, "y": 240, "width": 640, "height": 360 }
   },
 
   "lineChart": {
-    "page": "Tendencias",
+    "page": "Trends",
     "visual_type": "lineChart",
-    "title": "Evolución de Margen",
+    "title": "Margin Over Time",
     "fields": {
-      "category": "Calendario[Fecha]",
-      "values": ["[Margen]"]
+      "category": "Calendar[Date]",
+      "values": ["[Margin]"]
     },
     "position": { "x": 700, "y": 240, "width": 560, "height": 360 }
   },
 
   "table": {
-    "page": "Detalle",
+    "page": "Detail",
     "visual_type": "table",
-    "title": "Detalle por Cliente",
+    "title": "Detail by Customer",
     "fields": {
-      "values": ["Cliente[Nombre]", "[Total Ventas]", "[Margen]"]
+      "values": ["Customer[Name]", "[Total Sales]", "[Margin]"]
     },
     "position": { "x": 24, "y": 88, "width": 800, "height": 500 }
   },
 
   "matrix": {
-    "page": "Detalle",
+    "page": "Detail",
     "visual_type": "matrix",
-    "title": "Ventas por Categoría y Mes",
+    "title": "Sales by Category and Month",
     "fields": {
-      "rows": "Producto[Categoria]",
-      "columns": "Calendario[Mes]",
-      "values": ["[Total Ventas]"]
+      "rows": "Product[Category]",
+      "columns": "Calendar[Month]",
+      "values": ["[Total Sales]"]
     },
     "position": { "x": 24, "y": 88, "width": 900, "height": 480 }
   },
 
   "slicer": {
-    "page": "Resumen Ejecutivo",
+    "page": "Executive Summary",
     "visual_type": "slicer",
-    "title": "Año",
-    "fields": { "values": ["Calendario[Anio]"] },
+    "title": "Year",
+    "fields": { "values": ["Calendar[Year]"] },
     "position": { "x": 1000, "y": 88, "width": 220, "height": 300 }
   },
 
   "arrange_example": {
-    "_comment": "Entrada para pbi_arrange_visuals",
-    "page": "Resumen Ejecutivo",
+    "_comment": "Input for pbi_arrange_visuals",
+    "page": "Executive Summary",
     "layout": "executive_summary",
     "canvas": { "width": 1280, "height": 720 },
     "spacing": 16

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 - Repository: https://github.com/HorizunGroup/horizun-pbi-mcp
 - Latest stable release: https://github.com/HorizunGroup/horizun-pbi-mcp/releases/latest
 - Installation and client setup: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/INSTALL.md
-- Full tool catalogue (127 tools): https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TOOL_CATALOG.md
+- Full tool catalogue (134 tools): https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TOOL_CATALOG.md
 - Architecture and invariants: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/ARCHITECTURE.md
 - Security model: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/SECURITY.md
 - Tutorial, install to first dashboard: https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/TUTORIAL.md
@@ -29,10 +29,14 @@ model; visuals, pages and layout are never touched through it or through any
 live API — those are edited exclusively through PBIR files. The server
 enforces that separation instead of trying to move visuals live.
 
-v1.2.0 ships 127 tools, backed by 1793 passing tests (3 skipped, each with
-its documented condition). Two validation layers check every PBIR edit
-before it is written, and non-read-only DAX is blocked by a fail-closed
-classifier.
+The current release ships 134 tools. Two validation layers check every PBIR
+edit before it is written, and non-read-only DAX is blocked by a fail-closed
+classifier. Project writes are backed up and re-read after the fact, so a
+write that silently did not land is reported as a failure rather than a
+success.
+
+For the exact version and its test results, read the release notes rather
+than this file: https://github.com/HorizunGroup/horizun-pbi-mcp/releases/latest
 
 ## How to use it
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horizun-pbi-mcp"
-# PEP 440. Debe coincidir con branding.VERSION y con el tag de Git.
+# PEP 440. Must match branding.VERSION and the Git tag.
 version = "2.0.1"
 description = "MCP server for Power BI: live semantic model (DAX/TOM), .pbip projects (TMDL/PBIR), report authoring, full auditing and workflows."
 readme = "README.md"
@@ -22,25 +22,26 @@ classifiers = [
 ]
 
 dependencies = [
-    # Acotada por arriba a proposito: el servidor fija la version del producto
-    # con `mcp._mcp_server.version` porque FastMCP.__init__ NO acepta `version`
-    # (comprobado en 1.28.1). Es API privada, asi que un salto mayor de `mcp`
-    # podria retirarla y dejar el servidor anunciando la version de la libreria
-    # en vez de la suya. tests/test_mcp_compat.py lo vigila.
+    # Upper-bounded on purpose: the server sets the product version through
+    # `mcp._mcp_server.version` because FastMCP.__init__ does NOT accept
+    # `version` (checked against 1.28.1). That is private API, so a major bump
+    # of `mcp` could withdraw it and leave the server announcing the library's
+    # version instead of its own. tests/test_mcp_compat.py guards this.
     "mcp>=1.28.1,<2",
     "pythonnet>=3.0.5,<4",
     "psutil>=5.9,<8",
     "python-dotenv>=1.0,<2",
-    # Fase E3.1: validacion PBIR contra los esquemas OFICIALES. Un validador
-    # casero solo cubria type/required/properties/items/enum e ignoraba $ref,
-    # anyOf, const y additionalProperties, que es lo que el PBIR usa de verdad.
+    # Phase E3.1: PBIR validation against the OFFICIAL schemas. A home-grown
+    # validator only covered type/required/properties/items/enum and ignored
+    # $ref, anyOf, const and additionalProperties -- which is what PBIR
+    # actually uses.
     "jsonschema>=4.20,<5",
     "referencing>=0.30,<1",
-    # Exportaciones de datos y reportes verificables.
+    # Verifiable data and report exports.
     "openpyxl>=3.1,<4",
     "reportlab>=4.2,<6",
     "pypdf>=5,<7",
-    # Autenticacion oficial de Microsoft para SharePoint/Graph app-only.
+    # Microsoft's official app-only authentication for SharePoint/Graph.
     "msal>=1.31,<2",
 ]
 
@@ -51,11 +52,11 @@ Documentation = "https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/docs/
 Changelog = "https://github.com/HorizunGroup/horizun-pbi-mcp/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
-# pyyaml: tests/test_release_pipeline.py analiza el DAG de los workflows.
-# Sin el, esas guardas no se ejecutarian en CI, que es justo donde importan.
-# tomli: `scripts/generar_lock.py --check` lee pyproject y corre en CI
-# tambien en 3.10, donde `tomllib` todavia no existe. Ruff, mypy y pytest-cov
-# son gates del repositorio; no se instalan en el runtime de los usuarios.
+# pyyaml: tests/test_release_pipeline.py parses the workflow DAG. Without it
+# those guards would not run in CI, which is exactly where they matter.
+# tomli: `scripts/generar_lock.py --check` reads pyproject and also runs in CI
+# on 3.10, where `tomllib` does not exist yet. Ruff, mypy and pytest-cov are
+# repository gates; they are not installed into users' runtime.
 test = [
     "pytest>=8.0",
     "pyyaml>=6,<7",
@@ -67,41 +68,42 @@ test = [
 
 [project.scripts]
 horizun-pbi-mcp = "horizun_pbi_mcp.server:main"
-# Alias legacy: se conserva para no romper instalaciones existentes.
+# Legacy alias: kept so existing installations do not break.
 powerbi-mcp = "horizun_pbi_mcp.server:main"
-# INSTALL-005. El wheel no puede traer las DLL de Microsoft ni los esquemas
-# PBIR, asi que una instalacion por `pip` arranca pero no puede trabajar.
-# `pbi_health_check` ya lo decia; lo que faltaba era que el comando que
-# recomienda EXISTA en esa misma instalacion, y no en un `scripts/` que el
-# wheel no lleva.
+# INSTALL-005. The wheel cannot ship Microsoft's DLLs or the PBIR schemas, so
+# a `pip` install starts but cannot do any work. `pbi_health_check` already
+# said so; what was missing is that the command it recommends should EXIST in
+# that same installation, rather than in a `scripts/` the wheel does not
+# carry.
 horizun-pbi-completar = "horizun_pbi_mcp.completado:main"
 
 [tool.setuptools]
 package-dir = { "" = "src" }
 
 [tool.setuptools.package-data]
-# Los esquemas PBIR son DATOS, no codigo: sin esto el wheel se instala y
-# services/pbir_schema.py lanza schema_unavailable en la primera escritura.
-# El manifiesto (URLs + SHA-256) SI va en el paquete; los esquemas NO,
-# porque no declaran permiso de redistribucion.
+# The PBIR schemas are DATA, not code: without this the wheel installs and
+# services/pbir_schema.py raises schema_unavailable on the first write. The
+# manifest (URLs + SHA-256) DOES ship in the package; the schemas do NOT,
+# because they declare no redistribution permission.
 "horizun_pbi_mcp.services" = ["schemas/*.json"]
-# El contrato MCP que el healthcheck exige antes de dar una instalacion por
-# buena. Tiene que viajar en el wheel: el golden equivalente vive en `tests/`,
-# y una instalacion por `pip` no tiene `tests/`. Sin este archivo el oraculo
-# falla cerrado -no da nada por bueno- en vez de comprobar de menos.
+# The MCP contract the healthcheck requires before calling an installation
+# good. It has to ship in the wheel: the equivalent golden lives in `tests/`,
+# and a `pip` install has no `tests/`. Without this file the oracle fails
+# closed -- it passes nothing -- instead of checking less than it should.
 "horizun_pbi_mcp.lifecycle" = ["contract_baseline.json"]
-# Versiones y SHA-256 de las DLL de Analysis Services. El manifiesto SI viaja
-# -es una lista, no un binario-; las DLL no, que son de Microsoft. Sin el,
-# `horizun-pbi-completar` no sabria que descargar ni contra que verificarlo.
+# Versions and SHA-256 of the Analysis Services DLLs. The manifest DOES ship
+# -- it is a list, not a binary -- the DLLs do not, being Microsoft's. Without
+# it, `horizun-pbi-completar` would not know what to download nor what to
+# verify it against.
 "horizun_pbi_mcp.completado" = ["libs_manifest.json"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-# UN solo nombre de primer nivel. Antes se instalaban diez -`config`, `server`,
+# ONE top-level name only. Ten used to be installed -- `config`, `server`,
 # `services`, `tools`, `utils`, `pbip`, `powerbi`, `reporting`,
-# `logging_config`, `branding`- y cuatro de ellos estan entre los mas comunes
-# de Python: en cualquier entorno donde otro paquete hiciera `import config`,
-# uno de los dos ganaba. Publicado en PyPI, eso lo sufre quien lo instale.
+# `logging_config`, `branding` -- and four of those are among the most common
+# names in Python: in any environment where another package did `import
+# config`, one of the two won. Published on PyPI, whoever installs it pays.
 include = ["horizun_pbi_mcp*"]
 
 [tool.pytest.ini_options]
@@ -113,8 +115,8 @@ target-version = "py310"
 line-length = 100
 
 [tool.ruff.lint]
-# Gate inicial deliberadamente estricto en errores, no en preferencias de
-# formato: sintaxis inválida, nombres inexistentes y fallos de flujo evidentes.
+# An initial gate deliberately strict about errors, not formatting taste:
+# invalid syntax, undefined names and obvious control-flow faults.
 select = ["E9", "F63", "F7", "F82"]
 
 [tool.mypy]
@@ -122,8 +124,9 @@ python_version = "3.10"
 ignore_missing_imports = true
 follow_imports = "skip"
 show_error_codes = true
-# Alcance inicial: bordes de seguridad, transacciones, locks y generación de
-# dependencias. Se amplía por módulos; no se silencian miles de errores de golpe.
+# Initial scope: safety boundaries, transactions, locks and dependency
+# generation. Widened module by module; thousands of errors are not silenced
+# in one go.
 files = [
     "src/horizun_pbi_mcp/branding.py",
     "src/horizun_pbi_mcp/tools/risk.py",
@@ -141,7 +144,8 @@ files = [
 source = ["horizun_pbi_mcp"]
 
 [tool.coverage.report]
-# Medido el 2026-08-15: 86% sobre 18.780 sentencias. Un punto de margen evita
-# ruido entre 3.13 y 3.14, pero convierte una caída material en fallo de CI.
+# Measured on 2026-08-15: 86% over 18,780 statements. One point of slack
+# absorbs noise between 3.13 and 3.14, while still turning a material drop
+# into a CI failure.
 fail_under = 85
 show_missing = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,39 +1,40 @@
-# Horizun PBI MCP — dependencias de runtime.
+# Horizun PBI MCP - runtime dependencies.
 #
-# Este archivo DEBE declarar exactamente lo mismo que `project.dependencies` de
-# `pyproject.toml`, topes incluidos. `tests/test_packaging.py` lo comprueba.
+# This file MUST declare exactly what `project.dependencies` in
+# `pyproject.toml` declares, upper bounds included. `tests/test_packaging.py`
+# checks that.
 #
-# Por que importa: el README ofrece `pip install -r requirements.txt` como
-# primera opcion, y este archivo se habia quedado atras en las SEIS
-# dependencias. Sin tope, `mcp>=1.10` instalaba la 2.0.0 —donde
-# `mcp.server.fastmcp` ya no existe— y el servidor no llegaba ni a importar.
-# `jsonschema` y `referencing` faltaban del todo, asi que toda escritura PBIR
-# fallaba con `schema_unavailable`. Se descubrio instalando en limpio.
+# Why it matters: this is the dependency list used when installing from a
+# clone (see docs/INSTALL.md), and it had fallen behind on SIX dependencies.
+# With no upper bound, `mcp>=1.10` installed 2.0.0 -- where
+# `mcp.server.fastmcp` no longer exists -- and the server could not even
+# import. `jsonschema` and `referencing` were missing entirely, so every PBIR
+# write failed with `schema_unavailable`. Found by installing from scratch.
 
-# Servidor MCP (incluye FastMCP en mcp.server.fastmcp).
-# Acotado por arriba a proposito: el servidor fija la version del producto con
-# `mcp._mcp_server.version` porque FastMCP.__init__ NO acepta `version`. Es API
-# privada, asi que un salto mayor podria retirarla.
+# MCP server (includes FastMCP under mcp.server.fastmcp).
+# Upper bound on purpose: the server sets the product version through
+# `mcp._mcp_server.version` because FastMCP.__init__ does NOT accept
+# `version`. That is private API, so a major bump could withdraw it.
 mcp>=1.28.1,<2
 
-# Interop .NET para cargar ADOMD.NET (DAX) y TOM (modelo).
+# .NET interop, to load ADOMD.NET (DAX) and TOM (model).
 pythonnet>=3.0.5,<4
 
-# Descubrimiento de procesos/puertos de Power BI Desktop (msmdsrv).
+# Discovery of Power BI Desktop processes and ports (msmdsrv).
 psutil>=5.9,<8
 
-# Carga de configuracion desde .env.
+# Configuration loading from .env.
 python-dotenv>=1.0,<2
 
-# Validacion PBIR contra los esquemas OFICIALES. Sin estas dos, toda escritura
-# en el informe falla con `schema_unavailable`.
+# PBIR validation against the OFFICIAL schemas. Without these two, every write
+# to the report fails with `schema_unavailable`.
 jsonschema>=4.20,<5
 referencing>=0.30,<1
 
-# Exportacion verificada a Excel y PDF.
+# Verified export to Excel and PDF.
 openpyxl>=3.1,<4
 reportlab>=4.2,<6
 pypdf>=5,<7
 
-# Autenticacion app-only para SharePoint Online mediante Microsoft Graph.
+# App-only authentication for SharePoint Online through Microsoft Graph.
 msal>=1.31,<2

--- a/tests/test_mcp_compat.py
+++ b/tests/test_mcp_compat.py
@@ -183,3 +183,17 @@ def test_el_manifiesto_del_registro_mcp_declara_esta_version():
     assert datos["version"] == branding.VERSION, (
         f".mcp/server.json dice {datos['version']!r} y branding "
         f"{branding.VERSION!r}")
+
+    # El bloque `packages` es lo que le dice al registro DE DONDE se instala.
+    # Lleva su propia version, y una version anidada que nadie vigile se queda
+    # atras en silencio: el registro anunciaria la 2.0.1 apuntando al paquete
+    # de PyPI de una version anterior, que es peor que no anunciar nada.
+    paquetes = datos.get("packages") or []
+    assert paquetes, ".mcp/server.json sin `packages`: el registro no diria como instalarlo"
+    pypi = [p for p in paquetes if p.get("registryType") == "pypi"]
+    assert len(pypi) == 1, f"se espera exactamente un paquete pypi, hay {len(pypi)}"
+    assert pypi[0]["identifier"] == "horizun-pbi-mcp", pypi[0]
+    assert pypi[0]["version"] == branding.VERSION, (
+        f"packages[pypi].version dice {pypi[0]['version']!r} y branding "
+        f"{branding.VERSION!r}")
+    assert pypi[0]["transport"]["type"] == "stdio", pypi[0]

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -549,7 +549,11 @@ def test_readme_e_install_no_mienten_ni_numero_ni_version():
     patron = re.compile(
         r"(?:[Tt]he |the |tools \(|contract \(the )?(\d{3})(?:\s*`?pbi_\*`?)?"
         r"\s*(?:tools|`pbi_\*` tools)|tools \((\d{3})\)")
-    for nombre in ("README.md", "docs/INSTALL.md"):
+    # `llms.txt` entra en la lista porque es el archivo que existe PARA que lo
+    # lean agentes, y era el que peor estaba: anunciaba 127 tools y "v1.2.0"
+    # con 134 publicadas y la 2.x fuera. Un conteo viejo en README lo ve una
+    # persona y desconfia; en `llms.txt` se lo cree una maquina.
+    for nombre in ("README.md", "docs/INSTALL.md", "llms.txt"):
         texto = (raiz / nombre).read_text(encoding="utf-8")
         numeros = {int(n) for tupla in patron.findall(texto)
                    for n in tupla if n}


### PR DESCRIPTION
Dos huecos **reales** en las fichas públicas, encontrados al revisar por qué esas carpetas seguían sin tocarse.

## 1 · El registro MCP no decía cómo instalar

`.mcp/server.json` publicaba nombre, título, descripción, versión, repositorio y web — y **nada sobre de dónde se instala**. Quien encontraba el servidor en el registro oficial se quedaba con una descripción y ninguna forma de actuar, teniendo el paquete en PyPI desde siempre.

El bloque `packages` lo cierra: `registryType: pypi`, `identifier: horizun-pbi-mcp`, `transport: stdio`. La forma está copiada de una entrada **ya publicada** en el registro, y el documento valida contra el schema oficial `2025-12-11`.

### Y su guarda

Ese bloque lleva **su propia versión**, y una versión anidada que nadie vigile se queda atrás en silencio: el registro anunciaría 2.0.1 apuntando al paquete de PyPI de una versión anterior — peor que no anunciar nada. La guarda existente solo miraba la versión de arriba; ahora cubre también la anidada, el identifier y el transport.

## 2 · El marketplace de Codex salía sin descripción

`.agents/plugins/marketplace.json` no tenía `description` ni para el marketplace ni para el plugin, mientras que su equivalente de Claude tenía las dos. En el navegador de plugins de Codex esa entrada se veía desnuda.

Ahora dicen lo mismo, que es justo lo que `test_los_marketplaces_publican_el_mismo_plugin` existe para mantener cierto.

## Nota

Ninguno de los dos es cosmético: son la ficha que lee una persona en el momento de decidir si instala. Como efecto secundario, estos son los dos directorios cuyo mensaje de commit seguía en español.

Verificado en local: 61 tests de manifiestos y documentación en verde, y el `server.json` valida contra el schema oficial del registro.