### PR TITLE
fix(readme): el registro MCP exige un mcp-name: que el README nunca tuvo

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,14 @@ committed. See [AGENTS.md](AGENTS.md) for the repository invariants.
 ## License
 
 Apache License 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+
+## MCP Registry
+
+This package is the one published under the server name below. The registry
+reads this line from the README of the **PyPI package** to confirm that whoever
+publishes the metadata also owns the package, so it has to live here rather
+than in `.mcp/server.json` alone.
+
+```
+mcp-name: io.github.HorizunGroup/horizun-pbi-mcp
+```

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -54,6 +54,27 @@ def test_marketplace_declara_la_version_del_proyecto(ruta):
         f"{ruta} apunta a {refs} y el proyecto es {esperado}")
 
 
+def test_el_readme_declara_el_nombre_del_servidor_para_el_registro():
+    """Sin esta linea, `publicar-mcp` falla con 400 y arrastra a la release.
+
+    El registro MCP comprueba la propiedad del paquete leyendo `mcp-name:` en
+    el README **del paquete publicado en PyPI**, no en el repositorio. Cuando
+    rechazo la 2.0.2 el dano no fue quedarse sin entrada en el registro: como
+    `publicar-github-release` depende de `publicar-mcp`, la release no se creo,
+    y el bloque de un pegado -que ya apuntaba a /v2.0.2/- quedo en 404 con la
+    version ya publicada en PyPI e irreemplazable.
+
+    Se valida contra `.mcp/server.json` en vez de contra una constante para que
+    renombrar el servidor rompa aqui y no en mitad de una publicacion.
+    """
+    nombre = json.loads((RAIZ / ".mcp/server.json").read_text(encoding="utf-8"))["name"]
+    readme = (RAIZ / "README.md").read_text(encoding="utf-8")
+    assert f"mcp-name: {nombre}" in readme, (
+        f"README.md no declara 'mcp-name: {nombre}'. El registro MCP la exige "
+        "para validar la propiedad del paquete de PyPI, y sin ella la release "
+        "de GitHub ni siquiera llega a crearse")
+
+
 def test_todos_los_sitios_de_version_coinciden_con_branding():
     """El gate del release comprueba esto AL TAGUEAR; aqui se comprueba antes.
 


### PR DESCRIPTION
El registro MCP rechazo la publicacion de la 2.0.2 con `400 Bad Request`: valida
la propiedad del paquete buscando `mcp-name: io.github.HorizunGroup/horizun-pbi-mcp`
en el README **del paquete publicado en PyPI**, y no estaba.

Nunca estuvo — la 2.0.1 publico al registro sin el ocho horas antes. Lo endurecio
el registro entre ambas publicaciones; no hubo regresion aqui.

El dano no fue quedarse fuera del directorio: `publicar-github-release` depende de
`publicar-mcp`, asi que se omitio, la release de la 2.0.2 no se creo, y su
one-paste quedo en 404 con el paquete ya en PyPI e irreemplazable. **Eso ya esta
resuelto**: la release se publico con los bytes firmados de la propia corrida,
verificando los seis hashes contra `SHA256SUMS` antes de subirlos y releyendo el
instalador despues de subirlo (26 889 bytes, `00b7893c…`, identico byte a byte a
`scripts/instalar.ps1` en el tag).

## Que lleva este PR

- La linea en `README.md`, en una seccion corta que explica por que tiene que
  vivir ahi y no solo en `.mcp/server.json`.
- Una prueba que la exige, comparandola contra el campo `name` de
  `.mcp/server.json`: renombrar el servidor rompe la suite en vez de romper una
  publicacion a mitad de camino.

**Sin tocar la version.** `main` sigue declarando 2.0.2, que es lo publicado y lo
que apuntan el marketplace y el one-paste. La proxima version, sea cual sea,
saldra ya con la marca puesta.

## Fuera de alcance, anotado

`publicar-github-release` sigue dependiendo de `publicar-mcp`. Esa es la
dependencia que convirtio el rechazo de unos metadatos en un instalador roto, y
cambiarla es una decision de diseno que merece su propio PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)