### PR TITLE
fix: el check clr mentia siempre, y la skill citaba un README que ya no lleva el bloque

### DIFF
--- a/skills/horizun-pbi-setup/SKILL.md
+++ b/skills/horizun-pbi-setup/SKILL.md
@@ -18,7 +18,7 @@ administrador.
 
 1. **Corre el instalador de un pegado** en PowerShell:
    El bloque exacto esta en `scripts/one_paste.ps1` y se reproduce
-   integro en `README.md` y `docs/INSTALL.md`. **No lo escribas de
+   integro en `docs/INSTALL.md`. **No lo escribas de
    memoria ni lo acortes**: descarga desde una release fija,
    comprueba el SHA-256 y solo entonces ejecuta.
 

--- a/src/horizun_pbi_mcp/powerbi/clr_bootstrap.py
+++ b/src/horizun_pbi_mcp/powerbi/clr_bootstrap.py
@@ -25,6 +25,10 @@ log = get_logger("clr")
 
 _lock = threading.Lock()
 _runtime_loaded = False
+#: Causa del ultimo intento fallido de cargar el runtime, para que el
+#: diagnostico distinga "todavia no se intento" de "se intento y no se pudo".
+#: Sin esto, un health check de solo lectura no puede decir mas que "algo pasa".
+_runtime_error: Optional[str] = None
 _adomd_ns: Optional[Any] = None
 _tom_ns: Optional[Any] = None
 
@@ -39,32 +43,42 @@ _TOM_DEPS = (
 
 
 def _ensure_runtime(runtime: str = "netfx") -> None:
-    """Selecciona el runtime .NET de pythonnet (una sola vez)."""
-    global _runtime_loaded
+    """Selecciona el runtime .NET de pythonnet (una sola vez).
+
+    `RuntimeError` NO significa "ya habia un runtime cargado", aunque durante
+    mucho tiempo este codigo lo dio por hecho. En pythonnet 3.x el caso
+    ya-cargado sale por `if _LOADED: return`, sin excepcion; el `RuntimeError`
+    queda para los fallos de verdad ("Failed to create a .NET runtime (netfx)",
+    "No valid runtime selected", "Failed to initialize Python.Runtime.dll").
+    Tratarlo como exito marcaba el runtime como cargado sin runtime -el error
+    reaparecia despues en `clr.AddReference`, culpando a la DLL- y, por hacerlo
+    con un `return` dentro del bucle, dejaba el respaldo a `coreclr` en codigo
+    muerto: una maquina sin .NET Framework nunca llegaba a intentar el otro.
+    """
+    global _runtime_loaded, _runtime_error
     if _runtime_loaded:
         return
     from pythonnet import load
 
     order = [runtime] + [r for r in ("netfx", "coreclr") if r != runtime]
-    last_exc: Optional[Exception] = None
+    fallos: list[str] = []
     for rt in order:
         try:
             load(rt)
-            log.info("Runtime .NET cargado: %s", rt)
-            _runtime_loaded = True
-            return
-        except RuntimeError:
-            # Ya habia un runtime cargado en el proceso: lo aceptamos.
-            log.debug("Runtime .NET ya estaba cargado; se reutiliza.")
-            _runtime_loaded = True
-            return
         except Exception as exc:  # pragma: no cover - depende del entorno
-            last_exc = exc
+            fallos.append(f"{rt}: {type(exc).__name__}: {exc}")
             log.warning("No se pudo cargar el runtime .NET '%s': %s", rt, exc)
+            continue
+        log.info("Runtime .NET cargado: %s", rt)
+        _runtime_loaded = True
+        _runtime_error = None
+        return
+
+    _runtime_error = "; ".join(fallos)
     raise ClrNotAvailableError(
         "No se pudo inicializar el runtime .NET (pythonnet). Verifica que .NET "
         "Framework 4.x o .NET Core este disponible.",
-        details={"cause": str(last_exc) if last_exc else None},
+        details={"cause": _runtime_error or None},
     )
 
 
@@ -139,11 +153,41 @@ def load_tom() -> Any:
         return TOM
 
 
+#: Los tres estados posibles del interop. Son TRES, no dos: el runtime se carga
+#: perezosamente -solo `load_adomd()` / `load_tom()` lo piden-, asi que un
+#: servidor recien arrancado esta legitimamente sin cargar, y eso no es un
+#: fallo. Colapsar `not_attempted` con `failed` es lo que convertia el check en
+#: un aviso permanente.
+CLR_LOADED = "loaded"
+CLR_NOT_ATTEMPTED = "not_attempted"
+CLR_FAILED = "failed"
+
+
+def clr_state() -> tuple[str, str]:
+    """Estado del interop y su explicacion en texto. El detalle nunca va vacio.
+
+    No se sondea el runtime aqui a proposito: `pbi_health_check` se anuncia
+    como solo lectura y cargar .NET dentro de el seria un efecto secundario
+    justo en la tool que se llama para mirar sin tocar.
+    """
+    preferencia = get_settings().dotnet_runtime
+    if _runtime_loaded:
+        return CLR_LOADED, f"runtime .NET '{preferencia}' cargado"
+    if _runtime_error:
+        return CLR_FAILED, f"no se pudo cargar el runtime .NET: {_runtime_error}"
+    return CLR_NOT_ATTEMPTED, (
+        f"runtime .NET '{preferencia}' aun sin cargar; se carga en la primera "
+        "operacion contra un modelo (usa pbi_test_connection para comprobarlo)")
+
+
 def diagnostics() -> dict:
     """Estado del interop para pbi_test_connection / troubleshooting."""
     settings = get_settings()
     libs = settings.libs_dir
+    estado, detalle = clr_state()
     return {
+        "clr_state": estado,
+        "clr_detail": detalle,
         "libs_dir": str(libs),
         "libs_dir_exists": libs.exists(),
         "adomd_dll_present": (libs / _ADOMD_DLL).exists(),

--- a/src/horizun_pbi_mcp/tools/ops_tools.py
+++ b/src/horizun_pbi_mcp/tools/ops_tools.py
@@ -194,7 +194,7 @@ def register(mcp) -> None:
         atencion (sesion obsoleta, journals pendientes).
         """
         def _impl():
-            from horizun_pbi_mcp.powerbi.clr_bootstrap import diagnostics
+            from horizun_pbi_mcp.powerbi.clr_bootstrap import CLR_FAILED, diagnostics
 
             session = get_session()
             settings = get_settings()
@@ -214,8 +214,12 @@ def register(mcp) -> None:
             dlls = sorted(p.name for p in libs.glob("*.dll")) if libs.exists() else []
             add("analysis_services_dlls", len(dlls) >= 3, f"{len(dlls)} DLL")
 
+            # Solo un fallo REAL avisa. Que el runtime aun no este cargado es
+            # el estado normal de un servidor recien arrancado -se carga en la
+            # primera operacion contra un modelo-, y contarlo como aviso dejaba
+            # el health check en 'warning' permanente.
             diag = diagnostics()
-            add("clr", bool(diag.get("clr_available")), diag.get("runtime"),
+            add("clr", diag["clr_state"] != CLR_FAILED, diag["clr_detail"],
                 requerido=False)
 
             modelo = session.active_model

--- a/tests/test_clr_diagnostics.py
+++ b/tests/test_clr_diagnostics.py
@@ -1,0 +1,148 @@
+"""El estado del interop CLR: lo que `diagnostics()` dice y lo que se cree.
+
+Dos defectos distintos vivian aqui, y ninguno lo habria visto la suite porque
+NADIE probaba `_ensure_runtime` ni el check `clr` del health check.
+
+1. `pbi_health_check` leia `clr_available` y `runtime`, dos claves que
+   `diagnostics()` no produce. `bool(None)` es `False`: el check salia rojo en
+   toda instalacion sana, con `detail: null`, y mandaba a diagnosticar un
+   problema inexistente. Mientras tanto `pbi_list_desktop_models` reportaba
+   `runtime_loaded: true` en el mismo proceso. Dos tools contradiciendose sobre
+   el mismo estado.
+
+2. `_ensure_runtime` trataba TODO `RuntimeError` de `pythonnet.load()` como "ya
+   habia un runtime cargado". En pythonnet 3.x eso es exactamente al reves: el
+   caso ya-cargado sale por `if _LOADED: return` SIN excepcion, y el
+   `RuntimeError` queda reservado para los fallos de verdad -no se pudo crear
+   el runtime, no se pudo inicializar `Python.Runtime.dll`-. El `except`
+   convertia cada uno de esos fallos en un exito fingido, y como ademas hacia
+   `return` dentro del bucle, el respaldo a `coreclr` era codigo muerto: una
+   maquina sin .NET Framework nunca llegaba a intentar el otro runtime.
+
+Las pruebas de `_ensure_runtime` sustituyen `pythonnet.load` porque el objetivo
+es la LOGICA de decision, no el runtime de la maquina; una prueba que dependiera
+del .NET instalado no podria distinguir un fallo de un entorno.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from horizun_pbi_mcp.powerbi import clr_bootstrap
+from horizun_pbi_mcp.powerbi.errors import ClrNotAvailableError
+
+
+@pytest.fixture(autouse=True)
+def estado_limpio(monkeypatch):
+    """Cada prueba arranca con el interop 'sin intentar todavia'.
+
+    El estado es de modulo y el proceso de pytest es uno solo: sin esto, la
+    primera prueba que cargue el runtime decidiria el resultado de las demas.
+    """
+    monkeypatch.setattr(clr_bootstrap, "_runtime_loaded", False)
+    monkeypatch.setattr(clr_bootstrap, "_runtime_error", None, raising=False)
+    yield
+
+
+def _falso_load(fallos: dict):
+    """`pythonnet.load` de mentira: falla en los runtimes que se le indiquen."""
+    intentos = []
+
+    def load(rt):
+        intentos.append(rt)
+        if rt in fallos:
+            raise fallos[rt]
+
+    load.intentos = intentos
+    return load
+
+
+def _instalar_load(monkeypatch, load):
+    """`_ensure_runtime` hace `from pythonnet import load` DENTRO de la funcion."""
+    modulo = sys.modules.setdefault("pythonnet", type(sys)("pythonnet"))
+    monkeypatch.setattr(modulo, "load", load, raising=False)
+
+
+# ------------------------------------------------- 1. el estado que se cree ---
+def test_diagnostics_produce_las_claves_que_el_health_check_consume():
+    """El defecto original en una linea: se leia lo que nadie escribia."""
+    diag = clr_bootstrap.diagnostics()
+    for clave in ("clr_state", "clr_detail", "runtime_loaded", "runtime_preference"):
+        assert clave in diag, f"diagnostics() ya no produce '{clave}'"
+    assert diag["clr_detail"], "el detalle nunca debe quedar vacio ni en None"
+
+
+@pytest.mark.parametrize("cargado,error,esperado", [
+    (False, None, "not_attempted"),
+    (True, None, "loaded"),
+    (False, "ClrNotAvailableError: no hay .NET", "failed"),
+])
+def test_los_tres_estados_del_interop(monkeypatch, cargado, error, esperado):
+    """Cargado, fallado y 'todavia no se intento' son cosas distintas.
+
+    Confundir las dos ultimas es lo que hacia permanente el aviso: el runtime
+    se carga PEREZOSAMENTE, en la primera operacion contra un modelo, asi que
+    un servidor recien arrancado esta legitimamente sin cargar.
+    """
+    monkeypatch.setattr(clr_bootstrap, "_runtime_loaded", cargado)
+    monkeypatch.setattr(clr_bootstrap, "_runtime_error", error, raising=False)
+    diag = clr_bootstrap.diagnostics()
+    assert diag["clr_state"] == esperado
+    assert diag["clr_detail"], "un estado sin explicacion no sirve para diagnosticar"
+    if esperado == "failed":
+        assert "no hay .NET" in diag["clr_detail"], (
+            "el detalle de un fallo tiene que llevar la causa, no un rotulo")
+
+
+# ------------------------------------------- 2. la decision sobre el runtime ---
+def test_un_runtimeerror_no_se_toma_por_exito(monkeypatch):
+    """El nucleo del segundo defecto: fallar no es 'ya estaba cargado'."""
+    load = _falso_load({"netfx": RuntimeError("Failed to create a .NET runtime (netfx)"),
+                        "coreclr": RuntimeError("No valid runtime selected")})
+    _instalar_load(monkeypatch, load)
+
+    with pytest.raises(ClrNotAvailableError):
+        clr_bootstrap._ensure_runtime("netfx")
+    assert clr_bootstrap._runtime_loaded is False, (
+        "quedo marcado como cargado sin runtime: el error real aparecera mas "
+        "tarde en clr.AddReference, culpando a la DLL equivocada")
+
+
+def test_si_el_preferido_falla_se_intenta_el_otro(monkeypatch):
+    """El respaldo a coreclr era codigo muerto: el `return` no lo dejaba correr."""
+    load = _falso_load({"netfx": RuntimeError("Failed to create a .NET runtime (netfx)")})
+    _instalar_load(monkeypatch, load)
+
+    clr_bootstrap._ensure_runtime("netfx")
+    assert load.intentos == ["netfx", "coreclr"]
+    assert clr_bootstrap._runtime_loaded is True
+
+
+def test_el_caso_ya_cargado_de_pythonnet_no_levanta_nada(monkeypatch):
+    """Por que el `except` sobraba: `load()` vuelve limpio si ya estaba cargado.
+
+    `pythonnet.load` empieza con `if _LOADED: return`. La rama que el codigo
+    creia estar atendiendo nunca pasaba por una excepcion.
+    """
+    load = _falso_load({})
+    _instalar_load(monkeypatch, load)
+
+    clr_bootstrap._ensure_runtime("netfx")
+    assert load.intentos == ["netfx"]
+    assert clr_bootstrap._runtime_loaded is True
+
+
+def test_un_fallo_deja_su_causa_registrada(monkeypatch):
+    """Sin esto, el health check solo puede decir 'algo fallo'."""
+    load = _falso_load({"netfx": RuntimeError("Failed to initialize Python.Runtime.dll"),
+                        "coreclr": RuntimeError("No valid runtime selected")})
+    _instalar_load(monkeypatch, load)
+
+    with pytest.raises(ClrNotAvailableError):
+        clr_bootstrap._ensure_runtime("netfx")
+
+    diag = clr_bootstrap.diagnostics()
+    assert diag["clr_state"] == "failed"
+    assert "Python.Runtime.dll" in diag["clr_detail"] or \
+           "No valid runtime" in diag["clr_detail"]

--- a/tests/test_envelope_and_ops.py
+++ b/tests/test_envelope_and_ops.py
@@ -286,6 +286,39 @@ def test_health_check(proyecto, tools):
     assert {"python", "analysis_services_dlls", "active_pbip"} <= ids
 
 
+@pytest.mark.parametrize("cargado,error,ok_esperado", [
+    (True, None, True),        # interop vivo
+    (False, None, True),       # todavia no se intento: no es un problema
+    (False, "ClrNotAvailableError: no hay .NET 4.x", False),
+])
+def test_el_check_clr_dice_la_verdad_y_nunca_calla_el_motivo(
+        proyecto, tools, monkeypatch, cargado, error, ok_esperado):
+    """El check leia dos claves inexistentes y salia rojo SIEMPRE.
+
+    `bool(None)` es `False`, asi que toda instalacion sana arrancaba con
+    `warnings: ["clr"]` y `detail: null`: un aviso permanente que mandaba a
+    diagnosticar un problema que no existia, sin decir cual. Visto desde una
+    instalacion externa el 2026-08-16, con ADOMD y TOM cargando bien.
+
+    Que un servidor recien arrancado no tenga el runtime cargado NO es un
+    fallo: se carga en la primera operacion contra un modelo. Solo el fallo
+    real avisa, y entonces el detalle tiene que llevar la causa.
+    """
+    from horizun_pbi_mcp.powerbi import clr_bootstrap
+
+    monkeypatch.setattr(clr_bootstrap, "_runtime_loaded", cargado)
+    monkeypatch.setattr(clr_bootstrap, "_runtime_error", error, raising=False)
+
+    r = llamar(tools, "pbi_health_check")
+    clr = next(c for c in r["checks"] if c["check"] == "clr")
+
+    assert clr["ok"] is ok_esperado
+    assert clr["detail"], "un check sin explicacion es peor que no tenerlo"
+    assert ("clr" in r["warnings"]) is not ok_esperado
+    if not ok_esperado:
+        assert "no hay .NET 4.x" in clr["detail"]
+
+
 def test_capabilities_declara_both_como_no_soportado(proyecto, tools):
     r = llamar(tools, "pbi_capabilities")
     assert r["ok"] is True

--- a/tests/test_one_paste.py
+++ b/tests/test_one_paste.py
@@ -548,6 +548,31 @@ def test_ninguna_copia_del_bloque_diverge_del_canonico():
         "Reparalo con: python scripts/sync_one_paste.py")
 
 
+def test_la_prosa_de_la_skill_solo_cita_documentos_que_llevan_el_bloque():
+    """La skill manda a copiar el bloque; si nombra un archivo que ya no lo
+    lleva, el agente que la sigue al pie de la letra no lo encuentra y acaba
+    reconstruyendolo de memoria -exactamente lo que la frase quiere evitar-.
+
+    Paso: la frase cito `README.md` durante meses despues de que el README
+    dejara de incrustar el bloque y pasara a solo enlazar a `docs/INSTALL.md`.
+    Los bloques se vigilan por hash; la prosa que los anuncia, no lo estaba.
+    """
+    rel = "skills/horizun-pbi-setup/SKILL.md"
+    texto = (RAIZ / rel).read_text(encoding="utf-8")
+    # El punto que cierra la frase es el que va seguido de espacio o fin: un
+    # `\.` a secas corta dentro de `one_paste.ps1` y deja fuera precisamente
+    # los documentos que hay que revisar (con lo que el test pasaria solo).
+    frase = re.search(r"El bloque exacto esta en.*?\.(?=\s|$)", texto, re.S)
+    assert frase, f"{rel} ya no dice donde esta el bloque exacto"
+
+    citados = [c for c in re.findall(r"`([^`]+)`", frase.group(0))
+               if c.endswith(".md")]
+    intrusos = [c for c in citados if c not in DOCUMENTOS]
+    assert not intrusos, (
+        f"{rel} anuncia el bloque en {intrusos}, que no lo incrustan. "
+        f"Los documentos que lo llevan son {list(DOCUMENTOS)}")
+
+
 def test_el_manifest_y_el_bloque_declaran_la_misma_descarga():
     entrada = _entrada_manifest()
     bloque = _snippet_canonico()


### PR DESCRIPTION
Dos reportes externos del 2026-08-16, triados contra el arbol y reducidos a lo
que seguia vigente. Ninguno de los dos defectos lo habria visto la suite.

## 1. El check `clr` salia rojo en toda instalacion sana

`pbi_health_check` leia `clr_available` y `runtime`; `diagnostics()` nunca
produjo esas claves. `bool(None)` es `False`, asi que el servidor arrancaba con
`warnings: ["clr"]`, `status: warning` y `detail: null` — un aviso permanente
que mandaba a diagnosticar un problema inexistente y encima no decia cual.
En el mismo proceso `pbi_list_desktop_models` reportaba `runtime_loaded: true`.

Cambiar la clave a secas no bastaba: el runtime se carga perezosamente, asi que
un servidor recien arrancado esta legitimamente sin cargar. Son **tres** estados
—`loaded` / `not_attempted` / `failed`— y solo el ultimo avisa. No se sondea el
runtime dentro del check: la tool se anuncia como solo lectura.

## 2. El respaldo a `coreclr` era codigo muerto

Encontrado al leer pythonnet 3.1.0 para arreglar lo anterior. `_ensure_runtime`
trataba todo `RuntimeError` de `load()` como "ya habia un runtime cargado". Es
al reves: `load()` empieza con `if _LOADED: return`, o sea que el caso
ya-cargado no pasa por excepcion, y el `RuntimeError` queda para los fallos de
verdad. El `except` convertia cada fallo en exito fingido y, por hacerlo con un
`return` dentro del bucle, impedia intentar el segundo runtime: una maquina sin
.NET Framework se rendia fingiendo que habia funcionado.

## 3. La skill mandaba a copiar el one-paste desde el README

`skills/horizun-pbi-setup/SKILL.md` decia que el bloque se reproduce integro en
`README.md`, que dejo de incrustarlo cuando paso a solo enlazar a INSTALL. La
frase existe para decir "no lo escribas de memoria"; un agente que la sigue no
lo encuentra y concluye que le toca reconstruirlo. Los bloques estaban vigilados
por hash; la prosa que los anuncia, no.

## Verificacion

- Rojo primero en los tres casos. En el del CLR, 10 de 11 pruebas nuevas fallan
  sobre `e3ed562`; la que ya pasaba es la que fija que el caso ya-cargado de
  pythonnet no levanta nada — el supuesto del que salio el defecto 2.
- Suite completa: **2988 pasan, 3 se omiten**.
- Sin cambios de contrato.

## Lo que se descarto del reporte

- `ref: "main"` en el marketplace: ya estaba fijado al tag desde `a8160e3`
  (2026-08-14), y `release_verify.py` lo compara contra el tag como gate.
- `llms.txt` con "v1.2.0 / 127 tools" dentro del tag `v2.0.1`: cierto, pero es
  historia inmutable; la guarda ya corre en el job `test` del release, del que
  dependen las tres publicaciones. Se corrige solo al salir la 2.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)